### PR TITLE
Allow subquery expansion via pre-Quats expander

### DIFF
--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -10,6 +10,7 @@ object Messages {
   private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "false").toBoolean
   private[getquill] def alwaysAlias = variable("quill.query.alwaysAlias", "quill_query_alwaysAlias", "false").toBoolean
   private[getquill] def pruneColumns = variable("quill.query.pruneColumns", "quill_query_pruneColumns", "true").toBoolean
+  private[getquill] def legacyExpand = variable("quill.query.legacyExpand", "quill_query_pruneColumns", "false").toBoolean
   private[util] def debugEnabled = variable("quill.macro.log", "quill_macro_log", "true").toBoolean
   private[util] def traceEnabled = variable("quill.trace.enabled", "quill_trace_enabled", "false").toBoolean
   private[util] def traceColors = variable("quill.trace.color", "quill_trace_color,", "false").toBoolean

--- a/quill-sql-portable/src/main/scala/io/getquill/SQLServerDialect.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/SQLServerDialect.scala
@@ -17,7 +17,7 @@ trait SQLServerDialect
   with ConcatSupport
   with CanOutputClause {
 
-  override def querifyAst(ast: Ast) = AddDropToNestedOrderBy(SqlQuery(ast))
+  override def querifyAst(ast: Ast) = AddDropToNestedOrderBy(super.querifyAst(ast))
 
   override def emptySetContainsToken(field: Token) = StringToken("1 <> 1")
 

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -29,26 +29,52 @@ trait SqlIdiom extends Idiom {
 
   override def format(queryString: String): String = SqlFormatter.format(queryString)
 
-  def querifyAst(ast: Ast) = SqlQuery(ast)
+  def querifyAst(ast: Ast) = {
+    import io.getquill.sql.norm.migration._
+    if (Messages.legacyExpand)
+      SqlQueryLegacy(ast)
+    else
+      SqlQuery(ast)
+  }
 
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
     val normalizedAst = SqlNormalize(ast, concatBehavior, equalityBehavior)
 
     implicit val tokernizer = defaultTokenizer
 
+    def pipeline(q: Query): Token = {
+      val sql = querifyAst(q)
+      trace("sql")(sql)
+      VerifySqlQuery(sql).map(fail)
+      val expanded = ExpandNestedQueries(sql)
+      trace("expanded sql")(expanded)
+      val refined = if (Messages.pruneColumns) RemoveUnusedSelects(expanded) else expanded
+      trace("filtered sql (only used selects)")(refined)
+      val cleaned = if (!Messages.alwaysAlias) RemoveExtraAlias(naming)(refined) else refined
+      trace("cleaned sql")(cleaned)
+      val tokenized = cleaned.token
+      tokenized
+    }
+
+    def legacyPipeline(q: Query): Token = {
+      import io.getquill.sql.norm.migration._
+      val sql = querifyAst(q)
+      trace("sql")(sql)
+      VerifySqlQuery(sql).map(fail)
+      val expanded = new ExpandNestedQueriesLegacy(naming).apply(sql, List())
+      trace("expanded sql")(expanded)
+      val tokenized = expanded.token
+      tokenized
+    }
+
     val token =
       normalizedAst match {
         case q: Query =>
-          val sql = querifyAst(q)
-          trace("sql")(sql)
-          VerifySqlQuery(sql).map(fail)
-          val expanded = ExpandNestedQueries(sql)
-          trace("expanded sql")(expanded)
-          val refined = if (Messages.pruneColumns) RemoveUnusedSelects(expanded) else expanded
-          trace("filtered sql (only used selects)")(refined)
-          val cleaned = if (!Messages.alwaysAlias) RemoveExtraAlias(naming)(refined) else refined
-          trace("cleaned sql")(cleaned)
-          val tokenized = cleaned.token
+          val tokenized =
+            if (Messages.legacyExpand)
+              legacyPipeline(q)
+            else
+              pipeline(q)
           trace("tokenized sql")(tokenized)
           tokenized
         case other =>

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/ExpandNestedQueriesLegacy.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/ExpandNestedQueriesLegacy.scala
@@ -1,0 +1,126 @@
+package io.getquill.sql.norm.migration
+
+import io.getquill.NamingStrategy
+import io.getquill.ast.Ast
+import io.getquill.ast.Ident
+import io.getquill.ast._
+import io.getquill.ast.Visibility.Visible
+import io.getquill.context.sql._
+
+import scala.collection.mutable.LinkedHashSet
+import io.getquill.util.Interpolator
+import io.getquill.util.Messages.TraceType.NestedQueryExpansion
+
+import io.getquill.norm.{ BetaReduction, TypeBehavior }
+import io.getquill.quat.Quat
+import io.getquill.sql.norm._
+
+import scala.collection.mutable
+
+class ExpandNestedQueriesLegacy(strategy: NamingStrategy) {
+
+  val interp = new Interpolator(NestedQueryExpansion, 3)
+  import interp._
+
+  def apply(q: SqlQuery, references: List[Property]): SqlQuery =
+    apply(q, LinkedHashSet.empty ++ references, true)
+
+  // Using LinkedHashSet despite the fact that it is mutable because it has better characteristics then ListSet.
+  // Also this collection is strictly internal to ExpandNestedQueries and exposed anywhere else.
+  private def apply(q: SqlQuery, references: LinkedHashSet[Property], isTopLevel: Boolean = false): SqlQuery =
+    q match {
+      case q: FlattenSqlQuery =>
+        val expand = expandNested(q.copy(select = ExpandSelectLegacy(q.select, references, strategy))(q.quat), isTopLevel)
+        trace"Expanded Nested Query $q into $expand".andLog()
+        expand
+      case SetOperationSqlQuery(a, op, b) =>
+        SetOperationSqlQuery(apply(a, references), op, apply(b, references))(q.quat)
+      case UnaryOperationSqlQuery(op, q) =>
+        UnaryOperationSqlQuery(op, apply(q, references))(q.quat)
+    }
+
+  private def expandNested(q: FlattenSqlQuery, isTopLevel: Boolean): SqlQuery =
+    q match {
+      case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select, distinct) =>
+        val asts = Nil ++ select.map(_.ast) ++ where ++ groupBy ++ orderBy.map(_.ast) ++ limit ++ offset
+        val expansions = q.from.map(expandContext(_, asts))
+        val from = expansions.map(_._1)
+        val references = expansions.flatMap(_._2)
+
+        val replacedRefs = references.map(ref => (ref, unhideAst(ref)))
+
+        // Need to unhide properties that were used during the query
+        def replaceProps(ast: Ast) =
+          BetaReduction(ast, TypeBehavior.ReplaceWithReduction, replacedRefs: _*) // Since properties could not actually be inside, don't typecheck the reduction
+        def replacePropsOption(ast: Option[Ast]) =
+          ast.map(replaceProps(_))
+
+        def distinctIfNotTopLevel(values: List[SelectValue]) =
+          if (isTopLevel)
+            values
+          else
+            values.distinct
+
+        /*
+         * In sub-queries, need to make sure that the same field/alias pair is not selected twice
+         * which is possible when aliases are used. For example, something like this:
+         *
+         * case class Emb(id: Int, name: String) extends Embedded
+         * case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+         * case class GrandParent(id: Int, par: Parent)
+         * val q = quote { query[GrandParent].map(g => g.par).distinct.map(p => (p.name, p.emb, p.id, p.emb.id)).distinct.map(tup => (tup._1, tup._2, tup._3, tup._4)).distinct }
+         * Will cause double-select inside the innermost subselect:
+         * SELECT DISTINCT theParentName AS theParentName, id AS embid, theName AS embtheName, id AS id, id AS embid FROM GrandParent g
+         * Note how embid occurs twice? That's because (p.emb.id, p.emb) are expanded into (p.emb.id, p.emb.id, e.emb.name).
+         *
+         * On the other hand if the query is top level we need to make sure not to do this deduping or else the encoders won't work since they rely on clause positions
+         * For example, something like this:
+         * val q = quote { query[GrandParent].map(g => g.par).distinct.map(p => (p.name, p.emb, p.id, p.emb.id)) }
+         * Would normally expand to this:
+         * SELECT p.theParentName, p.embid, p.embtheName, p.id, p.embid FROM ...
+         * Note now embed occurs twice? We need to maintain this because the second element of the output tuple
+         * (p.name, p.emb, p.id, p.emb.id) needs the fields p.embid, p.embtheName in that precise order in the selection
+         * or they cannot be encoded.
+         */
+        val newSelects =
+          distinctIfNotTopLevel(select.map(sv => sv.copy(ast = replaceProps(sv.ast))))
+
+        q.copy(
+          select = newSelects,
+          from = from,
+          where = replacePropsOption(where),
+          groupBy = replacePropsOption(groupBy),
+          orderBy = orderBy.map(ob => ob.copy(ast = replaceProps(ob.ast))),
+          limit = replacePropsOption(limit),
+          offset = replacePropsOption(offset)
+        )(q.quat)
+
+    }
+
+  def unhideAst(ast: Ast): Ast =
+    Transform(ast) {
+      case Property.Opinionated(a, n, r, v) =>
+        Property.Opinionated(unhideAst(a), n, r, Visible)
+    }
+
+  private def unhideProperties(sv: SelectValue) =
+    sv.copy(ast = unhideAst(sv.ast))
+
+  private def expandContext(s: FromContext, asts: List[Ast]): (FromContext, LinkedHashSet[Property]) =
+    s match {
+      case QueryContext(q, alias) =>
+        val refs = references(alias, asts)
+        (QueryContext(apply(q, refs), alias), refs)
+      case JoinContext(t, a, b, on) =>
+        val (left, leftRefs) = expandContext(a, asts :+ on)
+        val (right, rightRefs) = expandContext(b, asts :+ on)
+        (JoinContext(t, left, right, on), leftRefs ++ rightRefs)
+      case FlatJoinContext(t, a, on) =>
+        val (next, refs) = expandContext(a, asts :+ on)
+        (FlatJoinContext(t, next, on), refs)
+      case _: TableContext | _: InfixContext => (s, new mutable.LinkedHashSet[Property]())
+    }
+
+  private def references(alias: String, asts: List[Ast]) =
+    LinkedHashSet.empty ++ (References(State(Ident(alias, Quat.Value), Nil))(asts)(_.apply)._2.state.references) // TODO scrap this whole thing with quats
+}

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/ExpandSelectLegacy.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/ExpandSelectLegacy.scala
@@ -1,0 +1,211 @@
+package io.getquill.sql.norm.migration
+
+import io.getquill.NamingStrategy
+import io.getquill.ast.Property
+import io.getquill.context.sql.SelectValue
+import io.getquill.util.Interpolator
+import io.getquill.util.Messages.TraceType.NestedQueryExpansion
+
+import scala.collection.mutable.LinkedHashSet
+import io.getquill.context.sql.norm.nested.Elements._
+import io.getquill.ast._
+import io.getquill.norm.BetaReduction
+import io.getquill.quat.Quat
+import io.getquill.context.sql.norm.nested.FindUnexpressedInfixes
+
+/**
+ * Takes the `SelectValue` elements inside of a sub-query (if a super/sub-query constrct exists) and flattens
+ * them from a nested-hiearchical structure (i.e. tuples inside case classes inside tuples etc..) into
+ * into a single series of top-level select elements where needed. In cases where a user wants to select an element
+ * that contains an entire tuple (i.e. a sub-tuple of the outer select clause) we pull out the entire tuple
+ * that is being selected and leave it to the tokenizer to flatten later.
+ *
+ * The part about this operation that is tricky is if there are situations where there are infix clauses
+ * in a sub-query representing an element that has not been selected by the query-query but in order to ensure
+ * the SQL operation has the same meaning, we need to keep track for it. For example:
+ * <pre><code>
+ *   val q = quote {
+ *     query[Person].map(p => (infix"DISTINCT ON (${p.other})".as[Int], p.name, p.id)).map(t => (t._2, t._3))
+ *   }
+ *   run(q)
+ *   // SELECT p._2, p._3 FROM (SELECT DISTINCT ON (p.other), p.name AS _2, p.id AS _3 FROM Person p) AS p
+ * </code></pre>
+ * Since `DISTINCT ON` significantly changes the behavior of the outer query, we need to keep track of it
+ * inside of the inner query. In order to do this, we need to keep track of the location of the infix in the inner query
+ * so that we can reconstruct it. This is why the `OrderedSelect` and `DoubleOrderedSelect` objects are used.
+ * See the notes on these classes for more detail.
+ *
+ * See issue #1597 for more details and another example.
+ */
+private class ExpandSelectLegacy(selectValues: List[SelectValue], references: LinkedHashSet[Property], strategy: NamingStrategy) {
+  val interp = new Interpolator(NestedQueryExpansion, 3)
+  import interp._
+
+  object TupleIndex {
+    def unapply(s: String): Option[Int] =
+      if (s.matches("_[0-9]*"))
+        Some(s.drop(1).toInt - 1)
+      else
+        None
+  }
+
+  object MultiTupleIndex {
+    def unapply(s: String): Boolean =
+      if (s.matches("(_[0-9]+)+"))
+        true
+      else
+        false
+  }
+
+  val select =
+    selectValues.zipWithIndex.map {
+      case (value, index) => OrderedSelect(index, value)
+    }
+
+  def expandColumn(name: String, renameable: Renameable): String =
+    renameable.fixedOr(name)(strategy.column(name))
+
+  def apply: List[SelectValue] =
+    trace"Expanding Select values: $selectValues into references: $references" andReturn {
+
+      def expandReference(ref: Property): OrderedSelect =
+        trace"Expanding: $ref from $select" andReturn {
+
+          def expressIfTupleIndex(str: String) =
+            str match {
+              case MultiTupleIndex() => Some(str)
+              case _                 => None
+            }
+
+          def concat(alias: Option[String], idx: Int) =
+            Some(s"${alias.getOrElse("")}_${idx + 1}")
+
+          val orderedSelect = ref match {
+            case pp @ Property(ast: Property, TupleIndex(idx)) =>
+              trace"Reference is a sub-property of a tuple index: $idx. Walking inside." andReturn
+                expandReference(ast) match {
+                  case OrderedSelect(o, SelectValue(Tuple(elems), alias, c)) =>
+                    trace"Expressing Element $idx of $elems " andReturn
+                    OrderedSelect(o :+ idx, SelectValue(elems(idx), concat(alias, idx), c))
+                  case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                    trace"Appending $idx to $alias " andReturn
+                    OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+                }
+            case pp @ Property.Opinionated(ast: Property, name, renameable, visible) =>
+              trace"Reference is a sub-property. Walking inside." andReturn
+                expandReference(ast) match {
+                  case OrderedSelect(o, SelectValue(ast, nested, c)) =>
+                    // Alias is the name of the column after the naming strategy
+                    // The clauses in `SqlIdiom` that use `Tokenizer[SelectValue]` select the
+                    // alias field when it's value is Some(T).
+                    // Technically the aliases of a column should not be using naming strategies
+                    // but this is an issue to fix at a later date.
+
+                    // In the current implementation, aliases we add nested tuple names to queries e.g.
+                    // SELECT foo from
+                    // SELECT x, y FROM (SELECT foo, bar, red, orange FROM baz JOIN colors)
+                    // Typically becomes SELECT foo _1foo, _1bar, _2red, _2orange when
+                    // this kind of query is the result of an applicative join that looks like this:
+                    // query[baz].join(query[colors]).nested
+                    // this may need to change based on how distinct appends table names instead of just tuple indexes
+                    // into the property path.
+
+                    trace"...inside walk completed, continuing to return: " andReturn
+                    OrderedSelect(o, SelectValue(
+                      // Note: Pass invisible properties to be tokenized by the idiom, they should be excluded there
+                      Property.Opinionated(ast, name, renameable, visible),
+                      // Skip concatonation of invisible properties into the alias e.g. so it will be
+                      Some(expandColumn(s"${nested.getOrElse("")}$name", renameable))
+                    ))
+                }
+            case pp @ Property(_, TupleIndex(idx)) =>
+              trace"Reference is a tuple index: $idx from $select." andReturn
+                select(idx) match {
+                  case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                    OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+                }
+            case pp @ Property.Opinionated(_, name, renameable, visible) => // TODO Propagate the Quat.Value from the property when Properties implement Quats
+              select match {
+                case List(OrderedSelect(o, SelectValue(cc: CaseClass, alias, c))) =>
+                  // Currently case class element name is not being appended. Need to change that in order to ensure
+                  // path name uniqueness in future.
+                  val ((_, ast), index) = cc.values.zipWithIndex.find(_._1._1 == name) match {
+                    case Some(v) => v
+                    case None    => throw new IllegalArgumentException(s"Cannot find element $name in $cc")
+                  }
+                  trace"Reference is a case class member: " andReturn
+                    OrderedSelect(o :+ index, SelectValue(ast, Some(expandColumn(name, renameable)), c))
+                case List(OrderedSelect(o, SelectValue(i: Ident, _, c))) =>
+                  trace"Reference is an identifier: " andReturn
+                    OrderedSelect(o, SelectValue(Property.Opinionated(i, name, renameable, visible), Some(name), c))
+                case other =>
+                  trace"Reference is unidentified: $other returning:" andReturn
+                    OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident.Opinionated(name, Quat.Value, visible), Some(expandColumn(name, renameable)), false))
+              }
+          }
+
+          // For certain very large queries where entities are unwrapped and then re-wrapped into CaseClass/Tuple constructs,
+          // the actual row-types can contain Tuple/CaseClass values. For this reason. They need to be beta-reduced again.
+          val normalizedOrderedSelect = orderedSelect.copy(selectValue =
+            orderedSelect.selectValue.copy(ast =
+              BetaReduction(orderedSelect.selectValue.ast)))
+
+          trace"Expanded $ref into $orderedSelect then Normalized to $normalizedOrderedSelect" andReturn
+            normalizedOrderedSelect
+        }
+
+      def deAliasWhenUneeded(os: OrderedSelect) =
+        os match {
+          case OrderedSelect(_, sv @ SelectValue(Property(Ident(_, _), propName), Some(alias), _)) if (propName == alias) =>
+            trace"Detected select value with un-needed alias: $os removing it:" andReturn
+              os.copy(selectValue = sv.copy(alias = None))
+          case _ => os
+        }
+
+      references.toList match {
+        case Nil => select.map(_.selectValue)
+        case refs => {
+          // elements first need to be sorted by their order in the select clause. Since some may map to multiple
+          // properties when expanded, we want to maintain this order of properties as a secondary value.
+          val mappedRefs =
+            refs
+              // Expand all the references to properties that we have selected in the super query
+              .map(expandReference)
+              // Once all the recursive calls of expandReference are done, remove the alias if it is not needed.
+              // We cannot do this because during recursive calls, the aliases of outer clauses are used for inner ones.
+              .map(deAliasWhenUneeded(_))
+
+          trace"Mapped Refs: $mappedRefs".andLog()
+
+          // are there any selects that have infix values which we have not already selected? We need to include
+          // them because they could be doing essential things e.g. RANK ... ORDER BY
+          val remainingSelectsWithInfixes =
+            trace"Searching Selects with Infix:" andReturn
+              new FindUnexpressedInfixes(select)(mappedRefs)
+
+          implicit val ordering: scala.math.Ordering[List[Int]] = new scala.math.Ordering[List[Int]] {
+            override def compare(x: List[Int], y: List[Int]): Int =
+              (x, y) match {
+                case (head1 :: tail1, head2 :: tail2) =>
+                  val diff = head1 - head2
+                  if (diff != 0) diff
+                  else compare(tail1, tail2)
+                case (Nil, Nil)   => 0 // List(1,2,3) == List(1,2,3)
+                case (head1, Nil) => -1 // List(1,2,3) < List(1,2)
+                case (Nil, head2) => 1 // List(1,2) > List(1,2,3)
+              }
+          }
+
+          val sortedRefs =
+            (mappedRefs ++ remainingSelectsWithInfixes).sortBy(ref => ref.order) //(ref.order, ref.secondaryOrder)
+
+          sortedRefs.map(_.selectValue)
+        }
+      }
+    }
+}
+
+object ExpandSelectLegacy {
+  def apply(selectValues: List[SelectValue], references: LinkedHashSet[Property], strategy: NamingStrategy): List[SelectValue] =
+    new ExpandSelectLegacy(selectValues, references, strategy).apply
+}

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/SqlQueryLegacy.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/migration/SqlQueryLegacy.scala
@@ -1,0 +1,206 @@
+package io.getquill.sql.norm.migration
+
+import io.getquill.ast._
+import io.getquill.context.sql.norm.FlattenGroupByAggregation
+import io.getquill.norm.BetaReduction
+import io.getquill.quat.Quat
+import io.getquill.util.Messages.fail
+import io.getquill.context.sql._
+
+object SqlQueryLegacy {
+
+  def apply(query: Ast): SqlQuery =
+    query match {
+      case Union(a, b)                       => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))(query.quat)
+      case UnionAll(a, b)                    => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))(query.quat)
+      case UnaryOperation(op, q: Query)      => UnaryOperationSqlQuery(op, apply(q))(query.quat)
+      case _: Operation | _: Value           => FlattenSqlQuery(select = List(SelectValue(query)))(query.quat)
+      case Map(q, a, b) if a == b            => apply(q)
+      case TakeDropFlatten(q, limit, offset) => flatten(q, "x").copy(limit = limit, offset = offset)(q.quat)
+      case q: Query                          => flatten(q, "x")
+      case infix: Infix                      => flatten(infix, "x")
+      case other                             => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")
+    }
+
+  private def flatten(query: Ast, alias: String): FlattenSqlQuery = {
+    val (sources, finalFlatMapBody) = flattenContexts(query)
+    flatten(sources, finalFlatMapBody, alias)
+  }
+
+  private def flattenContexts(query: Ast): (List[FromContext], Ast) =
+    query match {
+      case FlatMap(q @ (_: Query | _: Infix), Ident(alias, _), p: Query) =>
+        val source = this.source(q, alias)
+        val (nestedContexts, finalFlatMapBody) = flattenContexts(p)
+        (source +: nestedContexts, finalFlatMapBody)
+      case FlatMap(q @ (_: Query | _: Infix), Ident(alias, _), p: Infix) =>
+        fail(s"Infix can't be use as a `flatMap` body. $query")
+      case other =>
+        (List.empty, other)
+    }
+
+  object NestedNest {
+    def unapply(q: Ast): Option[Ast] =
+      q match {
+        case _: Nested => recurse(q)
+        case _         => None
+      }
+
+    private def recurse(q: Ast): Option[Ast] =
+      q match {
+        case Nested(qn) => recurse(qn)
+        case other      => Some(other)
+      }
+  }
+
+  private def flatten(sources: List[FromContext], finalFlatMapBody: Ast, alias: String): FlattenSqlQuery = {
+
+    def select(alias: String, quat: Quat) = SelectValue(Ident(alias, quat), None) :: Nil
+
+    def base(q: Ast, alias: String) = {
+      def nest(ctx: FromContext) = FlattenSqlQuery(from = sources :+ ctx, select = select(alias, q.quat))(q.quat)
+      q match {
+        case Map(_: GroupBy, _, _) => nest(source(q, alias))
+        case NestedNest(q)         => nest(QueryContext(apply(q), alias))
+        case q: ConcatMap          => nest(QueryContext(apply(q), alias))
+        case Join(tpe, a, b, iA, iB, on) =>
+          val ctx = source(q, alias)
+          def aliases(ctx: FromContext): List[(String, Quat)] =
+            ctx match {
+              case TableContext(_, alias)   => (alias, ctx.quat) :: Nil
+              case QueryContext(_, alias)   => (alias, ctx.quat) :: Nil
+              case InfixContext(_, alias)   => (alias, ctx.quat) :: Nil
+              case JoinContext(_, a, b, _)  => aliases(a) ::: aliases(b)
+              case FlatJoinContext(_, a, _) => aliases(a)
+            }
+          FlattenSqlQuery(
+            from = ctx :: Nil,
+            select = aliases(ctx).map { case (a, quat) => SelectValue(Ident(a, quat), None) }
+          )(q.quat)
+        case q @ (_: Map | _: Filter | _: Entity) => flatten(sources, q, alias)
+        case q if (sources == Nil)                => flatten(sources, q, alias)
+        case other                                => nest(source(q, alias))
+      }
+    }
+
+    val quat = finalFlatMapBody.quat
+    finalFlatMapBody match {
+
+      case ConcatMap(q, Ident(alias, _), p) =>
+        FlattenSqlQuery(
+          from = source(q, alias) :: Nil,
+          select = selectValues(p).map(_.copy(concat = true))
+        )(quat)
+
+      case Map(GroupBy(q, x @ Ident(alias, _), g), a, p) =>
+        val b = base(q, alias)
+        val select = BetaReduction(p, a -> Tuple(List(g, x)))
+        val flattenSelect = FlattenGroupByAggregation(x)(select)
+        b.copy(groupBy = Some(g), select = this.selectValues(flattenSelect))(quat)
+
+      case GroupBy(q, Ident(alias, _), p) =>
+        fail("A `groupBy` clause must be followed by `map`.")
+
+      case Map(q, Ident(alias, _), p) =>
+        val b = base(q, alias)
+        val agg = b.select.collect {
+          case s @ SelectValue(_: Aggregation, _, _) => s
+        }
+        if (!b.distinct && agg.isEmpty)
+          b.copy(select = selectValues(p))(quat)
+        else
+          FlattenSqlQuery(
+            from = QueryContext(apply(q), alias) :: Nil,
+            select = selectValues(p)
+          )(quat)
+
+      case Filter(q, Ident(alias, _), p) =>
+        val b = base(q, alias)
+        if (b.where.isEmpty)
+          b.copy(where = Some(p))(quat)
+        else
+          FlattenSqlQuery(
+            from = QueryContext(apply(q), alias) :: Nil,
+            where = Some(p),
+            select = select(alias, quat)
+          )(quat)
+
+      case SortBy(q, Ident(alias, _), p, o) =>
+        val b = base(q, alias)
+        val criterias = orderByCriterias(p, o)
+        if (b.orderBy.isEmpty)
+          b.copy(orderBy = criterias)(quat)
+        else
+          FlattenSqlQuery(
+            from = QueryContext(apply(q), alias) :: Nil,
+            orderBy = criterias,
+            select = select(alias, quat)
+          )(quat)
+
+      case Aggregation(op, q: Query) =>
+        val b = flatten(q, alias)
+        b.select match {
+          case head :: Nil if !b.distinct =>
+            b.copy(select = List(head.copy(ast = Aggregation(op, head.ast))))(quat)
+          case other =>
+            FlattenSqlQuery(
+              from = QueryContext(apply(q), alias) :: Nil,
+              select = List(SelectValue(Aggregation(op, Ident("*", quat)))) // Quat of a * aggregation is same as for the entire query
+            )(quat)
+        }
+
+      case Take(q, n) =>
+        val b = base(q, alias)
+        if (b.limit.isEmpty)
+          b.copy(limit = Some(n))(quat)
+        else
+          FlattenSqlQuery(
+            from = QueryContext(apply(q), alias) :: Nil,
+            limit = Some(n),
+            select = select(alias, quat)
+          )(quat)
+
+      case Drop(q, n) =>
+        val b = base(q, alias)
+        if (b.offset.isEmpty && b.limit.isEmpty)
+          b.copy(offset = Some(n))(quat)
+        else
+          FlattenSqlQuery(
+            from = QueryContext(apply(q), alias) :: Nil,
+            offset = Some(n),
+            select = select(alias, quat)
+          )(quat)
+
+      case Distinct(q: Query) =>
+        val b = base(q, alias)
+        b.copy(distinct = true)(quat)
+
+      case other =>
+        FlattenSqlQuery(from = sources :+ source(other, alias), select = select(alias, quat))(quat)
+    }
+  }
+
+  private def selectValues(ast: Ast) =
+    ast match {
+      case Tuple(values) => values.map(SelectValue(_))
+      case other         => SelectValue(ast) :: Nil
+    }
+
+  private def source(ast: Ast, alias: String): FromContext =
+    ast match {
+      case entity: Entity            => TableContext(entity, alias)
+      case infix: Infix              => InfixContext(infix, alias)
+      case Join(t, a, b, ia, ib, on) => JoinContext(t, source(a, ia.name), source(b, ib.name), on)
+      case FlatJoin(t, a, ia, on)    => FlatJoinContext(t, source(a, ia.name), on)
+      case Nested(q)                 => QueryContext(apply(q), alias)
+      case other                     => QueryContext(apply(other), alias)
+    }
+
+  private def orderByCriterias(ast: Ast, ordering: Ast): List[OrderByCriteria] =
+    (ast, ordering) match {
+      case (Tuple(properties), ord: PropertyOrdering) => properties.flatMap(orderByCriterias(_, ord))
+      case (Tuple(properties), TupleOrdering(ord))    => properties.zip(ord).flatMap { case (a, o) => orderByCriterias(a, o) }
+      case (a, o: PropertyOrdering)                   => List(OrderByCriteria(a, o))
+      case other                                      => fail(s"Invalid order by criteria $ast")
+    }
+}


### PR DESCRIPTION
A great deal of functionality was changed in #1920 where Quat-based subquery expansion was introduced. It may be useful for users to be able to revert to the previous Query expansion mechanism if things are not functioning as needed.

This is only intended to exist for one or two Quill versions going forward and will then be removed.

@getquill/maintainers
