### PR TITLE
quill-cassandra-lagom: expose public method to retrieve bound statements

### DIFF
--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
@@ -20,6 +20,10 @@ class CassandraLagomAsyncContext[N <: NamingStrategy](
 
   private val logger = ContextLogger(this.getClass)
 
+  def bindQuery[T](cql: String, prepare: Prepare = identityPrepare)(implicit executionContext: ExecutionContext): Future[PrepareRow] = {
+    prepareAsyncAndGetStatement(cql, prepare, logger)
+  }
+
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, logger)
     statement.flatMap(st => session.selectAll(st)).map(_.map(extractor))

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomSessionContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomSessionContext.scala
@@ -3,9 +3,11 @@ package io.getquill
 import akka.Done
 import com.datastax.driver.core.BoundStatement
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
+import io.getquill.context.BindMacro
 import io.getquill.context.cassandra.CassandraSessionContext
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.language.experimental.macros
 
 abstract class CassandraLagomSessionContext[N <: NamingStrategy](
   val naming: N,
@@ -15,6 +17,8 @@ abstract class CassandraLagomSessionContext[N <: NamingStrategy](
 
   override type RunActionResult = Done
   override type RunBatchActionResult = Done
+
+  def bind[T](quoted: Quoted[T]): Future[PrepareRow] = macro BindMacro.bindQuery[T]
 
   override def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement] = {
     session.prepare(cql).map(_.bind())

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomStreamContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomStreamContext.scala
@@ -5,7 +5,7 @@ import akka.{ Done, NotUsed }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
 import io.getquill.util.ContextLogger
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Future }
 
 class CassandraLagomStreamContext[N <: NamingStrategy](
   naming:  N,
@@ -20,6 +20,10 @@ class CassandraLagomStreamContext[N <: NamingStrategy](
   override type RunBatchActionResult = Done
 
   private val logger = ContextLogger(this.getClass)
+
+  def bindQuery[T](cql: String, prepare: Prepare = identityPrepare)(implicit executionContext: ExecutionContext): Future[PrepareRow] = {
+    prepareAsyncAndGetStatement(cql, prepare, logger)
+  }
 
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, logger)

--- a/quill-cassandra-lagom/src/test/scala/io/getquill/context/cassandra/lagom/QueryResultTypeCassandraAsyncSpec.scala
+++ b/quill-cassandra-lagom/src/test/scala/io/getquill/context/cassandra/lagom/QueryResultTypeCassandraAsyncSpec.scala
@@ -21,6 +21,35 @@ class QueryResultTypeCassandraAsyncSpec extends QueryResultTypeCassandraSpec {
     ()
   }
 
+  "bind" - {
+    "action" - {
+      "noArgs" in {
+        val bs = result(context.bind(insert(OrderTestEntity(1, 2))))
+        bs.preparedStatement().getVariables.size() mustEqual 0
+      }
+
+      "withArgs" in {
+        val bs = result(context.bind(insert(lift(OrderTestEntity(1, 2)))))
+        bs.preparedStatement().getVariables.size() mustEqual 2
+        bs.getInt("id") mustEqual 1
+        bs.getInt("i") mustEqual 2
+      }
+    }
+
+    "query" - {
+      "noArgs" in {
+        val bs = result(context.bind(selectAll))
+        bs.preparedStatement().getVariables.size() mustEqual 0
+      }
+
+      "withArgs" in {
+        val bs = result(context.bind(parametrizedSize(lift(1))))
+        bs.preparedStatement().getVariables.size() mustEqual 1
+        bs.getInt("id") mustEqual 1
+      }
+    }
+  }
+
   "query" in {
     result(context.run(selectAll)) mustEqual entries
   }

--- a/quill-core/src/main/scala/io/getquill/context/BindMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/BindMacro.scala
@@ -1,0 +1,20 @@
+package io.getquill.context
+
+import scala.reflect.macros.whitebox.{ Context => MacroContext }
+import io.getquill.util.EnableReflectiveCalls
+
+class BindMacro(val c: MacroContext) extends ContextMacro {
+  import c.universe.{ Ident => _, _ }
+
+  def bindQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    c.untypecheck {
+      q"""
+        ..${EnableReflectiveCalls(c)}
+        val expanded = ${expand(extractAst(quoted))}
+        ${c.prefix}.bindQuery(
+          expanded.string,
+          expanded.prepare
+        )
+      """
+    }
+}


### PR DESCRIPTION
Fixes #1414

### Problem

Users of `quill-cassandra-lagom` cannot currently use quill extensively if they wish to retain atomicity within Lagom's read side processors given Lagom's existing cassandra base classes. Lagom expects users to provide a list of BoundStatement to be executed when handling a particular event from the journal. Quill can easily expose the BoundStatement(s).

### Solution

Provide a BindMacro which expands the ast and invokes the prepare callback to produce a BoundStatement. Give users access via context#bind iff context is a CassandraLagomSessionContext.

### Notes

1. I'm not sure if BindMacro belongs in `quill-core`, or if there is an easier way to accomplish generic ast expansion with a dispatch to prepare
2. I'm not sure if `quill-cassandra-lagom` CassandraLagomSessionContext#bind should be promoted in general form to `quill-cassandra` CassandraContext or CassandraSessionContext
3. I'm not sure if bindQuery should be duplicated across the AsyncContext and StreamContext in `quill-cassandra-lagom` or if ContextLogger should just be moved to the base SessionContext.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

@WayneWang12