### PR TITLE
Prefix error messages with [quill]

### DIFF
--- a/quill-core/src/main/scala/io/getquill/util/MacroContextExt.scala
+++ b/quill-core/src/main/scala/io/getquill/util/MacroContextExt.scala
@@ -11,10 +11,10 @@ object MacroContextExt {
   implicit class RichContext(c: MacroContext) {
 
     def error(msg: String): Unit =
-      c.error(c.enclosingPosition, msg)
+      c.error(c.enclosingPosition, s"[quill] $msg")
 
     def fail(msg: String): Nothing =
-      c.abort(c.enclosingPosition, msg)
+      c.abort(c.enclosingPosition, s"[quill] $msg")
 
     def warn(msg: String): Unit =
       c.warning(c.enclosingPosition, msg)


### PR DESCRIPTION
Fixes #990

### Problem

All error messages should be prefixed with `[quill]`

### Solution

Add `[quill]` prefix to error messages

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
