### PR TITLE
Support OffsetDateTime in JDBC

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -1,9 +1,8 @@
 package io.getquill.context.jdbc
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, OffsetDateTime }
 import java.util
 import java.util.Calendar
-
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
 trait Decoders {
@@ -62,4 +61,7 @@ trait Decoders {
   implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
     decoder((index, row, session) =>
       row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).toLocalDateTime)
+  implicit val offsetDateTimeDecoder: Decoder[OffsetDateTime] =
+    decoder((index, row, session) =>
+      row.getObject(index, classOf[OffsetDateTime]))
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.sql.{ Date, Timestamp, Types }
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, OffsetDateTime, ZoneId }
 import java.util.{ Calendar, TimeZone }
 import java.{ sql, util }
 
@@ -60,4 +60,9 @@ trait Encoders {
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
     encoder(Types.TIMESTAMP, (index, value, row) =>
       row.setTimestamp(index, Timestamp.valueOf(value), Calendar.getInstance(dateTimeZone)))
+  implicit val offsetDateTimeEncoder: Encoder[OffsetDateTime] =
+    encoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, value, row) => {
+      row.setObject(index, value)
+    })
+
 }

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE EncodingTestEntity(
     v12 VARCHAR(255),
     v13 DATE,
     v14 UUID,
+    v15 TIMESTAMPTZ,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,


### PR DESCRIPTION
### Problem

OffsetDateTime cannot be saved into PostgreSQL column of specific type timestamptz.

### Solution

Add JDBC encoder and decoder for OffsetDateTime

### Notes

Did not test with other databases.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
@deusaquilus 
@fwbrasil
@jilen
@juliano
@mentegy
@mdedetrich