### PR TITLE
Update pprint to 0.6.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,10 +190,6 @@ lazy val ultraPure = new sbtcrossproject.CrossType {
     }
 }
 
-def pprintVersion(v: String) = {
-  if(v.startsWith("2.11")) "0.5.4" else "0.5.9"
-}
-
 lazy val `quill-core-portable` =
   crossProject(JVMPlatform, JSPlatform).crossType(ultraPure)
     .settings(commonSettings: _*)
@@ -210,9 +206,8 @@ lazy val `quill-core-portable` =
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "com.lihaoyi" %%% "pprint" % pprintVersion(scalaVersion.value),
+        "com.lihaoyi" %%% "pprint" % "0.6.6",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
-        "com.lihaoyi" %%% "pprint" % "0.5.4",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
         "io.suzaku" %%% "boopickle" % "1.3.1"
       ),
@@ -238,7 +233,7 @@ lazy val `quill-core` =
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "com.lihaoyi" %%% "pprint" % pprintVersion(scalaVersion.value),
+        "com.lihaoyi" %%% "pprint" % "0.6.6",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
       ),
@@ -846,7 +841,7 @@ lazy val basicSettings = Seq(
   crossScalaVersions := Seq(scala_v_11, scala_v_12, scala_v_13),
   libraryDependencies ++= Seq(
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.2.0",
-    "com.lihaoyi"     %% "pprint"         % pprintVersion(scalaVersion.value),
+    "com.lihaoyi"     %% "pprint"         % "0.6.6",
     "org.scalatest"   %%% "scalatest"     % "3.2.10"          % Test,
     "com.google.code.findbugs" % "jsr305" % "3.0.2"          % Provided // just to avoid warnings during compilation
   ) ++ {

--- a/quill-core/src/test/scala/io/getquill/util/InterpolatorSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/util/InterpolatorSpec.scala
@@ -14,11 +14,11 @@ class InterpolatorSpec extends Spec {
   val small = Small(123)
 
   "traces small objects on single line - single" in {
-    trace"small object: $small".generateString() mustEqual (("small object: Small(123) ", 0))
+    trace"small object: $small".generateString() mustEqual (("small object: Small(id = 123) ", 0))
   }
 
   "traces multiple small objects on single line" in {
-    trace"small object: $small and $small".generateString() mustEqual (("small object: Small(123) and Small(123) ", 0))
+    trace"small object: $small and $small".generateString() mustEqual (("small object: Small(id = 123) and Small(id = 123) ", 0))
   }
 
   "traces multiple small objects multline text" in {
@@ -26,10 +26,10 @@ class InterpolatorSpec extends Spec {
 and bar $small""".generateString() mustEqual (
       (
         """small object:
-        ||  Small(123)
+        ||  Small(id = 123)
         ||and foo
         ||and bar
-        ||  Small(123)
+        ||  Small(id = 123)
         |""".stripMargin,
         0
       )
@@ -44,17 +44,17 @@ and bar $small""".generateString() mustEqual (
     trace"large object: $large".generateString() mustEqual ((
       """large object:
         ||  Large(
-        ||    123,
-        ||    "",
-        ||    "Test",
-        ||    "TestTest",
-        ||    "TestTestTest",
-        ||    "TestTestTestTest",
-        ||    "TestTestTestTestTest",
-        ||    "TestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTestTest"
+        ||    id = 123,
+        ||    one = "",
+        ||    two = "Test",
+        ||    three = "TestTest",
+        ||    four = "TestTestTest",
+        ||    five = "TestTestTestTest",
+        ||    six = "TestTestTestTestTest",
+        ||    seven = "TestTestTestTestTestTest",
+        ||    eight = "TestTestTestTestTestTestTest",
+        ||    nine = "TestTestTestTestTestTestTestTest",
+        ||    ten = "TestTestTestTestTestTestTestTestTest"
         ||  )
         |""".stripMargin, 0
     ))
@@ -64,17 +64,17 @@ and bar $small""".generateString() mustEqual (
     trace"%2 large object: $large".generateString() mustEqual ((
       """    large object:
         |    |  Large(
-        |    |    123,
-        |    |    "",
-        |    |    "Test",
-        |    |    "TestTest",
-        |    |    "TestTestTest",
-        |    |    "TestTestTestTest",
-        |    |    "TestTestTestTestTest",
-        |    |    "TestTestTestTestTestTest",
-        |    |    "TestTestTestTestTestTestTest",
-        |    |    "TestTestTestTestTestTestTestTest",
-        |    |    "TestTestTestTestTestTestTestTestTest"
+        |    |    id = 123,
+        |    |    one = "",
+        |    |    two = "Test",
+        |    |    three = "TestTest",
+        |    |    four = "TestTestTest",
+        |    |    five = "TestTestTestTest",
+        |    |    six = "TestTestTestTestTest",
+        |    |    seven = "TestTestTestTestTestTest",
+        |    |    eight = "TestTestTestTestTestTestTest",
+        |    |    nine = "TestTestTestTestTestTestTestTest",
+        |    |    ten = "TestTestTestTestTestTestTestTestTest"
         |    |  )
         |""".stripMargin, 2
     ))
@@ -84,31 +84,31 @@ and bar $small""".generateString() mustEqual (
     trace"large object: $large and $large".generateString() mustEqual ((
       """large object:
         ||  Large(
-        ||    123,
-        ||    "",
-        ||    "Test",
-        ||    "TestTest",
-        ||    "TestTestTest",
-        ||    "TestTestTestTest",
-        ||    "TestTestTestTestTest",
-        ||    "TestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTestTest"
+        ||    id = 123,
+        ||    one = "",
+        ||    two = "Test",
+        ||    three = "TestTest",
+        ||    four = "TestTestTest",
+        ||    five = "TestTestTestTest",
+        ||    six = "TestTestTestTestTest",
+        ||    seven = "TestTestTestTestTestTest",
+        ||    eight = "TestTestTestTestTestTestTest",
+        ||    nine = "TestTestTestTestTestTestTestTest",
+        ||    ten = "TestTestTestTestTestTestTestTestTest"
         ||  )
         ||and
         ||  Large(
-        ||    123,
-        ||    "",
-        ||    "Test",
-        ||    "TestTest",
-        ||    "TestTestTest",
-        ||    "TestTestTestTest",
-        ||    "TestTestTestTestTest",
-        ||    "TestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTest",
-        ||    "TestTestTestTestTestTestTestTestTest"
+        ||    id = 123,
+        ||    one = "",
+        ||    two = "Test",
+        ||    three = "TestTest",
+        ||    four = "TestTestTest",
+        ||    five = "TestTestTestTest",
+        ||    six = "TestTestTestTestTest",
+        ||    seven = "TestTestTestTestTestTest",
+        ||    eight = "TestTestTestTestTestTestTest",
+        ||    nine = "TestTestTestTestTestTestTestTest",
+        ||    ten = "TestTestTestTestTestTestTestTestTest"
         ||  )
         |""".stripMargin, 0
     ))
@@ -134,7 +134,7 @@ and bar $small""".generateString() mustEqual (
 
       trace"small object: $small".andLog()
       ps.flush()
-      buff.toString mustEqual "small object: Small(123) \n"
+      buff.toString mustEqual "small object: Small(id = 123) \n"
     }
 
     "traces large objects on multiple line - multi - with return" in {
@@ -148,46 +148,46 @@ and bar $small""".generateString() mustEqual (
       buff.toString mustEqual (
         """large object:
           ||  Large(
-          ||    123,
-          ||    "",
-          ||    "Test",
-          ||    "TestTest",
-          ||    "TestTestTest",
-          ||    "TestTestTestTest",
-          ||    "TestTestTestTestTest",
-          ||    "TestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTestTest"
+          ||    id = 123,
+          ||    one = "",
+          ||    two = "Test",
+          ||    three = "TestTest",
+          ||    four = "TestTestTest",
+          ||    five = "TestTestTestTest",
+          ||    six = "TestTestTestTestTest",
+          ||    seven = "TestTestTestTestTestTest",
+          ||    eight = "TestTestTestTestTestTestTest",
+          ||    nine = "TestTestTestTestTestTestTestTest",
+          ||    ten = "TestTestTestTestTestTestTestTestTest"
           ||  )
           ||and
           ||  Large(
-          ||    123,
-          ||    "",
-          ||    "Test",
-          ||    "TestTest",
-          ||    "TestTestTest",
-          ||    "TestTestTestTest",
-          ||    "TestTestTestTestTest",
-          ||    "TestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTestTest"
+          ||    id = 123,
+          ||    one = "",
+          ||    two = "Test",
+          ||    three = "TestTest",
+          ||    four = "TestTestTest",
+          ||    five = "TestTestTestTest",
+          ||    six = "TestTestTestTestTest",
+          ||    seven = "TestTestTestTestTestTest",
+          ||    eight = "TestTestTestTestTestTestTest",
+          ||    nine = "TestTestTestTestTestTestTestTest",
+          ||    ten = "TestTestTestTestTestTestTestTestTest"
           ||  )
           |
           |>
           ||  Large(
-          ||    123,
-          ||    "",
-          ||    "Test",
-          ||    "TestTest",
-          ||    "TestTestTest",
-          ||    "TestTestTestTest",
-          ||    "TestTestTestTestTest",
-          ||    "TestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTest",
-          ||    "TestTestTestTestTestTestTestTestTest"
+          ||    id = 123,
+          ||    one = "",
+          ||    two = "Test",
+          ||    three = "TestTest",
+          ||    four = "TestTestTest",
+          ||    five = "TestTestTestTest",
+          ||    six = "TestTestTestTestTest",
+          ||    seven = "TestTestTestTestTestTest",
+          ||    eight = "TestTestTestTestTestTestTest",
+          ||    nine = "TestTestTestTestTestTestTestTest",
+          ||    ten = "TestTestTestTestTestTestTestTestTest"
           ||  )
           |""".stripMargin
       )


### PR DESCRIPTION
### Problem

The current version of pprint is switched because pprint was not published for Scala 2.11 anymore. Now I published all com-lihaoyi libraries for Scala 2.11 so we can update and use a single version.

### Solution

Updated print to 0.6.6 which is published for all Scala versions from 2.11 to 3

### Notes

pprint 0.6.6 has a behavioural change which is that now it prints the name of case class members:
```scala
Small(123) // before
Small(id = 123) // after
```

Checked with MiMa and the only backward binary compatibility issue is:
```
 * method Colored()pprint.TPrintColors#Colors# in object pprint.TPrintColors#Colors has a different result type in current version, where it is pprint.TPrintColors rather than pprint.TPrintColors#Colors#
   filter with: ProblemFilters.exclude[IncompatibleResultTypeProblem]("pprint.TPrintColors#Colors.Colored")
```
which is not used in quill

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
