### PR TITLE
Allow Postgres context over JAsync to release prepared statements

### DIFF
--- a/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
@@ -10,15 +10,15 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 import scala.jdk.CollectionConverters._
 
-class PostgresJAsyncContext[N <: NamingStrategy](naming: N, pool: ConnectionPool[PostgreSQLConnection])
-  extends JAsyncContext[PostgresDialect, N, PostgreSQLConnection](PostgresDialect, naming, pool)
+class PostgresJAsyncContext[N <: NamingStrategy](naming: N, pool: ConnectionPool[PostgreSQLConnection], release: Boolean = false)
+  extends JAsyncContext[PostgresDialect, N, PostgreSQLConnection](PostgresDialect, naming, pool, release)
   with ArrayEncoders
   with ArrayDecoders
   with UUIDObjectEncoding {
 
-  def this(naming: N, config: PostgresJAsyncContextConfig) = this(naming, config.pool)
-  def this(naming: N, config: Config) = this(naming, PostgresJAsyncContextConfig(config))
-  def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))
+  def this(naming: N, config: PostgresJAsyncContextConfig, release: Boolean) = this(naming, config.pool, release)
+  def this(naming: N, config: Config, release: Boolean) = this(naming, PostgresJAsyncContextConfig(config), release)
+  def this(naming: N, configPrefix: String, release: Boolean) = this(naming, LoadConfig(configPrefix), release)
 
   override protected def extractActionResult[O](returningAction: ReturnAction, returningExtractor: Extractor[O])(result: DBQueryResult): O =
     result.getRows.asScala


### PR DESCRIPTION
This small fix allows Postgres contexts over JAsyc to release prepared statements after query executions. 

Care has been taken not to break existing API.

This solves issues when using eg pgbouncer with pooling mode transaction. Fix is inspired from JAsync FAQ (https://github.com/jasync-sql/jasync-sql/wiki/FAQ), Q: I am getting the following error: prepared statement "X" does not exist. What can cause this?

@getquill/maintainers
