### PR TITLE
Fix ZioJdbc README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2863,7 +2863,7 @@ provide a `DataSource` instead of a `Connection` like this (note that the Connec
 
 ```scala
 import ZioJdbc._
-val zioConn = Layers.dataSourceFromPrefix("testPostgresDB") >>> Layers.dataSourceToConnection
+val zioConn = QDataSource.fromPrefix("testPostgresDB") >>> QDataSource.toConnection
 MyZioContext.run(query[Person]).provideCustomLayer(zioConn)
 ```
 


### PR DESCRIPTION
### Problem

There is no `Layers` object. I think this may have changed in a refactor and the README wasn't updated?

### Solution

I updated it to use `QDataSource` instead.

### Checklist

- [ ] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
