### PR TITLE
Add 'like' extension to Option[String]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,8 @@ ctx.run(q)
 // SELECT p.id, p.name, p.age FROM Person p WHERE p.name like '%John%'
 ```
 
+`like` extension works on `Option[String]` fields as well.
+
 ### forUpdate
 
 ```scala

--- a/quill-sql/src/main/scala/io/getquill/context/sql/dsl/SqlDsl.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/dsl/SqlDsl.scala
@@ -7,7 +7,11 @@ trait SqlDsl {
   this: SqlContext[_, _] =>
 
   implicit class Like(s1: String) {
-    def like(s2: String) = quote(infix"$s1 like $s2".as[Boolean])
+    def like(s2: String) = quote(infix"$s1 like $s2".asCondition)
+  }
+
+  implicit class LikeOption(s1: Option[String]) {
+    def like(s2: String) = quote(infix"$s1 like $s2".asCondition)
   }
 
   implicit class ForUpdate[T](q: Query[T]) {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
@@ -6,18 +6,36 @@ import io.getquill.context.sql.testContext._
 
 class SqlDslSpec extends Spec {
 
-  "like" - {
+  case class SqlDslTestEntity(s: String, i: Int, l: Long, o: Option[String], b: Boolean)
+
+  "like for String" - {
     "constant" in {
       val q = quote {
-        query[TestEntity].filter(t => Like(t.s) like "a")
+        query[SqlDslTestEntity].filter(t => Like(t.s) like "a")
       }
-      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s like 'a'"
+      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM SqlDslTestEntity t WHERE t.s like 'a'"
     }
     "string interpolation" in {
       val q = quote {
-        query[TestEntity].filter(t => t.s like s"%${lift("a")}%")
+        query[SqlDslTestEntity].filter(t => t.s like s"%${lift("a")}%")
       }
-      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s like ('%' || ?) || '%'"
+      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM SqlDslTestEntity t WHERE t.s like ('%' || ?) || '%'"
+    }
+  }
+
+  "like for Option[String]" - {
+
+    "constant" in {
+      val q = quote {
+        query[SqlDslTestEntity].filter(t => LikeOption(t.o) like "a")
+      }
+      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM SqlDslTestEntity t WHERE t.o like 'a'"
+    }
+    "string interpolation" in {
+      val q = quote {
+        query[SqlDslTestEntity].filter(t => t.o like s"%${lift("a")}%")
+      }
+      testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM SqlDslTestEntity t WHERE t.o like ('%' || ?) || '%'"
     }
   }
 


### PR DESCRIPTION
Supersedes #2039

### Problem

1. In large databases, string partial match on nullable strings are not uncommon. It would be more ergonomic to write `field like "%abc%"` than `field.exists(_ like "%abc%")`.
2. Furthermore, "like" extension sometimes causes syntax error In SQL Server as reported in #2039  

### Solution

- Add `LikeOption(s1: Option[String])` extension similar to `Like`.
- Make "like" expression a condition instead of a boolean

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
