### PR TITLE
PostgresAsyncContext: reusing same transaction

### DIFF
--- a/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncContextSpec.scala
+++ b/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncContextSpec.scala
@@ -2,13 +2,61 @@ package io.getquill.context.jasync.mysql
 
 import com.github.jasync.sql.db.{ QueryResult, ResultSetKt }
 import io.getquill.ReturnAction.ReturnColumns
+import io.getquill._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import io.getquill.{ Literal, MysqlJAsyncContext, ReturnAction, Spec }
+import scala.concurrent.Future
 
 class MysqlJAsyncContextSpec extends Spec {
 
   import testContext._
+
+  "provides transaction support" - {
+    "success" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        _ <- testContext.transaction { implicit ec =>
+          testContext.run(qr4.insert(_.i -> 33))
+        }
+        r <- testContext.run(qr4)
+      } yield r).map(_.i) mustEqual List(33)
+    }
+    "failure" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        e <- testContext.transaction { implicit ec =>
+          Future.sequence(Seq(
+            testContext.run(qr4.insert(_.i -> 18)),
+            Future(throw new IllegalStateException)
+          ))
+        }.recoverWith {
+          case e: Exception => Future(e.getClass.getSimpleName)
+        }
+        r <- testContext.run(qr4)
+      } yield (e, r.isEmpty)) mustEqual (("CompletionException", true))
+    }
+    "nested" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        _ <- testContext.transaction { implicit ec =>
+          testContext.transaction { implicit ec =>
+            testContext.run(qr4.insert(_.i -> 33))
+          }
+        }
+        r <- testContext.run(qr4)
+      } yield r).map(_.i) mustEqual List(33)
+    }
+    "nested transactions use the same connection" in {
+      await(for {
+        e <- testContext.transaction { implicit ec =>
+          val externalConn = ec.conn
+          testContext.transaction { implicit ec =>
+            Future(externalConn == ec.conn)
+          }
+        }
+      } yield e) mustEqual true
+    }
+  }
 
   "run non-batched action" in {
     val insert = quote { (i: Int) =>

--- a/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresJAsyncContextSpec.scala
+++ b/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresJAsyncContextSpec.scala
@@ -2,13 +2,61 @@ package io.getquill.context.jasync.postgres
 
 import com.github.jasync.sql.db.{ QueryResult, ResultSetKt }
 import io.getquill.ReturnAction.ReturnColumns
-import scala.concurrent.ExecutionContext.Implicits.global
+import io.getquill._
 
-import io.getquill.{ Literal, PostgresJAsyncContext, ReturnAction, Spec }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class PostgresJAsyncContextSpec extends Spec {
 
   import testContext._
+
+  "provides transaction support" - {
+    "success" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        _ <- testContext.transaction { implicit ec =>
+          testContext.run(qr4.insert(_.i -> 33))
+        }
+        r <- testContext.run(qr4)
+      } yield r).map(_.i) mustEqual List(33)
+    }
+    "failure" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        e <- testContext.transaction { implicit ec =>
+          Future.sequence(Seq(
+            testContext.run(qr4.insert(_.i -> 18)),
+            Future(throw new IllegalStateException)
+          ))
+        }.recoverWith {
+          case e: Exception => Future(e.getClass.getSimpleName)
+        }
+        r <- testContext.run(qr4)
+      } yield (e, r.isEmpty)) mustEqual (("CompletionException", true))
+    }
+    "nested" in {
+      await(for {
+        _ <- testContext.run(qr4.delete)
+        _ <- testContext.transaction { implicit ec =>
+          testContext.transaction { implicit ec =>
+            testContext.run(qr4.insert(_.i -> 33))
+          }
+        }
+        r <- testContext.run(qr4)
+      } yield r).map(_.i) mustEqual List(33)
+    }
+    "nested transactions use the same connection" in {
+      await(for {
+        e <- testContext.transaction { implicit ec =>
+          val externalConn = ec.conn
+          testContext.transaction { implicit ec =>
+            Future(externalConn == ec.conn)
+          }
+        }
+      } yield e) mustEqual true
+    }
+  }
 
   "run non-batched action" in {
     val insert = quote { (i: Int) =>


### PR DESCRIPTION
Fixes #1420 

### Problem

PostgresAsyncContext doesn't handle nested transactions correctly

### Solution

Adopted solution described in the issue

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
