### PR TITLE
Need to change EntityQuery.insert(CaseClass) to EntityQuery.insertValue(CaseClass) for upstream Scala 3 issues.

### DIFF
--- a/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/monix/DecodeNullSpec.scala
+++ b/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/monix/DecodeNullSpec.scala
@@ -13,7 +13,7 @@ class DecodeNullSpec extends Spec {
       val result =
         for {
           _ <- testMonixDB.run(writeEntities.delete)
-          _ <- testMonixDB.run(writeEntities.insert(lift(insertValue)))
+          _ <- testMonixDB.run(writeEntities.insertValue(lift(insertValue)))
           result <- testMonixDB.run(query[DecodeNullTestEntity])
         } yield {
           result

--- a/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/monix/EncodingSpec.scala
+++ b/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/monix/EncodingSpec.scala
@@ -11,7 +11,7 @@ class EncodingSpec extends EncodingSpecHelper {
       val result =
         for {
           _ <- testMonixDB.run(query[EncodingTestEntity].delete)
-          _ <- testMonixDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testMonixDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           result <- testMonixDB.run(query[EncodingTestEntity])
         } yield {
           result
@@ -32,7 +32,7 @@ class EncodingSpec extends EncodingSpecHelper {
       val result =
         for {
           _ <- testMonixDB.run(query[EncodingTestEntity].delete)
-          _ <- testMonixDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testMonixDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           result <- testMonixDB.run(q(liftQuery(insertValues.map(_.id))))
         } yield {
           result

--- a/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/streaming/DecodeNullSpec.scala
+++ b/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/streaming/DecodeNullSpec.scala
@@ -14,7 +14,7 @@ class DecodeNullSpec extends Spec {
       val result =
         for {
           _ <- testStreamDB.run(writeEntities.delete)
-          _ <- Observable.fromTask(testStreamDB.run(writeEntities.insert(lift(insertValue))).countL)
+          _ <- Observable.fromTask(testStreamDB.run(writeEntities.insertValue(lift(insertValue))).countL)
           result <- testStreamDB.run(query[DecodeNullTestEntity])
         } yield {
           result

--- a/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/streaming/EncodingSpec.scala
+++ b/quill-cassandra-monix/src/test/scala/io/getquill/context/cassandra/streaming/EncodingSpec.scala
@@ -13,7 +13,7 @@ class EncodingSpec extends EncodingSpecHelper {
         for {
           _ <- testStreamDB.run(query[EncodingTestEntity].delete)
           inserts = Observable(insertValues: _*)
-          _ <- Observable.fromTask(testStreamDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e))).countL)
+          _ <- Observable.fromTask(testStreamDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e))).countL)
           result <- testStreamDB.run(query[EncodingTestEntity])
         } yield {
           result
@@ -35,7 +35,7 @@ class EncodingSpec extends EncodingSpecHelper {
         for {
           _ <- testStreamDB.run(query[EncodingTestEntity].delete)
           inserts = Observable(insertValues: _*)
-          _ <- Observable.fromTask(testStreamDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e))).countL)
+          _ <- Observable.fromTask(testStreamDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e))).countL)
           result <- testStreamDB.run(q(liftQuery(insertValues.map(_.id))))
         } yield {
           result

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/DecodeNullSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/DecodeNullSpec.scala
@@ -10,7 +10,7 @@ class DecodeNullSpec extends ZioCassandraSpec {
       val ret =
         for {
           _ <- testZioDB.run(writeEntities.delete)
-          _ <- testZioDB.run(writeEntities.insert(lift(insertValue)))
+          _ <- testZioDB.run(writeEntities.insertValue(lift(insertValue)))
           result <- testZioDB.run(query[DecodeNullTestEntity])
         } yield {
           result

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/EncodingSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/EncodingSpec.scala
@@ -10,7 +10,7 @@ class EncodingSpec extends EncodingSpecHelper with ZioCassandraSpec {
       val ret =
         for {
           _ <- testZioDB.run(query[EncodingTestEntity].delete)
-          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           result <- testZioDB.run(query[EncodingTestEntity])
         } yield {
           result
@@ -30,7 +30,7 @@ class EncodingSpec extends EncodingSpecHelper with ZioCassandraSpec {
       val ret =
         for {
           _ <- testZioDB.run(query[EncodingTestEntity].delete)
-          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           result <- testZioDB.run(q(liftQuery(insertValues.map(_.id))))
         } yield {
           result

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/UdtEncodingSessionContextSpec.scala
@@ -53,7 +53,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec with ZioCassandraSpec {
         Set(1, 2),
         Map(1 -> "1", 2 -> "2")),
         List(Name("first", None)))
-      ctx.run(query[WithEverything].insert(lift(e))).runSyncUnsafe()
+      ctx.run(query[WithEverything].insertValue(lift(e))).runSyncUnsafe()
       ctx.run(query[WithEverything].filter(_.id == 1)).runSyncUnsafe().headOption must contain(e)
     }
     "with meta" in {
@@ -62,7 +62,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec with ZioCassandraSpec {
       implicit val myNameMeta = udtMeta[MyName]("Name", _.first -> "firstName")
 
       val e = WithEverything(2, MyName("first"), List(MyName("first")))
-      ctx.run(query[WithEverything].insert(lift(e))).runSyncUnsafe()
+      ctx.run(query[WithEverything].insertValue(lift(e))).runSyncUnsafe()
       ctx.run(query[WithEverything].filter(_.id == 2)).runSyncUnsafe().headOption must contain(e)
     }
   }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CaseClassQueryCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CaseClassQueryCassandraSpec.scala
@@ -10,7 +10,7 @@ class CaseClassQueryCassandraSpec extends Spec {
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
 
   val peopleInsert =
-    quote((p: Contact) => query[Contact].insert(p))
+    quote((p: Contact) => query[Contact].insertValue(p))
 
   val peopleEntries = List(
     Contact(1, "Alex", "Jones", 60, 2, "foo"),
@@ -19,7 +19,7 @@ class CaseClassQueryCassandraSpec extends Spec {
   )
 
   val addressInsert =
-    quote((c: Address) => query[Address].insert(c))
+    quote((c: Address) => query[Address].insertValue(c))
 
   val addressEntries = List(
     Address(1, "123 Fake Street", 11234, "something"),

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -259,7 +259,7 @@ class CqlIdiomSpec extends Spec {
   "action" - {
     "insert" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true)))
       }
       mirrorContext.run(q).string mustEqual
         "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)"

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/DecodeNullSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/DecodeNullSpec.scala
@@ -11,7 +11,7 @@ class DecodeNullSpec extends Spec {
       val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
 
       testSyncDB.run(writeEntities.delete)
-      testSyncDB.run(writeEntities.insert(lift(insertValue)))
+      testSyncDB.run(writeEntities.insertValue(lift(insertValue)))
       intercept[IllegalStateException] {
         testSyncDB.run(query[DecodeNullTestEntity])
       }
@@ -25,7 +25,7 @@ class DecodeNullSpec extends Spec {
       val result =
         for {
           _ <- testAsyncDB.run(writeEntities.delete)
-          _ <- testAsyncDB.run(writeEntities.insert(lift(insertValue)))
+          _ <- testAsyncDB.run(writeEntities.insertValue(lift(insertValue)))
           result <- testAsyncDB.run(query[DecodeNullTestEntity])
         } yield {
           result

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/EncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/EncodingSpec.scala
@@ -10,7 +10,7 @@ class EncodingSpec extends EncodingSpecHelper {
     "sync" in {
       import testSyncDB._
       testSyncDB.run(query[EncodingTestEntity].delete)
-      testSyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      testSyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
       verify(testSyncDB.run(query[EncodingTestEntity]))
     }
 
@@ -20,7 +20,7 @@ class EncodingSpec extends EncodingSpecHelper {
       await {
         for {
           _ <- testAsyncDB.run(query[EncodingTestEntity].delete)
-          _ <- testAsyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testAsyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           result <- testAsyncDB.run(query[EncodingTestEntity])
         } yield {
           verify(result)
@@ -37,7 +37,7 @@ class EncodingSpec extends EncodingSpecHelper {
           query[EncodingTestEntity].filter(t => list.contains(t.id))
       }
       testSyncDB.run(query[EncodingTestEntity])
-      testSyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      testSyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
       verify(testSyncDB.run(q(liftQuery(insertValues.map(_.id)))))
     }
 
@@ -51,7 +51,7 @@ class EncodingSpec extends EncodingSpecHelper {
       await {
         for {
           _ <- testAsyncDB.run(query[EncodingTestEntity].delete)
-          _ <- testAsyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          _ <- testAsyncDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
           r <- testAsyncDB.run(q(liftQuery(insertValues.map(_.id))))
         } yield {
           verify(r)
@@ -99,11 +99,11 @@ class EncodingSpec extends EncodingSpecHelper {
       val c = CasTypes(LocalDate.ofEpochDay(epohDay), Instant.ofEpochMilli(epoh), Some(zonedDateTime))
 
       ctx.run(jq.delete)
-      ctx.run(jq.insert(lift(j)))
+      ctx.run(jq.insertValue(lift(j)))
       ctx.run(cq).headOption mustBe Some(c)
 
       ctx.run(cq.delete)
-      ctx.run(cq.insert(lift(c)))
+      ctx.run(cq.insertValue(lift(c)))
       ctx.run(jq).headOption mustBe Some(j)
     }
   }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
@@ -29,7 +29,7 @@ class ListsEncodingSpec extends CollectionsSpec {
   val q = quote(query[ListsEntity])
 
   "List encoders/decoders for CassandraTypes and CassandraMappers" in {
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -38,7 +38,7 @@ class ListsEncodingSpec extends CollectionsSpec {
     val e = Entity(1, Some(List("1", "2")), None, Nil)
     val q = quote(querySchema[Entity]("ListsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     val r = ctx.run(q.filter(_.id == 1)).head
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
@@ -48,7 +48,7 @@ class ListsEncodingSpec extends CollectionsSpec {
     val e = StrEntity(1, List("1", "2").map(StrWrap.apply))
     val q = quote(querySchema[StrEntity]("ListsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -57,7 +57,7 @@ class ListsEncodingSpec extends CollectionsSpec {
     val e = IntEntity(1, List(1, 2).map(IntWrap.apply))
     val q = quote(querySchema[IntEntity]("ListsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -66,14 +66,14 @@ class ListsEncodingSpec extends CollectionsSpec {
     val e = BlobsEntity(1, List(Array(1.toByte, 2.toByte), Array(2.toByte)))
     val q = quote(querySchema[BlobsEntity]("ListsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1))
       .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
   }
 
   "List in where clause / contains" in {
     val e = ListFrozen(List(1, 2))
-    ctx.run(listFroz.insert(lift(e)))
+    ctx.run(listFroz.insertValue(lift(e)))
     ctx.run(listFroz.filter(_.id == lift(List(1, 2)))) mustBe List(e)
     ctx.run(listFroz.filter(_.id == lift(List(1)))) mustBe Nil
 

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/MapsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/MapsEncodingSpec.scala
@@ -21,7 +21,7 @@ class MapsEncodingSpec extends CollectionsSpec {
   val q = quote(query[MapsEntity])
 
   "Map encoders/decoders" in {
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -35,7 +35,7 @@ class MapsEncodingSpec extends CollectionsSpec {
     val e = Entity(1, Some(Map("1" -> BigDecimal(1))), None, Map())
     val q = quote(querySchema[Entity]("MapsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -44,7 +44,7 @@ class MapsEncodingSpec extends CollectionsSpec {
     val e = StrEntity(1, Map(StrWrap("1") -> BigDecimal(1)))
     val q = quote(querySchema[StrEntity]("MapsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -53,13 +53,13 @@ class MapsEncodingSpec extends CollectionsSpec {
     val e = IntEntity(1, Map(IntWrap(1) -> 1d))
     val q = quote(querySchema[IntEntity]("MapsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
   "Map in where clause / contains" in {
     val e = MapFrozen(Map(1 -> true))
-    ctx.run(mapFroz.insert(lift(e)))
+    ctx.run(mapFroz.insertValue(lift(e)))
     ctx.run(mapFroz.filter(_.id == lift(Map(1 -> true)))) mustBe List(e)
     ctx.run(mapFroz.filter(_.id == lift(Map(1 -> false)))) mustBe Nil
 
@@ -69,7 +69,7 @@ class MapsEncodingSpec extends CollectionsSpec {
 
   "Map.containsValue" in {
     val e = MapFrozen(Map(1 -> true))
-    ctx.run(mapFroz.insert(lift(e)))
+    ctx.run(mapFroz.insertValue(lift(e)))
 
     ctx.run(mapFroz.filter(_.id.containsValue(true)).allowFiltering) mustBe List(e)
     ctx.run(mapFroz.filter(_.id.containsValue(false)).allowFiltering) mustBe Nil

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/PeopleCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/PeopleCassandraSpec.scala
@@ -17,7 +17,7 @@ class PeopleCassandraSpec extends Spec {
       Person(5, "Dre", 60)
     )
     testSyncDB.run(query[Person].delete)
-    testSyncDB.run(liftQuery(entries).foreach(e => query[Person].insert(e)))
+    testSyncDB.run(liftQuery(entries).foreach(e => query[Person].insertValue(e)))
     ()
   }
 

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSpec.scala
@@ -18,7 +18,7 @@ trait QueryResultTypeCassandraSpec extends Spec {
     OrderTestEntity(3, 3)
   )
 
-  val insert = quote((e: OrderTestEntity) => query[OrderTestEntity].insert(e))
+  val insert = quote((e: OrderTestEntity) => query[OrderTestEntity].insertValue(e))
   val deleteAll = quote(query[OrderTestEntity].delete)
   val selectAll = quote(query[OrderTestEntity])
   val map = quote(query[OrderTestEntity].map(_.id))

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
@@ -26,7 +26,7 @@ class SetsEncodingSpec extends CollectionsSpec {
   val q = quote(query[SetsEntity])
 
   "Set encoders/decoders" in {
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -35,7 +35,7 @@ class SetsEncodingSpec extends CollectionsSpec {
     val e = Entity(1, Some(Set("1", "2")), None, Set())
     val q = quote(querySchema[Entity]("SetsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -44,7 +44,7 @@ class SetsEncodingSpec extends CollectionsSpec {
     val e = StrEntity(1, Set("1", "2").map(StrWrap.apply))
     val q = quote(querySchema[StrEntity]("SetsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -53,7 +53,7 @@ class SetsEncodingSpec extends CollectionsSpec {
     val e = IntEntity(1, Set(1, 2).map(IntWrap.apply))
     val q = quote(querySchema[IntEntity]("SetsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -62,14 +62,14 @@ class SetsEncodingSpec extends CollectionsSpec {
     val e = BlobsEntity(1, Set(Array(1.toByte, 2.toByte), Array(2.toByte)))
     val q = quote(querySchema[BlobsEntity]("SetsEntity"))
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1))
       .head.blobs.map(_.toSet) mustBe e.blobs.map(_.toSet)
   }
 
   "Set in where clause" in {
     val e = SetFrozen(Set(1, 2))
-    ctx.run(setFroz.insert(lift(e)))
+    ctx.run(setFroz.insertValue(lift(e)))
     ctx.run(setFroz.filter(_.id == lift(Set(1, 2)))) mustBe List(e)
     ctx.run(setFroz.filter(_.id == lift(Set(1)))) mustBe List()
   }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
@@ -28,7 +28,7 @@ class RenamePropertiesSpec extends Spec {
     "action" - {
       "insert" in {
         val q = quote {
-          e.insert(lift(TestEntity("a", 1, 1L, None, true)))
+          e.insertValue(lift(TestEntity("a", 1, 1L, None, true)))
         }
         mirrorContext.run(q).string mustEqual
           "INSERT INTO test_entity (field_s,field_i,l,o,b) VALUES (?, ?, ?, ?, ?)"

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingMirrorContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingMirrorContextSpec.scala
@@ -29,6 +29,6 @@ class UdtEncodingMirrorContextSpec extends UdtSpec {
     case class User(id: Int, name: Name, names: List[Name])
     mirrorContext.run(query[User]).string mustBe "SELECT id, name, names FROM User"
     mirrorContext.run(query[User]
-      .insert(lift(User(1, Name("1", None), Nil)))).string mustBe "INSERT INTO User (id,name,names) VALUES (?, ?, ?)"
+      .insertValue(lift(User(1, Name("1", None), Nil)))).string mustBe "INSERT INTO User (id,name,names) VALUES (?, ?, ?)"
   }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingSessionContextSpec.scala
@@ -60,7 +60,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec {
         Set(1, 2),
         Map(1 -> "1", 2 -> "2")),
         List(Name("first", None)))
-      ctx1.run(query[WithEverything].insert(lift(e)))
+      ctx1.run(query[WithEverything].insertValue(lift(e)))
       ctx1.run(query[WithEverything].filter(_.id == 1)).headOption must contain(e)
     }
     "with meta" in {
@@ -69,7 +69,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec {
       implicit val myNameMeta = udtMeta[MyName]("Name", _.first -> "firstName")
 
       val e = WithEverything(2, MyName("first"), List(MyName("first")))
-      ctx1.run(query[WithEverything].insert(lift(e)))
+      ctx1.run(query[WithEverything].insertValue(lift(e)))
       ctx1.run(query[WithEverything].filter(_.id == 2)).headOption must contain(e)
     }
   }
@@ -100,7 +100,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec {
     case class WithUdt(id: Int, name: Name)
     val e = WithUdt(1, Name("first", Some("second")))
     // quill_test_2 uses snake case
-    ctx2.run(query[WithUdt].insert(lift(e)))
+    ctx2.run(query[WithUdt].insertValue(lift(e)))
     ctx2.run(query[WithUdt].filter(_.id == 1)).headOption must contain(e)
   }
 

--- a/quill-core/src/main/scala/io/getquill/ModelMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/ModelMacro.scala
@@ -11,6 +11,8 @@ sealed trait EntityQuery[T]
   override def filter(f: T => Boolean): EntityQuery[T] = NonQuotedException()
   override def map[R](f: T => R): EntityQuery[R] = NonQuotedException()
 
+  def insertValue(value: T): Insert[T] = macro QueryDslMacro.expandInsert[T]
+  @deprecated("EntityQuery.insert(value) is deprecated due to upstream Scala 3 requirements. Use EntityQuery.insertValue(value) instead.", "3.13.0")
   def insert(value: T): Insert[T] = macro QueryDslMacro.expandInsert[T]
   def insert(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Insert[T]
 

--- a/quill-core/src/test/scala/io/getquill/AsyncMirrorContextSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/AsyncMirrorContextSpec.scala
@@ -13,22 +13,22 @@ class AsyncMirrorContextSpec extends Spec {
   }
 
   "executeAction" in {
-    eval(ctx.run(qr4.insert(lift(TestEntity4(1)))))
+    eval(ctx.run(qr4.insertValue(lift(TestEntity4(1)))))
   }
 
   "executeActionReturning" in {
-    eval(ctx.run(qr4.insert(lift(TestEntity4(0))).returning(_.i)))
+    eval(ctx.run(qr4.insertValue(lift(TestEntity4(0))).returning(_.i)))
   }
 
   "executeBatchAction" in {
     eval(ctx.run {
-      liftQuery(List(TestEntity4(1))).foreach(e => qr4.insert(e))
+      liftQuery(List(TestEntity4(1))).foreach(e => qr4.insertValue(e))
     })
   }
 
   "executeBatchActionReturning" in {
     eval(ctx.run {
-      liftQuery(List(TestEntity4(0))).foreach(e => qr4.insert(e).returning(_.i))
+      liftQuery(List(TestEntity4(0))).foreach(e => qr4.insertValue(e).returning(_.i))
     })
   }
 

--- a/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
@@ -120,13 +120,13 @@ class UnlimitedOptionalEmbeddedSpec extends Spec {
     )
 
     "non-batched" in {
-      val r = testContext.run(qrOptEmd.insert(lift(optEmdEnt)))
+      val r = testContext.run(qrOptEmd.insertValue(lift(optEmdEnt)))
       r.string mustEqual resultString
       r.prepareRow mustEqual resultRow
     }
     "batched" in {
       val r = testContext.run(
-        liftQuery(List(optEmdEnt)).foreach(e => qrOptEmd.insert(e))
+        liftQuery(List(optEmdEnt)).foreach(e => qrOptEmd.insertValue(e))
       )
       r.groups mustEqual List(resultString -> List(resultRow))
     }

--- a/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
@@ -26,7 +26,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class lifting" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true)))
       }
       val r = testContext.run(q)
       r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.l -> ?, v => v.o -> ?, v => v.b -> ?)"""
@@ -34,7 +34,7 @@ class ActionMacroSpec extends Spec {
     }
     "nexted case class lifting" in {
       val q = quote {
-        t: TestEntity => qr1.insert(t)
+        t: TestEntity => qr1.insertValue(t)
       }
       val r = testContext.run(q(lift(TestEntity("s", 1, 2L, None, true))))
       r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.l -> ?, v => v.o -> ?, v => v.b -> ?)"""
@@ -120,7 +120,7 @@ class ActionMacroSpec extends Spec {
       }
       "case class lifting + returning value" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
+          qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
         }
         val r = testContext.run(q)
         r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.l -> ?, v => v.o -> ?, v => v.b -> ?).returning((t) => t.l)"""
@@ -129,7 +129,7 @@ class ActionMacroSpec extends Spec {
       }
       "case class lifting + returning generated value" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
+          qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
         }
         val r = testContext.run(q)
         r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.o -> ?, v => v.b -> ?).returningGenerated((t) => t.l)"""
@@ -138,7 +138,7 @@ class ActionMacroSpec extends Spec {
       }
       "case class lifting + returning multi value" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returning(t => (t.l, t.i, t.b))
+          qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returning(t => (t.l, t.i, t.b))
         }
         val r = testContext.run(q)
         r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.l -> ?, v => v.o -> ?, v => v.b -> ?).returning((t) => (t.l, t.i, t.b))"""
@@ -147,7 +147,7 @@ class ActionMacroSpec extends Spec {
       }
       "case class lifting + returning generated multi value" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => (t.l, t.i, t.b))
+          qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => (t.l, t.i, t.b))
         }
         val r = testContext.run(q)
         r.string mustEqual """querySchema("TestEntity").insert(v => v.s -> ?, v => v.o -> ?).returningGenerated((t) => (t.l, t.i, t.b))"""
@@ -254,7 +254,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p))
+        liftQuery(entities).foreach(p => qr1.insertValue(p))
       }
       val r = testContext.run(q)
       r.groups mustEqual List(
@@ -264,7 +264,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + nested action" in {
       val nested = quote {
-        p: TestEntity => qr1.insert(p)
+        p: TestEntity => qr1.insertValue(p)
       }
       val q = quote {
         liftQuery(entities).foreach(p => nested(p))
@@ -315,7 +315,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returning(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returning(t => t.l))
       }
       val r = testContext.run(q)
       r.groups mustEqual List(
@@ -327,7 +327,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning generated" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returningGenerated(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returningGenerated(t => t.l))
       }
       val r = testContext.run(q)
       r.groups mustEqual List(
@@ -339,7 +339,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning + nested action" in {
       val insert = quote {
-        p: TestEntity => qr1.insert(p).returning(t => t.l)
+        p: TestEntity => qr1.insertValue(p).returning(t => t.l)
       }
       val r = testContext.run(liftQuery(entities).foreach(p => insert(p)))
       r.groups mustEqual List(
@@ -351,7 +351,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning generated + nested action" in {
       val insert = quote {
-        (p: TestEntity) => qr1.insert(p).returningGenerated(t => t.l)
+        (p: TestEntity) => qr1.insertValue(p).returningGenerated(t => t.l)
       }
       val r = testContext.run(liftQuery(entities).foreach(p => insert(p)))
       r.groups mustEqual List(
@@ -380,14 +380,14 @@ class ActionMacroSpec extends Spec {
     }
     "case class lifting" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true)))
       }
       testContext.translate(q) mustEqual
         """querySchema("TestEntity").insert(v => v.s -> 's', v => v.i -> 1, v => v.l -> 2, v => v.o -> null, v => v.b -> true)"""
     }
     "nested case class lifting" in {
       val q = quote {
-        t: TestEntity => qr1.insert(t)
+        t: TestEntity => qr1.insertValue(t)
       }
       testContext.translate(q(lift(TestEntity("s", 1, 2L, None, true)))) mustEqual
         """querySchema("TestEntity").insert(v => v.s -> 's', v => v.i -> 1, v => v.l -> 2, v => v.o -> null, v => v.b -> true)"""
@@ -408,14 +408,14 @@ class ActionMacroSpec extends Spec {
     }
     "case class lifting + returning value" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
       }
       testContext.translate(q) mustEqual
         """querySchema("TestEntity").insert(v => v.s -> 's', v => v.i -> 1, v => v.l -> 2, v => v.o -> null, v => v.b -> true).returning((t) => t.l)"""
     }
     "case class lifting + returning generated value" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
       }
       testContext.translate(q) mustEqual
         """querySchema("TestEntity").insert(v => v.s -> 's', v => v.i -> 1, v => v.o -> null, v => v.b -> true).returningGenerated((t) => t.l)"""
@@ -443,7 +443,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p))
+        liftQuery(entities).foreach(p => qr1.insertValue(p))
       }
       testContext.translate(q) mustEqual List(
         """querySchema("TestEntity").insert(v => v.s -> 's1', v => v.i -> 2, v => v.l -> 3, v => v.o -> 4, v => v.b -> true)""",
@@ -452,7 +452,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + nested action" in {
       val nested = quote {
-        p: TestEntity => qr1.insert(p)
+        p: TestEntity => qr1.insertValue(p)
       }
       val q = quote {
         liftQuery(entities).foreach(p => nested(p))
@@ -500,7 +500,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returning(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returning(t => t.l))
       }
       testContext.translate(q) mustEqual List(
         """querySchema("TestEntity").insert(v => v.s -> 's1', v => v.i -> 2, v => v.l -> 3, v => v.o -> 4, v => v.b -> true).returning((t) => t.l)""",
@@ -509,7 +509,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning + nested action" in {
       val insert = quote {
-        p: TestEntity => qr1.insert(p).returning(t => t.l)
+        p: TestEntity => qr1.insertValue(p).returning(t => t.l)
       }
       testContext.translate(liftQuery(entities).foreach(p => insert(p))) mustEqual List(
         """querySchema("TestEntity").insert(v => v.s -> 's1', v => v.i -> 2, v => v.l -> 3, v => v.o -> 4, v => v.b -> true).returning((t) => t.l)""",
@@ -518,7 +518,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning generated" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returningGenerated(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returningGenerated(t => t.l))
       }
       testContext.translate(q) mustEqual List(
         """querySchema("TestEntity").insert(v => v.s -> 's1', v => v.i -> 2, v => v.o -> 4, v => v.b -> true).returningGenerated((t) => t.l)""",
@@ -527,7 +527,7 @@ class ActionMacroSpec extends Spec {
     }
     "case class + returning generated + nested action" in {
       val insert = quote {
-        p: TestEntity => qr1.insert(p).returningGenerated(t => t.l)
+        p: TestEntity => qr1.insertValue(p).returningGenerated(t => t.l)
       }
       testContext.translate(liftQuery(entities).foreach(p => insert(p))) mustEqual List(
         """querySchema("TestEntity").insert(v => v.s -> 's1', v => v.i -> 2, v => v.o -> 4, v => v.b -> true).returningGenerated((t) => t.l)""",

--- a/quill-core/src/test/scala/io/getquill/context/BindMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/BindMacroSpec.scala
@@ -25,14 +25,14 @@ class BindMacroSpec extends Spec {
     }
     "case class lifting" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true)))
       }
       val r = testContext.prepare(q)
       r(session) mustEqual Row("s", 1, 2L, None, true)
     }
     "nested case class lifting" in {
       val q = quote {
-        (t: TestEntity) => qr1.insert(t)
+        (t: TestEntity) => qr1.insertValue(t)
       }
       val r = testContext.prepare(q(lift(TestEntity("s", 1, 2L, None, true))))
       r(session) mustEqual Row("s", 1, 2L, None, true)
@@ -53,7 +53,7 @@ class BindMacroSpec extends Spec {
     }
     "case class lifting + returning value" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returning(t => t.l)
       }
       val r = testContext.prepare(q)
       r(session) mustEqual Row("s", 1, 2, None, true)
@@ -67,7 +67,7 @@ class BindMacroSpec extends Spec {
     }
     "case class lifting + returning generated value" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, None, true))).returningGenerated(t => t.l)
       }
       val r = testContext.prepare(q)
       r(session) mustEqual Row("s", 1, None, true)
@@ -95,14 +95,14 @@ class BindMacroSpec extends Spec {
     }
     "case class" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p))
+        liftQuery(entities).foreach(p => qr1.insertValue(p))
       }
       val r = testContext.prepare(q)
       r(session) mustEqual List(Row("s1", 2, 3L, Some(4), true), Row("s5", 6, 7L, Some(8), false))
     }
     "case class + nested action" in {
       val nested = quote {
-        (p: TestEntity) => qr1.insert(p)
+        (p: TestEntity) => qr1.insertValue(p)
       }
       val q = quote {
         liftQuery(entities).foreach(p => nested(p))
@@ -148,28 +148,28 @@ class BindMacroSpec extends Spec {
     }
     "case class + returning" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returning(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returning(t => t.l))
       }
       val r = testContext.prepare(q)
       r(session) mustEqual List(Row("s1", 2, 3L, Some(4), true), Row("s5", 6, 7L, Some(8), false))
     }
     "case class + returning generated" in {
       val q = quote {
-        liftQuery(entities).foreach(p => qr1.insert(p).returningGenerated(t => t.l))
+        liftQuery(entities).foreach(p => qr1.insertValue(p).returningGenerated(t => t.l))
       }
       val r = testContext.prepare(q)
       r(session) mustEqual List(Row("s1", 2, Some(4), true), Row("s5", 6, Some(8), false))
     }
     "case class + returning + nested action" in {
       val insert = quote {
-        (p: TestEntity) => qr1.insert(p).returning(t => t.l)
+        (p: TestEntity) => qr1.insertValue(p).returning(t => t.l)
       }
       val r = testContext.prepare(liftQuery(entities).foreach(p => insert(p)))
       r(session) mustEqual List(Row("s1", 2, 3L, Some(4), true), Row("s5", 6, 7L, Some(8), false))
     }
     "case class + returning generated + nested action" in {
       val insert = quote {
-        (p: TestEntity) => qr1.insert(p).returningGenerated(t => t.l)
+        (p: TestEntity) => qr1.insertValue(p).returningGenerated(t => t.l)
       }
       val r = testContext.prepare(liftQuery(entities).foreach(p => insert(p)))
       r(session) mustEqual List(Row("s1", 2, Some(4), true), Row("s5", 6, Some(8), false))

--- a/quill-core/src/test/scala/io/getquill/dsl/QueryDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/QueryDslSpec.scala
@@ -9,7 +9,7 @@ class QueryDslSpec extends Spec {
   "expands inserts" - {
     "default meta" in {
       val q = quote {
-        (t: TestEntity) => qr1.insert(t)
+        (t: TestEntity) => qr1.insertValue(t)
       }
       val u = quote {
         (t: TestEntity) =>
@@ -28,7 +28,7 @@ class QueryDslSpec extends Spec {
         override val expand = quote((q: EntityQuery[TestEntity], value: TestEntity) => q.insert(v => v.i -> value.i))
       }
       val q = quote {
-        (t: TestEntity) => qr1.insert(t)
+        (t: TestEntity) => qr1.insertValue(t)
       }
       val u = quote {
         (t: TestEntity) => qr1.insert(v => v.i -> t.i)

--- a/quill-core/src/test/scala/io/getquill/monad/ScalaFutureIOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/ScalaFutureIOMonadSpec.scala
@@ -28,22 +28,22 @@ class ScalaFutureIOMonadSpec extends IOMonadSpec {
     }
     "RunActionReturningResult" in {
       val t = TestEntity("1", 2, 3L, Some(4), true)
-      val q = quote(qr1.insert(lift(t)).returning(_.i))
+      val q = quote(qr1.insertValue(lift(t)).returning(_.i))
       eval(ctx.runIO(q)).string mustEqual ctx.eval(ctx.run(q)).string
     }
     "RunBatchActionResult" in {
       val l = List(TestEntity("1", 2, 3L, Some(4), true))
-      val q = quote(liftQuery(l).foreach(t => qr1.insert(t)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insertValue(t)))
       eval(ctx.runIO(q)).groups mustEqual ctx.eval(ctx.run(q)).groups
     }
     "RunBatchActionReturningResult" in {
       val l = List(TestEntity("1", 2, 3L, Some(4), true))
-      val q = quote(liftQuery(l).foreach(t => qr1.insert(t).returning(_.i)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insertValue(t).returning(_.i)))
       eval(ctx.runIO(q)).groups mustEqual ctx.eval(ctx.run(q)).groups
     }
     "transactional" in {
       val l = List(TestEntity("1", 2, 3L, Some(4), true))
-      val q = quote(liftQuery(l).foreach(t => qr1.insert(t).returning(_.i)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insertValue(t).returning(_.i)))
       eval(ctx.runIO(q).transactional).ec mustEqual TransactionalExecutionContext(implicitly[ExecutionContext])
     }
   }

--- a/quill-core/src/test/scala/io/getquill/monad/SyncIOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/SyncIOMonadSpec.scala
@@ -24,17 +24,17 @@ class SyncIOMonadSpec extends IOMonadSpec {
     }
     "RunActionReturningResult" in {
       val t = TestEntity("1", 2, 3L, Some(4), true)
-      val q = quote(qr1.insert(lift(t)).returning(_.i))
+      val q = quote(qr1.insertValue(lift(t)).returning(_.i))
       eval(ctx.runIO(q)).string mustEqual ctx.run(q).string
     }
     "RunBatchActionResult" in {
       val l = List(TestEntity("1", 2, 3L, Some(4), true))
-      val q = quote(liftQuery(l).foreach(t => qr1.insert(t)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insertValue(t)))
       eval(ctx.runIO(q)).groups mustEqual ctx.run(q).groups
     }
     "RunBatchActionReturningResult" in {
       val l = List(TestEntity("1", 2, 3L, Some(4), true))
-      val q = quote(liftQuery(l).foreach(t => qr1.insert(t).returning(_.i)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insertValue(t).returning(_.i)))
       eval(ctx.runIO(q)).groups mustEqual ctx.run(q).groups
     }
   }

--- a/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
@@ -21,7 +21,7 @@ class ExpandReturningSpec extends Spec {
 
     "should replace tuple clauses with ExternalIdent" in {
       val q = quote {
-        query[Person].insert(lift(Person("Joe", 123))).returning(p => (p.name, p.age))
+        query[Person].insertValue(lift(Person("Joe", 123))).returning(p => (p.name, p.age))
       }
       val list =
         ExpandReturning.apply(q.ast.asInstanceOf[Returning])(MirrorIdiom, Literal)
@@ -32,7 +32,7 @@ class ExpandReturningSpec extends Spec {
 
     "should replace case class clauses with ExternalIdent" in {
       val q = quote {
-        query[Person].insert(lift(Person("Joe", 123))).returning(p => Foo(p.name, p.age))
+        query[Person].insertValue(lift(Person("Joe", 123))).returning(p => Foo(p.name, p.age))
       }
       val list =
         ExpandReturning.apply(q.ast.asInstanceOf[Returning])(MirrorIdiom, Literal)
@@ -48,7 +48,7 @@ class ExpandReturningSpec extends Spec {
 
     "replaces tuple clauses with ExternalIdent(newAlias)" in {
       val q = quote {
-        query[Person].insert(lift(Person("Joe", 123))).returning(p => (p.name, p.age))
+        query[Person].insertValue(lift(Person("Joe", 123))).returning(p => (p.name, p.age))
       }
       val list =
         ExpandReturning.apply(q.ast.asInstanceOf[Returning], Some("OTHER"))(MirrorIdiom, SnakeCase)
@@ -59,7 +59,7 @@ class ExpandReturningSpec extends Spec {
 
     "replaces case class clauses with ExternalIdent(newAlias)" in {
       val q = quote {
-        query[Person].insert(lift(Person("Joe", 123))).returning(p => Foo(p.name, p.age))
+        query[Person].insertValue(lift(Person("Joe", 123))).returning(p => Foo(p.name, p.age))
       }
       val list =
         ExpandReturning.apply(q.ast.asInstanceOf[Returning], Some("OTHER"))(MirrorIdiom, SnakeCase)
@@ -73,7 +73,7 @@ class ExpandReturningSpec extends Spec {
     val mi = MirrorIdiom
     val ctx = new MirrorContext(mi, Literal)
     import ctx._
-    val q = quote { query[Person].insert(lift(Person("Joe", 123))) }
+    val q = quote { query[Person].insertValue(lift(Person("Joe", 123))) }
 
     "should expand tuples with plain record" in {
       val qi = quote { q.returning(p => (p.name, p.age)) }
@@ -108,7 +108,7 @@ class ExpandReturningSpec extends Spec {
     val mi = MirrorIdiomReturningMulti
     val ctx = new MirrorContext(mi, Literal)
     import ctx._
-    val q = quote { query[Person].insert(lift(Person("Joe", 123))) }
+    val q = quote { query[Person].insertValue(lift(Person("Joe", 123))) }
 
     "should expand tuples" in {
       val qi = quote { q.returning(p => (p.name, p.age)) }

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
@@ -14,7 +14,7 @@ class NormalizeReturningSpec extends Spec {
 
     val e = Entity(1, EmbEntity(2))
     val q = quote {
-      query[Entity].insert(lift(e))
+      query[Entity].insertValue(lift(e))
     }
 
     "when returning parent col" in {
@@ -28,14 +28,14 @@ class NormalizeReturningSpec extends Spec {
     }
     "when returning parent col - single - returning generated" in testContext.withDialect(MirrorIdiomReturningSingle) { ctx =>
       import ctx._
-      val r = ctx.run(query[Entity].insert(lift(e)).returningGenerated(p => p.id))
+      val r = ctx.run(query[Entity].insertValue(lift(e)).returningGenerated(p => p.id))
       r.string mustEqual """querySchema("Entity").insert(v => v.emb.id -> ?).returningGenerated((p) => p.id)"""
       r.prepareRow mustEqual Row(2)
       r.returningBehavior mustEqual ReturnColumns(List("id"))
     }
     "when returning parent col - multi - returning (supported)" in testContext.withDialect(MirrorIdiomReturningMulti) { ctx =>
       import ctx._
-      val r = ctx.run(query[Entity].insert(lift(e)).returning(p => p.id))
+      val r = ctx.run(query[Entity].insertValue(lift(e)).returning(p => p.id))
       r.string mustEqual """querySchema("Entity").insert(v => v.id -> ?, v => v.emb.id -> ?).returning((p) => p.id)"""
       r.prepareRow mustEqual Row(1, 2)
       r.returningBehavior mustEqual ReturnColumns(List("id"))
@@ -62,7 +62,7 @@ class NormalizeReturningSpec extends Spec {
 
     "when returning embedded col - single" in testContext.withDialect(MirrorIdiomReturningSingle) { ctx =>
       import ctx._
-      val r = ctx.run(query[Entity].insert(lift(e)).returningGenerated(p => p.emb.id))
+      val r = ctx.run(query[Entity].insertValue(lift(e)).returningGenerated(p => p.emb.id))
       r.string mustEqual """querySchema("Entity").insert(v => v.id -> ?).returningGenerated((p) => p.emb.id)"""
       r.prepareRow mustEqual Row(1)
       // As of #1489 the Idiom now decides how to tokenize a `returning` clause when for MirrorIdiom is `emb.id`

--- a/quill-core/src/test/scala/io/getquill/quotation/CompatibleDynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/CompatibleDynamicQuerySpec.scala
@@ -490,7 +490,7 @@ class CompatibleDynamicQuerySpec extends Spec {
     "insertValue" in {
       test(
         quote(query[TestEntity]).dynamic.insertValue(t),
-        query[TestEntity].insert(lift(t))
+        query[TestEntity].insertValue(lift(t))
       )
     }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
@@ -532,7 +532,7 @@ class DynamicQuerySpec extends Spec {
     "insertValue" in {
       test(
         dynamicQuery[TestEntity].insertValue(t),
-        query[TestEntity].insert(lift(t))
+        query[TestEntity].insertValue(lift(t))
       )
     }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -403,7 +403,7 @@ class QuotationSpec extends Spec {
         }
         "case class" in {
           val q = quote {
-            (t: TestEntity) => qr1.insert(t)
+            (t: TestEntity) => qr1.insertValue(t)
           }
           val n = quote {
             (t: TestEntity) =>
@@ -431,7 +431,7 @@ class QuotationSpec extends Spec {
             ActionTestEntity(1),
             ActionTestEntity(2)
           )
-          val insert = quote((row: ActionTestEntity) => query[ActionTestEntity].insert(row))
+          val insert = quote((row: ActionTestEntity) => query[ActionTestEntity].insertValue(row))
           val q = quote(liftQuery(list).foreach(row => quote(insert(row))))
           quote(unquote(q)).ast mustEqual
             Foreach(CaseClassQueryLift("q.list", list, quatOf[ActionTestEntity]), Ident("row"), insert.ast.body)
@@ -1664,7 +1664,7 @@ class QuotationSpec extends Spec {
         case class TestEntity(embedded: EmbeddedTestEntity)
         val t = TestEntity(EmbeddedTestEntity("test"))
         val q = quote {
-          query[TestEntity].insert(lift(t))
+          query[TestEntity].insertValue(lift(t))
         }
         q.liftings.`t.embedded.id`.value mustEqual t.embedded.id
         val q2 = quote(q)
@@ -1694,7 +1694,7 @@ class QuotationSpec extends Spec {
         }
         "action" in {
           val q = quote {
-            query[TestEntity].insert(lift(t))
+            query[TestEntity].insertValue(lift(t))
           }
           val l1 = q.liftings.`t.s`
           l1.value mustEqual t.s

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
@@ -27,7 +27,7 @@ class FinagleMysqlContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted: Long = await(testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     })
     await(testContext.run(qr4.filter(_.i == lift(inserted))))
       .head.i mustBe inserted
@@ -69,7 +69,7 @@ class FinagleMysqlContextSpec extends Spec {
     val context = masterSlaveContext(master, slave)
 
     import context._
-    await(context.run(query[TestEntity4].insert(TestEntity4(0))))
+    await(context.run(query[TestEntity4].insertValue(TestEntity4(0))))
 
     master.methodCount.get() mustBe 1
     slave.methodCount.get() mustBe 0

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -43,7 +43,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
     Await.result {
       for {
         _ <- testContext.run(query[EncodingTestEntity].delete)
-        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
       } yield {
         verify(r)
@@ -77,7 +77,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
     val decodeBoolean = (entity: BooleanEncodingTestEntity) => {
       val r = for {
         _ <- testContext.run(query[BooleanEncodingTestEntity].delete)
-        _ <- testContext.run(query[BooleanEncodingTestEntity].insert(lift(entity)))
+        _ <- testContext.run(query[BooleanEncodingTestEntity].insertValue(lift(entity)))
         result <- testContext.run(query[BooleanEncodingTestEntity])
       } yield result
       Await.result(r).head
@@ -128,7 +128,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
     "default timezone" in {
       val r = for {
         _ <- testContext.run(query[DateEncodingTestEntity].delete)
-        _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+        _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
         result <- testContext.run(query[DateEncodingTestEntity])
       } yield result
 
@@ -142,7 +142,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
       val r = for {
         _ <- testTimezoneContext.run(query[DateEncodingTestEntity].delete)
-        _ <- testTimezoneContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+        _ <- testTimezoneContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
         result <- testTimezoneContext.run(query[DateEncodingTestEntity])
       } yield result
 
@@ -174,7 +174,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
       val r = for {
         _ <- testTimezoneContext.run(query[LocalDateTimeEncodingTestEntity].delete)
-        _ <- testTimezoneContext.run(query[LocalDateTimeEncodingTestEntity].insert(lift(entity)))
+        _ <- testTimezoneContext.run(query[LocalDateTimeEncodingTestEntity].insertValue(lift(entity)))
         result <- testTimezoneContext.run(query[LocalDateTimeEncodingTestEntity])
       } yield result
 
@@ -190,7 +190,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
     val r = for {
       _ <- testContext.run(query[LocalDateTimeEncodingTestEntity].delete)
-      _ <- testContext.run(query[LocalDateTimeEncodingTestEntity].insert(lift(e)))
+      _ <- testContext.run(query[LocalDateTimeEncodingTestEntity].insertValue(lift(e)))
       result <- testContext.run(query[LocalDateTimeEncodingTestEntity])
     } yield result
 

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresContextSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresContextSpec.scala
@@ -25,7 +25,7 @@ class FinaglePostgresContextSpec extends Spec with BeforeAndAfter {
 
   "Insert with returning with single column table" in {
     val inserted: Long = await(testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     })
     await(testContext.run(qr4.filter(_.i == lift(inserted))))
       .head.i mustBe inserted

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
@@ -32,7 +32,7 @@ class FinaglePostgresEncodingSpec extends EncodingSpec {
     val rez0 = Await.result(testContext.run(q0))
 
     //insert new uuid
-    val rez1 = Await.result(testContext.run(query[EncodingUUIDTestEntity].insert(lift(EncodingUUIDTestEntity(testUUID)))))
+    val rez1 = Await.result(testContext.run(query[EncodingUUIDTestEntity].insertValue(lift(EncodingUUIDTestEntity(testUUID)))))
 
     //verify you can get the uuid back from the db
     val q2 = quote(query[EncodingUUIDTestEntity].map(p => p.v1))
@@ -66,7 +66,7 @@ class FinaglePostgresEncodingSpec extends EncodingSpec {
     val fut =
       for {
         _ <- testContext.run(query[EncodingTestEntity].delete)
-        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
       } yield {
         r
@@ -89,7 +89,7 @@ class FinaglePostgresEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDate.now, LocalDate.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r) must contain(entity)
@@ -100,7 +100,7 @@ class FinaglePostgresEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDateTime.now, LocalDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r)

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TransactionSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TransactionSpec.scala
@@ -21,7 +21,7 @@ class TransactionSpec extends ProductSpec {
           }
           Throw(_) <- context.transaction {
             context.run(quote {
-              query[Product].insert(lift(p.copy(id = id)))
+              query[Product].insertValue(lift(p.copy(id = id)))
             }).liftToTry
           }
         } yield id

--- a/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncContextSpec.scala
+++ b/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncContextSpec.scala
@@ -19,7 +19,7 @@ class MysqlJAsyncContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted: Long = await(testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     })
     await(testContext.run(qr4.filter(_.i == lift(inserted))))
       .head.i mustBe inserted

--- a/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncEncodingSpec.scala
+++ b/quill-jasync-mysql/src/test/scala/io/getquill/context/jasync/mysql/MysqlJAsyncEncodingSpec.scala
@@ -80,7 +80,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(new Date, new Date, new Date)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf)
@@ -92,7 +92,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDate.now, JodaDateTime.now, JodaDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf) must contain(entity)
@@ -103,7 +103,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(JodaLocalDate.now, JodaLocalDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf)
@@ -115,7 +115,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDate.now(), LocalDateTime.now.withNano(0), LocalDateTime.now.withNano(0))
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf) must contain(entity)
@@ -146,7 +146,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
     val fut =
       for {
         _ <- testContext.run(query[EncodingTestEntity].delete)
-        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
       } yield {
         r
@@ -160,7 +160,7 @@ class MysqlJAsyncEncodingSpec extends EncodingSpec {
         import c._
         for {
           _ <- c.run(query[EncodingTestEntity].delete)
-          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         } yield result
       }
     }

--- a/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/ArrayAsyncEncodingSpec.scala
+++ b/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/ArrayAsyncEncodingSpec.scala
@@ -16,7 +16,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
   val q = quote(query[ArraysTestEntity])
 
   "Support all sql base types and `Iterable` implementers" in {
-    await(ctx.run(q.insert(lift(e))))
+    await(ctx.run(q.insertValue(lift(e))))
     val actual = await(ctx.run(q)).head
     actual mustEqual e
     baseEntityDeepCheck(actual, e)
@@ -26,7 +26,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
     case class JodaTimes(timestamps: Seq[JodaLocalDateTime], dates: Seq[JodaLocalDate])
     val jE = JodaTimes(Seq(JodaLocalDateTime.now()), Seq(JodaLocalDate.now()))
     val jQ = quote(querySchema[JodaTimes]("ArraysTestEntity"))
-    await(ctx.run(jQ.insert(lift(jE))))
+    await(ctx.run(jQ.insertValue(lift(jE))))
     val actual = await(ctx.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
     actual.dates mustBe jE.dates
@@ -36,7 +36,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
     case class JodaTimes(timestamps: Seq[JodaDateTime])
     val jE = JodaTimes(Seq(JodaDateTime.now()))
     val jQ = quote(querySchema[JodaTimes]("ArraysTestEntity"))
-    await(ctx.run(jQ.insert(lift(jE))))
+    await(ctx.run(jQ.insertValue(lift(jE))))
     val actual = await(ctx.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
   }
@@ -45,7 +45,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
     case class Java8Times(timestamps: Seq[LocalDateTime], dates: Seq[LocalDate])
     val jE = Java8Times(Seq(LocalDateTime.now()), Seq(LocalDate.now()))
     val jQ = quote(querySchema[Java8Times]("ArraysTestEntity"))
-    await(ctx.run(jQ.insert(lift(jE))))
+    await(ctx.run(jQ.insertValue(lift(jE))))
     val actual = await(ctx.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
     actual.dates mustBe jE.dates
@@ -53,7 +53,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
 
   "Support Iterable encoding basing on MappedEncoding" in {
     val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
-    await(ctx.run(wrapQ.insert(lift(wrapE))))
+    await(ctx.run(wrapQ.insertValue(lift(wrapE))))
     await(ctx.run(wrapQ)).head mustBe wrapE
   }
 
@@ -64,7 +64,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
         arrayDecoder[LocalDate, LocalDate, Col](identity)
     }
     import newCtx._
-    await(newCtx.run(query[ArraysTestEntity].insert(lift(e))))
+    await(newCtx.run(query[ArraysTestEntity].insertValue(lift(e))))
     intercept[IllegalStateException] {
       await(newCtx.run(query[ArraysTestEntity])).head mustBe e
     }
@@ -72,7 +72,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
   }
 
   "Arrays in where clause" in {
-    await(ctx.run(q.insert(lift(e))))
+    await(ctx.run(q.insertValue(lift(e))))
     val actual1 = await(ctx.run(q.filter(_.texts == lift(List("test")))))
     val actual2 = await(ctx.run(q.filter(_.texts == lift(List("test2")))))
     baseEntityDeepCheck(actual1.head, e)
@@ -151,7 +151,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
     val realEntity = quote {
       querySchema[RealEncodingTestEntity]("EncodingTestEntity")
     }
-    await(ctx.run(realEntity.insert(lift(insertValue))))
+    await(ctx.run(realEntity.insertValue(lift(insertValue))))
 
     case class EncodingTestEntity(v1: List[String])
     intercept[IllegalStateException](await(ctx.run(query[EncodingTestEntity])))

--- a/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresAsyncEncodingSpec.scala
@@ -37,7 +37,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
     val rez0 = Await.result(testContext.run(q0), Duration.Inf)
 
     //insert new uuid
-    val rez1 = Await.result(testContext.run(query[EncodingUUIDTestEntity].insert(lift(EncodingUUIDTestEntity(testUUID)))), Duration.Inf)
+    val rez1 = Await.result(testContext.run(query[EncodingUUIDTestEntity].insertValue(lift(EncodingUUIDTestEntity(testUUID)))), Duration.Inf)
 
     //verify you can get the uuid back from the db
     val q2 = quote(query[EncodingUUIDTestEntity].map(p => p.v1))
@@ -71,7 +71,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
     val fut =
       for {
         _ <- testContext.run(query[EncodingTestEntity].delete)
-        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
       } yield {
         r
@@ -94,7 +94,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(JodaLocalDate.now, JodaLocalDateTime.now, JodaDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf) mustBe Seq(entity)
@@ -105,7 +105,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDate.now, LocalDateTime.now, ZonedDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf) mustBe Seq(entity)
@@ -117,7 +117,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
         import c._
         for {
           _ <- c.run(query[EncodingTestEntity].delete)
-          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         } yield result
       }
     }

--- a/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresJAsyncContextSpec.scala
+++ b/quill-jasync-postgres/src/test/scala/io/getquill/context/jasync/postgres/PostgresJAsyncContextSpec.scala
@@ -19,7 +19,7 @@ class PostgresJAsyncContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted: Long = await(testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     })
     await(testContext.run(qr4.filter(_.i == lift(inserted))))
       .head.i mustBe inserted
@@ -27,7 +27,7 @@ class PostgresJAsyncContextSpec extends Spec {
   "Insert with returning with multiple columns" in {
     await(testContext.run(qr1.delete))
     val inserted = await(testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+      qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
     })
     (1, "foo", Some(123)) mustBe inserted
   }

--- a/quill-jdbc-monix/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
@@ -22,7 +22,7 @@ class ResultSetIteratorSpec extends AnyFreeSpec with Matchers with BeforeAndAfte
   case class Person(name: String, age: Int)
 
   val peopleInsert =
-    quote((p: Person) => query[Person].insert(p))
+    quote((p: Person) => query[Person].insertValue(p))
 
   val peopleEntries = List(
     Person("Alex", 60),

--- a/quill-jdbc-monix/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -30,7 +30,7 @@ class ConnectionLeakTest extends ProductSpec {
         for {
           _ <- context.run {
             quote {
-              query[Product].insert(
+              query[Product].insertValue(
                 lift(Product(1, UUID.randomUUID().toString, Random.nextLong()))
               )
             }

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
@@ -20,14 +20,14 @@ class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
   implicit val im = insertMeta[Product](_.id)
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
@@ -19,7 +19,7 @@ class ResultSetIteratorSpec extends ZioSpec {
   case class Person(name: String, age: Int)
 
   val peopleInsert =
-    quote((p: Person) => query[Person].insert(p))
+    quote((p: Person) => query[Person].insertValue(p))
 
   val peopleEntries = List(
     Person("Alex", 60),

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
@@ -44,7 +44,7 @@ object DBManager {
 
   val live: ZLayer[Any, Nothing, DBManagerEnv] = ZLayer.succeed(new Service {
     def persist(person: Person): ZIO[Has[DataSource], SQLException, Long] =
-      ctx.run(quote(query[Person].insert(lift(person))))
+      ctx.run(quote(query[Person].insertValue(lift(person))))
 
     def retrieveJoes: ZIO[Has[DataSource], SQLException, List[Person]] =
       ctx.run(quote(query[Person].filter(p => p.name == "Joe")))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -30,7 +30,7 @@ class ConnectionLeakTest extends ProductSpec with ZioSpec {
         for {
           _ <- context.underlying.run {
             quote {
-              query[Product].insert(
+              query[Product].insertValue(
                 lift(Product(1, UUID.randomUUID().toString, Random.nextLong()))
               )
             }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
@@ -20,14 +20,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with ZioSpec with BeforeAnd
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/StreamingWithFetchSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/StreamingWithFetchSpec.scala
@@ -15,7 +15,7 @@ class StreamingWithFetchSpec extends ZioSpec with BeforeAndAfter {
   case class Person(name: String, age: Int)
 
   val selectAll = quote(query[Person])
-  val insert = quote { (p: Person) => query[Person].insert(p) }
+  val insert = quote { (p: Person) => query[Person].insertValue(p) }
 
   def result[T](qzio: QIO[T]): T =
     Runtime.default.unsafeRun(qzio.provide(Has(pool)))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
@@ -19,14 +19,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
@@ -20,14 +20,14 @@ class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
   implicit val im = insertMeta[Product](_.id)
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(prepareInsert) mustEqual false
     extractProducts(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/JdbcContextSpec.scala
@@ -46,7 +46,7 @@ class JdbcContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted = testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
     testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
   }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/PrepareJdbcSpec.scala
@@ -17,14 +17,14 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcContextSpec.scala
@@ -54,7 +54,7 @@ class JdbcContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted = testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
     testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
   }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcEncodingSpec.scala
@@ -16,7 +16,7 @@ class JdbcEncodingSpec extends EncodingSpec {
 
   "encodes sets" in {
     testContext.run(query[EncodingTestEntity].delete)
-    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insert(p)))
+    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insertValue(p)))
     val q = quote {
       (set: Query[Int]) =>
         query[EncodingTestEntity].filter(t => set.contains(t.v6))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/PrepareJdbcSpec.scala
@@ -17,14 +17,14 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcContextSpec.scala
@@ -58,7 +58,7 @@ class JdbcContextSpec extends Spec {
   "insert returning" - {
     "with single column table" in {
       val inserted = testContext.run {
-        qr4.insert(lift(TestEntity4(0))).returning(_.i)
+        qr4.insertValue(lift(TestEntity4(0))).returning(_.i)
       }
       testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
     }
@@ -66,7 +66,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns" in {
       testContext.run(qr1.delete)
       val inserted = testContext.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
       }
       (1, "foo", Some(123)) mustBe inserted
     }
@@ -75,7 +75,7 @@ class JdbcContextSpec extends Spec {
       case class Return(id: Int, str: String, opt: Option[Int])
       testContext.run(qr1.delete)
       val inserted = testContext.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
       }
       Return(1, "foo", Some(123)) mustBe inserted
     }
@@ -86,7 +86,7 @@ class JdbcContextSpec extends Spec {
   // Update MyTable Set Col1 = Value where primary key filters returning column1,column2... into variable1,variable2...
   "update returning" ignore {
     "with single column table" in {
-      testContext.run(qr4.insert(lift(TestEntity4(8))))
+      testContext.run(qr4.insertValue(lift(TestEntity4(8))))
 
       val updated = testContext.run {
         qr4.update(lift(TestEntity4(0))).returning(_.i)
@@ -96,7 +96,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns" in {
       testContext.run(qr1.delete)
-      testContext.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456), true))))
+      testContext.run(qr1.insertValue(lift(TestEntity("baz", 6, 42L, Some(456), true))))
 
       val updated = testContext.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
@@ -107,7 +107,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns - case class" in {
       case class Return(id: Int, str: String, opt: Option[Int])
       testContext.run(qr1.delete)
-      testContext.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456), true))))
+      testContext.run(qr1.insertValue(lift(TestEntity("baz", 6, 42L, Some(456), true))))
 
       val updated = testContext.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcEncodingSpec.scala
@@ -16,7 +16,7 @@ class JdbcEncodingSpec extends EncodingSpec {
 
   "encodes sets" in {
     testContext.run(query[EncodingTestEntity].delete)
-    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insert(p)))
+    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insertValue(p)))
     val q = quote {
       (set: Query[Int]) =>
         query[EncodingTestEntity].filter(t => set.contains(t.v6))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/PrepareJdbcSpec.scala
@@ -17,14 +17,14 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
@@ -15,7 +15,7 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
   val corrected = e.copy(timestamps = e.timestamps.map(d => new Timestamp(d.getTime)))
 
   "Support all sql base types and `Seq` implementers" in {
-    ctx.run(q.insert(lift(corrected)))
+    ctx.run(q.insertValue(lift(corrected)))
     val actual = ctx.run(q).head
     actual mustEqual corrected
     baseEntityDeepCheck(actual, corrected)
@@ -23,7 +23,7 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
 
   "Support Seq encoding basing on MappedEncoding" in {
     val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
-    ctx.run(wrapQ.insert(lift(wrapE)))
+    ctx.run(wrapQ.insertValue(lift(wrapE)))
     ctx.run(wrapQ).head.texts mustBe wrapE.texts
   }
 
@@ -31,7 +31,7 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
     case class Timestamps(timestamps: List[Timestamp])
     val tE = Timestamps(List(new Timestamp(System.currentTimeMillis())))
     val tQ = quote(querySchema[Timestamps]("ArraysTestEntity"))
-    ctx.run(tQ.insert(lift(tE)))
+    ctx.run(tQ.insertValue(lift(tE)))
     ctx.run(tQ).head.timestamps mustBe tE.timestamps
   }
 
@@ -42,7 +42,7 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
         arrayDecoder[LocalDate, LocalDate, Col](identity)
     }
     import newCtx._
-    newCtx.run(query[ArraysTestEntity].insert(lift(corrected)))
+    newCtx.run(query[ArraysTestEntity].insertValue(lift(corrected)))
     intercept[IllegalStateException] {
       newCtx.run(query[ArraysTestEntity]).head mustBe corrected
     }
@@ -57,12 +57,12 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
     implicit def arrayUUIDEncoder[Col <: Seq[UUID]]: Encoder[Col] = arrayRawEncoder[UUID, Col]("uuid")
     implicit def arrayUUIDDecoder[Col <: Seq[UUID]](implicit bf: CBF[UUID, Col]): Decoder[Col] = arrayRawDecoder[UUID, Col]
 
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q).head.uuids mustBe e.uuids
   }
 
   "Arrays in where clause" in {
-    ctx.run(q.insert(lift(corrected)))
+    ctx.run(q.insertValue(lift(corrected)))
     val actual1 = ctx.run(q.filter(_.texts == lift(List("test"))))
     val actual2 = ctx.run(q.filter(_.texts == lift(List("test2"))))
     actual1 mustEqual List(corrected)
@@ -71,7 +71,7 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
 
   "empty array on found null" in {
     case class ArraysTestEntity(texts: Option[List[String]])
-    ctx.run(query[ArraysTestEntity].insert(lift(ArraysTestEntity(None))))
+    ctx.run(query[ArraysTestEntity].insertValue(lift(ArraysTestEntity(None))))
 
     case class E(texts: List[String])
     ctx.run(querySchema[E]("ArraysTestEntity")).headOption.map(_.texts) mustBe Some(Nil)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ComplexQuerySpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ComplexQuerySpec.scala
@@ -19,10 +19,10 @@ class ComplexQuerySpec extends Spec with BeforeAndAfter {
     implicit val testEntity2InsertMeta = insertMeta[TestEntity2](_.o)
 
     val testEntityInsert =
-      quote((p: TestEntity) => query[TestEntity].insert(p))
+      quote((p: TestEntity) => query[TestEntity].insertValue(p))
 
     val testEntity2Insert =
-      quote((p: TestEntity2) => query[TestEntity2].insert(p))
+      quote((p: TestEntity2) => query[TestEntity2].insertValue(p))
 
     "join + nesting + infixes" in {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
@@ -55,7 +55,7 @@ class JdbcContextSpec extends Spec {
   "Insert with returning generated with single column table" in {
     ctx.run(qr4.delete)
     val insert = quote {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
 
     val inserted1 = ctx.run(insert)
@@ -70,7 +70,7 @@ class JdbcContextSpec extends Spec {
 
   "Insert with returning generated with single column table using query" in {
     ctx.run(qr5.delete)
-    val id = ctx.run(qr5.insert(lift(TestEntity5(0, "foo"))).returningGenerated(_.i))
+    val id = ctx.run(qr5.insertValue(lift(TestEntity5(0, "foo"))).returningGenerated(_.i))
     val id2 = ctx.run {
       qr5.insert(_.s -> "bar").returningGenerated(r => query[TestEntity5].filter(_.s == "foo").map(_.i).max)
     }.get
@@ -81,7 +81,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns" in {
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
       }
       (1, "foo", Some(123)) mustBe inserted
     }
@@ -89,7 +89,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
       }
       (1 + 100, "foo", Some(123 + 100)) mustBe inserted
     }
@@ -100,7 +100,7 @@ class JdbcContextSpec extends Spec {
 
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("two", 36, 18L, Some(123), true))).returning(r =>
+        qr1.insertValue(lift(TestEntity("two", 36, 18L, Some(123), true))).returning(r =>
           (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i).map(_.s).max))
       }
       (36, "two_s", Some("foobar")) mustBe inserted
@@ -113,7 +113,7 @@ class JdbcContextSpec extends Spec {
       val value = "foobar"
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("two", 36, 18L, Some(123), true))).returning(r =>
+        qr1.insertValue(lift(TestEntity("two", 36, 18L, Some(123), true))).returning(r =>
           (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i && rr.s == lift(value)).map(_.s).max))
       }
       (36, "two_s", Some("foobar")) mustBe inserted
@@ -121,9 +121,9 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query - same table" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("one", 1, 18L, Some(1), true))))
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("two", 2, 18L, Some(123), true))).returning(r =>
+        qr1.insertValue(lift(TestEntity("two", 2, 18L, Some(123), true))).returning(r =>
           (r.i, r.s + "_s", qr1.filter(rr => rr.o.exists(_ == r.i - 1)).map(_.s).max))
       }
       (2, "two_s", Some("one")) mustBe inserted
@@ -131,9 +131,9 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
       val inserted = ctx.run {
-        qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
+        qr1Emb.insertValue(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
           (r.emb.i, r.o))
       }
       (2, Some(123)) mustBe inserted
@@ -143,7 +143,7 @@ class JdbcContextSpec extends Spec {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
       }
       Return(1, "foo", Some(123)) mustBe inserted
     }
@@ -152,7 +152,7 @@ class JdbcContextSpec extends Spec {
   "update returning" - {
     "with multiple columns" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("bar", 2, 42L, Some(321), true))).returning(r => (r.i, r.s, r.o))
@@ -162,7 +162,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("bar", 2, 42L, Some(321), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
@@ -175,7 +175,7 @@ class JdbcContextSpec extends Spec {
       ctx.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
 
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("bar", 36, 42L, Some(321), true))).returning(r =>
@@ -190,7 +190,7 @@ class JdbcContextSpec extends Spec {
 
       val value = "foobar"
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("bar", 36, 42L, Some(321), true))).returning(r =>
@@ -201,7 +201,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query - same table" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("one", 1, 18L, Some(1), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("two", 2, 18L, Some(123), true))).returning(r =>
@@ -212,7 +212,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
 
       val updated = ctx.run {
         qr1Emb.update(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r => (r.emb.i, r.o))
@@ -223,7 +223,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns - case class" in {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("one", 1, 18L, Some(1), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
@@ -235,7 +235,7 @@ class JdbcContextSpec extends Spec {
   "delete returning" - {
     "with multiple columns" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => (r.i, r.s, r.o))
@@ -245,7 +245,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
@@ -258,7 +258,7 @@ class JdbcContextSpec extends Spec {
       ctx.run(qr2.insert(_.i -> 1, _.l -> 0L, _.s -> "foobar"))
 
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r =>
@@ -273,7 +273,7 @@ class JdbcContextSpec extends Spec {
 
       val value = "foobar"
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r =>
@@ -284,7 +284,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query - same table" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("one", 2, 18L, Some(1), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("one", 2, 18L, Some(1), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r =>
@@ -295,7 +295,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
 
       val deleted = ctx.run {
         qr1Emb.delete.returning(r => (r.emb.i, r.o))
@@ -306,7 +306,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns - case class" in {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("one", 1, 18L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => Return(r.i, r.s, r.o))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
@@ -18,7 +18,7 @@ class JdbcEncodingSpec extends EncodingSpec {
 
   "encodes sets" in {
     testContext.run(query[EncodingTestEntity].delete)
-    testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+    testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
     val q = quote {
       (set: Query[Int]) =>
         query[EncodingTestEntity].filter(t => set.contains(t.v6))
@@ -41,10 +41,10 @@ class JdbcEncodingSpec extends EncodingSpec {
     val res: (List[EncodingTestEntity], List[EncodingTestEntity]) = performIO {
       val steps = for {
         _ <- testContext.runIO(query[EncodingTestEntity].delete)
-        _ <- testContext.runIO(query[EncodingTestEntity].insert(lift(e1)))
+        _ <- testContext.runIO(query[EncodingTestEntity].insertValue(lift(e1)))
         withoutNull <- testContext.runIO(query[EncodingTestEntity])
         _ <- testContext.runIO(query[EncodingTestEntity].delete)
-        _ <- testContext.runIO(query[EncodingTestEntity].insert(lift(e2)))
+        _ <- testContext.runIO(query[EncodingTestEntity].insertValue(lift(e2)))
         withNull <- testContext.runIO(query[EncodingTestEntity])
       } yield (withoutNull, withNull)
       steps

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OnConflictJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OnConflictJdbcSpec.scala
@@ -43,7 +43,7 @@ class OnConflictJdbcSpec extends OnConflictSpec {
         _.i2 -> "i",
         _.l2 -> "l",
         _.o2 -> "o"
-      ).insert(lift(e)).onConflictUpdate(_.i2)(
+      ).insertValue(lift(e)).onConflictUpdate(_.i2)(
           (t, _) => t.l2 -> (t.l2 + 1)
         )
     }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrepareJdbcSpec.scala
@@ -17,14 +17,14 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/JdbcContextSpec.scala
@@ -46,7 +46,7 @@ class JdbcContextSpec extends Spec {
 
   "Insert with returning with single column table" in {
     val inserted = testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
     testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
   }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/PrepareJdbcSpec.scala
@@ -17,14 +17,14 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   val prepareQuery = prepare(query[Product])
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
   }
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
@@ -32,7 +32,7 @@ class ProductJdbcSpec extends ProductSpec {
       val result =
         testContext.run {
           liftQuery(list).foreach { prd =>
-            query[Product].insert(prd).returningGenerated(_.id)
+            query[Product].insertValue(prd).returningGenerated(_.id)
           }
         }
       result.size mustEqual list.size

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
@@ -54,14 +54,14 @@ class JdbcContextSpec extends Spec {
 
   "Insert with returning generated with single column table" in {
     val inserted = ctx.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
     ctx.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
   }
 
   "Insert with returning generated with multiple columns and query embedded" in {
     val inserted = ctx.run {
-      qr4Emb.insert(lift(TestEntity4Emb(EmbSingle(0)))).returningGenerated(_.emb.i)
+      qr4Emb.insertValue(lift(TestEntity4Emb(EmbSingle(0)))).returningGenerated(_.emb.i)
     }
     ctx.run(qr4Emb.filter(_.emb.i == lift(inserted))).head.emb.i mustBe inserted
   }
@@ -70,7 +70,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns" in {
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
       }
       (1, "foo", Some(123)) mustBe inserted
     }
@@ -78,16 +78,16 @@ class JdbcContextSpec extends Spec {
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
       }
       (1 + 100, "foo", Some(123 + 100)) mustBe inserted
     }
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
       val inserted = ctx.run {
-        qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
+        qr1Emb.insertValue(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
           (r.emb.i, r.o))
       }
       (2, Some(123)) mustBe inserted
@@ -97,7 +97,7 @@ class JdbcContextSpec extends Spec {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
       val inserted = ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
       }
       Return(1, "foo", Some(123)) mustBe inserted
     }
@@ -106,7 +106,7 @@ class JdbcContextSpec extends Spec {
   "update returning" - {
     "with multiple columns" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("baz", 6, 42L, Some(456), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
@@ -116,7 +116,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("baz", 6, 42L, Some(456), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
@@ -126,7 +126,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 42L, Some(456)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 42L, Some(456)))))
 
       val updated = ctx.run {
         qr1Emb.update(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r => (r.emb.i, r.o))
@@ -137,7 +137,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns - case class" in {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("baz", 6, 42L, Some(456), true))))
 
       val updated = ctx.run {
         qr1.update(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => Return(r.i, r.s, r.o))
@@ -149,7 +149,7 @@ class JdbcContextSpec extends Spec {
   "delete returning" - {
     "with multiple columns" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 42L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 42L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => (r.i, r.s, r.o))
@@ -159,7 +159,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and operations" in {
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 42L, Some(123), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 1, 42L, Some(123), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
@@ -169,7 +169,7 @@ class JdbcContextSpec extends Spec {
 
     "with multiple columns and query embedded" in {
       ctx.run(qr1Emb.delete)
-      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 42L, Some(333)))))
+      ctx.run(qr1Emb.insertValue(lift(TestEntityEmb(Emb("one", 1), 42L, Some(333)))))
 
       val deleted = ctx.run {
         qr1Emb.delete.returning(r => (r.emb.i, r.o))
@@ -180,7 +180,7 @@ class JdbcContextSpec extends Spec {
     "with multiple columns - case class" in {
       case class Return(id: Int, str: String, opt: Option[Int])
       ctx.run(qr1.delete)
-      ctx.run(qr1.insert(lift(TestEntity("foo", 2, 42L, Some(222), true))))
+      ctx.run(qr1.insertValue(lift(TestEntity("foo", 2, 42L, Some(222), true))))
 
       val deleted = ctx.run {
         qr1.delete.returning(r => Return(r.i, r.s, r.o))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcEncodingSpec.scala
@@ -16,7 +16,7 @@ class JdbcEncodingSpec extends EncodingSpec {
 
   "encodes sets" in {
     testContext.run(query[EncodingTestEntity].delete)
-    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insert(p)))
+    testContext.run(liftQuery(insertValues).foreach(p => query[EncodingTestEntity].insertValue(p)))
     val q = quote {
       (set: Query[Int]) =>
         query[EncodingTestEntity].filter(t => set.contains(t.v6))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PrepareJdbcSpec.scala
@@ -18,7 +18,7 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
   implicit val im = insertMeta[Product](_.id)
 
   "single" in {
-    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    val prepareInsert = prepare(query[Product].insertValue(lift(productEntries.head)))
 
     singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
     extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
@@ -26,7 +26,7 @@ class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
 
   "batch" in {
     val prepareBatchInsert = prepare(
-      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insertValue(p))
     )
 
     batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)

--- a/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/ArrayNdbcPostgresEncodingSpec.scala
+++ b/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/ArrayNdbcPostgresEncodingSpec.scala
@@ -10,7 +10,7 @@ class ArrayNdbcPostgresEncodingSpec extends ArrayEncodingBaseSpec {
   val q = quote(query[ArraysTestEntity])
 
   "Support all sql base types and `Traversable` implementers" in {
-    get(ctx.run(q.insert(lift(e))))
+    get(ctx.run(q.insertValue(lift(e))))
     val actual = get(ctx.run(q)).head
     actual mustEqual e
     baseEntityDeepCheck(actual, e)
@@ -18,7 +18,7 @@ class ArrayNdbcPostgresEncodingSpec extends ArrayEncodingBaseSpec {
 
   "Support Traversable encoding basing on MappedEncoding" in {
     val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
-    get(ctx.run(wrapQ.insert(lift(wrapE))))
+    get(ctx.run(wrapQ.insertValue(lift(wrapE))))
     get(ctx.run(wrapQ)).head mustBe wrapE
   }
 

--- a/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/NdbcPostgresEncodingSpec.scala
+++ b/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/NdbcPostgresEncodingSpec.scala
@@ -31,7 +31,7 @@ class NdbcPostgresEncodingSpec extends EncodingSpec {
     val rez0 = get(context.run(q0))
 
     // insert new uuid
-    val rez1 = get(context.run(query[EncodingUUIDTestEntity].insert(lift(EncodingUUIDTestEntity(testUUID)))))
+    val rez1 = get(context.run(query[EncodingUUIDTestEntity].insertValue(lift(EncodingUUIDTestEntity(testUUID)))))
 
     // verify you can get the uuid back from the db
     val q2 = quote(query[EncodingUUIDTestEntity].map(p => p.v1))
@@ -66,7 +66,7 @@ class NdbcPostgresEncodingSpec extends EncodingSpec {
     val fut =
       for {
         _ <- context.run(query[EncodingTestEntity].delete)
-        _ <- context.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- context.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- context.run(q(liftQuery(insertValues.map(_.v6))))
       } yield {
         r
@@ -89,7 +89,7 @@ class NdbcPostgresEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDate.now, LocalDate.now)
     val r = for {
       _ <- context.run(query[DateEncodingTestEntity].delete)
-      _ <- context.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- context.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- context.run(query[DateEncodingTestEntity])
     } yield result
     get(r) must contain(entity)
@@ -100,7 +100,7 @@ class NdbcPostgresEncodingSpec extends EncodingSpec {
     val entity = DateEncodingTestEntity(LocalDateTime.now, LocalDateTime.now)
     val r = for {
       _ <- context.run(query[DateEncodingTestEntity].delete)
-      _ <- context.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- context.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- context.run(query[DateEncodingTestEntity])
     } yield result
     get(r)

--- a/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/PostgresNdbcContextSpec.scala
+++ b/quill-ndbc-postgres/src/test/scala/io/getquill/context/ndbc/postgres/PostgresNdbcContextSpec.scala
@@ -19,7 +19,7 @@ class PostgresNdbcContextSpec extends Spec {
   "insert with returning" - {
     "single column table" in {
       val inserted: Long = get(ctx.run {
-        qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+        qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
       })
       get(ctx.run(qr4.filter(_.i == lift(inserted)))).head.i mustBe inserted
     }
@@ -27,7 +27,7 @@ class PostgresNdbcContextSpec extends Spec {
     "multiple columns" in {
       get(ctx.run(qr1.delete))
       val inserted = get(ctx.run {
-        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+        qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
       })
       (1, "foo", Some(123)) mustBe inserted
     }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/CaseClassQueryOrientSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/CaseClassQueryOrientSpec.scala
@@ -11,7 +11,7 @@ class CaseClassQueryOrientSpec extends Spec {
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
 
   val peopleInsert =
-    quote((p: Contact) => query[Contact].insert(p))
+    quote((p: Contact) => query[Contact].insertValue(p))
 
   val peopleEntries = List(
     Contact(1, "Alex", "Jones", 60, 2, "foo"),
@@ -20,7 +20,7 @@ class CaseClassQueryOrientSpec extends Spec {
   )
 
   val addressInsert =
-    quote((c: Address) => query[Address].insert(c))
+    quote((c: Address) => query[Address].insertValue(c))
 
   val addressEntries = List(
     Address(1, "123 Fake Street", 11234, "something"),

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/DecodeNullSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/DecodeNullSpec.scala
@@ -12,7 +12,7 @@ class DecodeNullSpec extends Spec {
       val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
 
       ctx.run(writeEntities.delete)
-      ctx.run(writeEntities.insert(lift(insertValue)))
+      ctx.run(writeEntities.insertValue(lift(insertValue)))
 
       intercept[IllegalStateException] {
         ctx.run(query[DecodeNullTestEntity])

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/EncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/EncodingSpec.scala
@@ -13,7 +13,7 @@ class EncodingSpec extends Spec {
       val ctx = orientdb.testSyncDB
       import ctx._
       ctx.run(query[EncodingTestEntity].delete)
-      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
       verify(ctx.run(query[EncodingTestEntity]))
       ctx.close()
     }
@@ -41,7 +41,7 @@ class EncodingSpec extends Spec {
           query[EncodingTestEntity].filter(t => list.contains(t.id))
       }
       ctx.run(query[EncodingTestEntity].delete)
-      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
       verify(ctx.run(q(liftQuery(insertValues.map(_.id)))))
       ctx.close()
     }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
@@ -34,7 +34,7 @@ class ListsEncodingSpec extends Spec {
     val ctx = orientdb.mirrorContext
     import ctx._
     val q = quote(query[ListsEntity])
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q)
   }
 
@@ -43,7 +43,7 @@ class ListsEncodingSpec extends Spec {
     import ctx._
     val q = quote(query[ListsEntity])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     verify(e, ctx.run(q.filter(_.id == 1)).head)
   }
 
@@ -55,7 +55,7 @@ class ListsEncodingSpec extends Spec {
     val q = quote(querySchema[Entity]("ListEntity"))
 
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
 
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
@@ -68,7 +68,7 @@ class ListsEncodingSpec extends Spec {
     val q = quote(querySchema[BlobsEntity]("BlobsEntity"))
 
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1))
       .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
   }
@@ -80,7 +80,7 @@ class ListsEncodingSpec extends Spec {
     val e = ListFrozen(List(1, 2))
     val q = quote(query[ListFrozen])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(p => liftQuery(Set(1)).contains(p.id))) mustBe List(e)
     ctx.run(q.filter(_.id == lift(List(1)))) mustBe Nil
   }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/MapsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/MapsEncodingSpec.scala
@@ -26,7 +26,7 @@ class MapsEncodingSpec extends Spec {
     val ctx = orientdb.mirrorContext
     import ctx._
     val q = quote(query[MapsEntity])
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q)
   }
 
@@ -35,7 +35,7 @@ class MapsEncodingSpec extends Spec {
     import ctx._
     val q = quote(query[MapsEntity])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     verify(e, ctx.run(q.filter(_.id == 1)).head)
   }
 
@@ -51,7 +51,7 @@ class MapsEncodingSpec extends Spec {
     val q = quote(querySchema[Entity]("MapEntity"))
 
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -62,7 +62,7 @@ class MapsEncodingSpec extends Spec {
     val e = MapFrozen(Map(1 -> true))
     val q = quote(query[MapFrozen])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(p => liftQuery(Set(1))
       .contains(p.id))).head.id.head._2 mustBe e.id.head._2
   }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
@@ -277,7 +277,7 @@ class OrientDBIdiomSpec extends Spec {
   "action" - {
     "insert" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("a", 1, 1L, None, true)))
+        qr1.insertValue(lift(TestEntity("a", 1, 1L, None, true)))
       }
       ctx.run(q).string mustEqual
         "INSERT INTO TestEntity (s, i, l, o, b) VALUES(?, ?, ?, ?, ?)"

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/PeopleOrientDBSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/PeopleOrientDBSpec.scala
@@ -18,7 +18,7 @@ class PeopleOrientDBSpec extends Spec {
       Person(5, "Dre", 60)
     )
     ctx.run(query[Person].delete)
-    ctx.run(liftQuery(entries).foreach(e => query[Person].insert(e)))
+    ctx.run(liftQuery(entries).foreach(e => query[Person].insertValue(e)))
     ()
   }
 

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
@@ -17,7 +17,7 @@ class QueryResultTypeOrientDBSync extends Spec {
     val ctx = orientdb.testSyncDB
     import ctx._
     ctx.run(quote(query[OrderTestEntity].delete))
-    entries.foreach(e => ctx.run(quote { query[OrderTestEntity].insert(lift(e)) }))
+    entries.foreach(e => ctx.run(quote { query[OrderTestEntity].insertValue(lift(e)) }))
   }
 
   "return list" - {

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
@@ -33,7 +33,7 @@ class SetsEncodingSpec extends Spec {
     val ctx = orientdb.mirrorContext
     import ctx._
     val q = quote(query[SetsEntity])
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q)
   }
 
@@ -42,7 +42,7 @@ class SetsEncodingSpec extends Spec {
     import ctx._
     val q = quote(query[SetsEntity])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     verify(e, ctx.run(q.filter(_.id == 1)).head)
   }
 
@@ -54,7 +54,7 @@ class SetsEncodingSpec extends Spec {
     val q = quote(querySchema[Entity]("ListEntity"))
 
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
@@ -66,7 +66,7 @@ class SetsEncodingSpec extends Spec {
     val q = quote(querySchema[BlobsEntity]("BlobsEntity"))
 
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(_.id == 1))
       .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
   }
@@ -78,7 +78,7 @@ class SetsEncodingSpec extends Spec {
     val e = ListFrozen(List(1, 2))
     val q = quote(query[ListFrozen])
     ctx.run(q.delete)
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insertValue(lift(e)))
     ctx.run(q.filter(p => liftQuery(Set(1)).contains(p.id))) mustBe List(e)
     ctx.run(q.filter(_.id == lift(List(1)))) mustBe Nil
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/ArrayOpsSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/ArrayOpsSpec.scala
@@ -20,7 +20,7 @@ trait ArrayOpsSpec extends Spec {
   val entity = quote(query[ArrayOps])
 
   val insertEntries = quote {
-    liftQuery(entriesList).foreach(e => entity.insert(e))
+    liftQuery(entriesList).foreach(e => entity.insertValue(e))
   }
 
   object `contains` {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
@@ -14,7 +14,7 @@ trait CaseClassQuerySpec extends Spec {
   case class NicknameSameField(firstName: String)
 
   val peopleInsert =
-    quote((p: Contact) => query[Contact].insert(p))
+    quote((p: Contact) => query[Contact].insertValue(p))
 
   val peopleEntries = List(
     Contact("Alex", "Jones", 60, 2, "foo"),
@@ -23,7 +23,7 @@ trait CaseClassQuerySpec extends Spec {
   )
 
   val addressInsert =
-    quote((c: Address) => query[Address].insert(c))
+    quote((c: Address) => query[Address].insertValue(c))
 
   val addressEntries = List(
     Address(1, "123 Fake Street", 11234, "something"),

--- a/quill-sql/src/test/scala/io/getquill/context/sql/DepartmentsSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/DepartmentsSpec.scala
@@ -15,7 +15,7 @@ trait DepartmentsSpec extends Spec {
 
   val departmentInsert =
     quote {
-      (dpt: Department) => query[Department].insert(dpt)
+      (dpt: Department) => query[Department].insertValue(dpt)
     }
 
   val departmentEntries =
@@ -28,7 +28,7 @@ trait DepartmentsSpec extends Spec {
 
   val employeeInsert =
     quote {
-      (emp: Employee) => query[Employee].insert(emp)
+      (emp: Employee) => query[Employee].insertValue(emp)
     }
 
   val employeeEntries =
@@ -43,7 +43,7 @@ trait DepartmentsSpec extends Spec {
 
   val taskInsert =
     quote {
-      (tsk: Task) => query[Task].insert(tsk)
+      (tsk: Task) => query[Task].insertValue(tsk)
     }
 
   val taskEntries =

--- a/quill-sql/src/test/scala/io/getquill/context/sql/DistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/DistinctSpec.scala
@@ -13,7 +13,7 @@ trait DistinctSpec extends Spec {
   case class Couple(him: String, her: String)
 
   val peopleInsert =
-    quote((p: Person) => query[Person].insert(p))
+    quote((p: Person) => query[Person].insertValue(p))
 
   val peopleEntries = List(
     Person("A", 1),
@@ -24,7 +24,7 @@ trait DistinctSpec extends Spec {
   )
 
   val couplesInsert =
-    quote((c: Couple) => query[Couple].insert(c))
+    quote((c: Couple) => query[Couple].insertValue(c))
 
   val couplesEntries = List(
     Couple("B", "X"),

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -60,7 +60,7 @@ trait EncodingSpec extends Spec {
   }
 
   val insert = quote {
-    (e: EncodingTestEntity) => query[EncodingTestEntity].insert(e)
+    (e: EncodingTestEntity) => query[EncodingTestEntity].insertValue(e)
   }
 
   val insertValues =
@@ -168,7 +168,7 @@ trait EncodingSpec extends Spec {
 
   case class BarCode(description: String, uuid: Option[UUID] = None)
 
-  val insertBarCode = quote((b: BarCode) => query[BarCode].insert(b).returningGenerated(_.uuid))
+  val insertBarCode = quote((b: BarCode) => query[BarCode].insertValue(b).returningGenerated(_.uuid))
   val barCodeEntry = BarCode("returning UUID")
 
   def findBarCodeByUuid(uuid: UUID) = quote(query[BarCode].filter(_.uuid.forall(_ == lift(uuid))))

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OnConflictSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OnConflictSpec.scala
@@ -8,7 +8,7 @@ trait OnConflictSpec extends Spec {
 
   object `onConflictIgnore` {
     val testQuery1, testQuery2 = quote {
-      qr1.insert(lift(TestEntity("", 1, 0, None, true))).onConflictIgnore
+      qr1.insertValue(lift(TestEntity("", 1, 0, None, true))).onConflictIgnore
     }
     val res1 = 1
     val res2 = 0
@@ -22,7 +22,7 @@ trait OnConflictSpec extends Spec {
   object `onConflictIgnore(_.i)` {
     val name = "ON CONFLICT (...) DO NOTHING"
     val testQuery1, testQuery2 = quote {
-      qr1.insert(lift(TestEntity("s", 2, 0, None, true))).onConflictIgnore(_.i)
+      qr1.insertValue(lift(TestEntity("s", 2, 0, None, true))).onConflictIgnore(_.i)
     }
     val res1 = 1
     val res2 = 0
@@ -49,7 +49,7 @@ trait OnConflictSpec extends Spec {
   object `onConflictUpdate((t, e) => ...)` extends onConflictUpdate(3) {
     def testQuery(e: TestEntity) = quote {
       qr1
-        .insert(lift(e))
+        .insertValue(lift(e))
         .onConflictUpdate((t, e) => t.s -> (t.s + "-" + e.s), (t, _) => t.l -> (t.l + 1))
     }
   }
@@ -57,7 +57,7 @@ trait OnConflictSpec extends Spec {
   object `onConflictUpdate(_.i)((t, e) => ...)` extends onConflictUpdate(4) {
     def testQuery(e: TestEntity) = quote {
       qr1
-        .insert(lift(e))
+        .insertValue(lift(e))
         .onConflictUpdate(_.i)((t, e) => t.s -> (t.s + "-" + e.s), (t, _) => t.l -> (t.l + 1))
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
@@ -14,7 +14,7 @@ trait OptionQuerySpec extends Spec {
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: Option[String])
 
   val peopleInsert =
-    quote((p: Contact) => query[Contact].insert(p))
+    quote((p: Contact) => query[Contact].insertValue(p))
 
   val peopleEntries = List(
     Contact("Alex", "Jones", 60, Option(1), "foo"),
@@ -23,7 +23,7 @@ trait OptionQuerySpec extends Spec {
   )
 
   val addressInsert =
-    quote((c: Address) => query[Address].insert(c))
+    quote((c: Address) => query[Address].insertValue(c))
 
   val addressEntries = List(
     Address(1, "123 Fake Street", 11234, Some("something")),

--- a/quill-sql/src/test/scala/io/getquill/context/sql/PeopleSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/PeopleSpec.scala
@@ -15,7 +15,7 @@ trait PeopleSpec extends Spec {
   case class Couple(her: String, him: String)
 
   val peopleInsert =
-    quote((p: Person) => query[Person].insert(p))
+    quote((p: Person) => query[Person].insertValue(p))
 
   val peopleEntries = List(
     Person("Alex", 60),
@@ -27,7 +27,7 @@ trait PeopleSpec extends Spec {
   )
 
   val couplesInsert =
-    quote((c: Couple) => query[Couple].insert(c))
+    quote((c: Couple) => query[Couple].insertValue(c))
 
   val couplesEntries = List(
     Couple("Alex", "Bert"),

--- a/quill-sql/src/test/scala/io/getquill/context/sql/ProductSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/ProductSpec.scala
@@ -18,7 +18,7 @@ trait ProductSpec extends Spec {
   }
 
   val productInsert = quote {
-    (p: Product) => query[Product].insert(p).returningGenerated(_.id)
+    (p: Product) => query[Product].insertValue(p).returningGenerated(_.id)
   }
 
   val productInsertBatch = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/QuerySchemaSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/QuerySchemaSpec.scala
@@ -14,7 +14,7 @@ class QuerySchemaSpec extends Spec {
     "querySchema" in {
       val q = quote {
         querySchema[Person]("thePerson", _.id -> "theId", _.name -> "theName")
-          .insert(lift(p))
+          .insertValue(lift(p))
           .onConflictUpdate(_.id)(_.name -> _.name)
       }
       ctx.run(q).string mustEqual "INSERT INTO thePerson AS t (theId,theName) VALUES (?, ?) ON CONFLICT (theId) DO UPDATE SET theName = EXCLUDED.theName"
@@ -24,7 +24,7 @@ class QuerySchemaSpec extends Spec {
       implicit val personSchemaMeta = schemaMeta[Person]("thePerson", _.id -> "theId", _.name -> "theName")
       val q = quote {
         query[Person]
-          .insert(lift(p))
+          .insertValue(lift(p))
           .onConflictUpdate(_.id)(_.name -> _.name)
       }
       ctx.run(q).string mustEqual "INSERT INTO thePerson AS t (theId,theName) VALUES (?, ?) ON CONFLICT (theId) DO UPDATE SET theName = EXCLUDED.theName"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -55,7 +55,7 @@ class SqlActionMacroSpec extends Spec {
     "insert returning generated" - {
       "single with returning generated" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
         }
 
         val mirror = testContext.run(q)
@@ -77,7 +77,7 @@ class SqlActionMacroSpec extends Spec {
       "multi" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -87,7 +87,7 @@ class SqlActionMacroSpec extends Spec {
       "multi with record type returning" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
         }
 
         val mirror = ctx.run(q)
@@ -97,7 +97,7 @@ class SqlActionMacroSpec extends Spec {
       "multi with record type returning generated should exclude all" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
         }
 
         val mirror = ctx.run(q)
@@ -117,7 +117,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - single" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -127,7 +127,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - multi" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, false))).returningGenerated(r => (r.i, r.l, r.b))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, false))).returningGenerated(r => (r.i, r.l, r.b))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,o) VALUES (?, ?) RETURNING i, l, b"
@@ -136,7 +136,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - operation" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l + 1))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l + 1))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,o,b) VALUES (?, ?, ?) RETURNING i, l + 1"
@@ -145,7 +145,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - record" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?) RETURNING s, i, l, o, b"
@@ -154,7 +154,7 @@ class SqlActionMacroSpec extends Spec {
       "returning generated clause - record" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity DEFAULT VALUES RETURNING s, i, l, o, b"
@@ -166,7 +166,7 @@ class SqlActionMacroSpec extends Spec {
         "embedded property" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(_.emb.i)
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(_.emb.i)
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?) RETURNING i"
@@ -175,7 +175,7 @@ class SqlActionMacroSpec extends Spec {
         "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (r.emb.i, r.emb.s))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (r.emb.i, r.emb.s))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (l,o) VALUES (?, ?) RETURNING i, s"
@@ -184,7 +184,7 @@ class SqlActionMacroSpec extends Spec {
         "query with filter using id - id should be excluded" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (query[Dummy].filter(d => d.i == r.emb.i).max))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (query[Dummy].filter(d => d.i == r.emb.i).max))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity AS r (s,l,o) VALUES (?, ?, ?) RETURNING (SELECT MAX(d.*) FROM Dummy d WHERE d.i = r.i)"
@@ -200,7 +200,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (query[Dummy].map(d => d.i).value))
           }
           val mirror = ctx.run(q)
@@ -211,7 +211,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (r.i, query[Dummy].map(d => d.i).value))
           }
           val mirror = ctx.run(q)
@@ -222,7 +222,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (query[Dummy].filter(d => d.i == r.i).max))
           }
           val mirror = ctx.run(q)
@@ -233,7 +233,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (query[Dummy].filter(d => d.i == r.i).max))
           }
           val mirror = ctx.run(q)
@@ -244,7 +244,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (r.s, r.i, r.l, r.o, r.b, query[Dummy].map(r => r.i).max))
           }
           val mirror = ctx.run(q)
@@ -256,7 +256,7 @@ class SqlActionMacroSpec extends Spec {
           val value = 123
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (query[Dummy].filter(r => r.i == lift(value)).max))
           }
           val mirror = ctx.run(q)
@@ -268,7 +268,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (query[Dummy].map(r => r.i).max))
           }
           val mirror = ctx.run(q)
@@ -279,7 +279,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (
                 query[Dummy].join(query[Dummy]).on((r, x) => r.i == x.i).map(_._1.i).max
               ))
@@ -292,7 +292,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (
                 query[Dummy].flatMap(r => query[Dummy].filter(s => r.i == s.i)).map(_.i).max
               ))
@@ -305,7 +305,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r => (
                 query[DummyS].concatMap(r => r.s.split(" ")).max
               ))
@@ -318,7 +318,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r =>
                 query[Dummy].groupBy(r => r.i).map(_._2.map(_.i).min).value)
           }
@@ -330,7 +330,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r =>
                 {
                   for {
@@ -347,7 +347,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(r =>
                 query[Dummy].sortBy(r => r.i).max)
           }
@@ -359,7 +359,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(
                 r =>
                   (query[Dummy]
@@ -379,7 +379,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(
                 r => (query[Dummy].filter(d => d.i == r.i).map(r => r.i).max)
               )
@@ -393,7 +393,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(
                 r => (query[Dummy].filter(r => r.i == r.i).filter(d => d.i == r.i).max)
               )
@@ -406,7 +406,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returningGenerated(
                 r => (r.i, query[Dummy].filter(r => r.i == r.i).filter(d => d.i == r.i).max)
               )
@@ -419,7 +419,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - single" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -429,7 +429,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - multi" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,o,b) OUTPUT INSERTED.i, INSERTED.l VALUES (?, ?, ?)"
@@ -437,7 +437,7 @@ class SqlActionMacroSpec extends Spec {
       }
       "output clause - operation" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
-        val q = quote { qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l + 1)) }
+        val q = quote { qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => (r.i, r.l + 1)) }
         val mirror = ctx.run(q)
 
         mirror.string mustEqual "INSERT INTO TestEntity (s,o,b) OUTPUT INSERTED.i, INSERTED.l + 1 VALUES (?, ?, ?)"
@@ -445,7 +445,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - record" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returningGenerated(r => r)
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity OUTPUT INSERTED.s, INSERTED.i, INSERTED.l, INSERTED.o, INSERTED.b DEFAULT VALUES"
@@ -457,7 +457,7 @@ class SqlActionMacroSpec extends Spec {
         "embedded property" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(_.emb.i)
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(_.emb.i)
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,l,o) OUTPUT INSERTED.i VALUES (?, ?, ?)"
@@ -466,7 +466,7 @@ class SqlActionMacroSpec extends Spec {
         "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (r.emb.i, r.emb.s))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(r => (r.emb.i, r.emb.s))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (l,o) OUTPUT INSERTED.i, INSERTED.s VALUES (?, ?)"
@@ -477,7 +477,7 @@ class SqlActionMacroSpec extends Spec {
         case class Person(firstName: String, age: Int)
         import ctx._
         val q = quote {
-          query[Person].insert(lift(Person("Joe", 123))).returning(p => p.firstName)
+          query[Person].insertValue(lift(Person("Joe", 123))).returning(p => p.firstName)
         }
 
         val mirror = ctx.run(q)
@@ -493,7 +493,7 @@ class SqlActionMacroSpec extends Spec {
       "multi" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -509,7 +509,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - single" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -519,7 +519,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - multi" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?) RETURNING i, l"
@@ -528,7 +528,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - operation" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l + 1))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l + 1))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?) RETURNING i, l + 1"
@@ -540,7 +540,7 @@ class SqlActionMacroSpec extends Spec {
         "embedded property" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o) VALUES (?, ?, ?, ?) RETURNING i"
@@ -549,7 +549,7 @@ class SqlActionMacroSpec extends Spec {
         "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o) VALUES (?, ?, ?, ?) RETURNING i, s"
@@ -558,7 +558,7 @@ class SqlActionMacroSpec extends Spec {
         "query with filter using id - id should be excluded" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (query[Dummy].filter(d => d.i == r.emb.i).max))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (query[Dummy].filter(d => d.i == r.emb.i).max))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity AS r (s,i,l,o) VALUES (?, ?, ?, ?) RETURNING (SELECT MAX(d.*) FROM Dummy d WHERE d.i = r.i)"
@@ -572,7 +572,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(r => (query[Dummy].map(d => d.i).max))
           }
           val mirror = ctx.run(q)
@@ -583,7 +583,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(r => (r.i, query[Dummy].map(d => d.i).max))
           }
           val mirror = ctx.run(q)
@@ -594,7 +594,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(r => (query[Dummy].filter(d => d.i == r.i).max))
           }
           val mirror = ctx.run(q)
@@ -605,7 +605,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(r => (query[Dummy].map(r => r.i).max))
           }
           val mirror = ctx.run(q)
@@ -616,7 +616,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(
                 r =>
                   (query[Dummy]
@@ -635,7 +635,7 @@ class SqlActionMacroSpec extends Spec {
           import ctx._
           val q = quote {
             qr1
-              .insert(lift(TestEntity("s", 0, 1L, None, true)))
+              .insertValue(lift(TestEntity("s", 0, 1L, None, true)))
               .returning(
                 r => (query[Dummy].filter(d => d.i == r.i).map(r => r.i).max)
               )
@@ -648,7 +648,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - single" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(_.l)
         }
 
         val mirror = ctx.run(q)
@@ -658,7 +658,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - multi" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l))
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l))
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) OUTPUT INSERTED.i, INSERTED.l VALUES (?, ?, ?, ?, ?)"
@@ -666,7 +666,7 @@ class SqlActionMacroSpec extends Spec {
       }
       "output clause - operation" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
-        val q = quote { qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l + 1)) }
+        val q = quote { qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => (r.i, r.l + 1)) }
         val mirror = ctx.run(q)
 
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) OUTPUT INSERTED.i, INSERTED.l + 1 VALUES (?, ?, ?, ?, ?)"
@@ -674,7 +674,7 @@ class SqlActionMacroSpec extends Spec {
       "output clause - record" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
         import ctx._
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
+          qr1.insertValue(lift(TestEntity("s", 0, 1L, None, true))).returning(r => r)
         }
         val mirror = ctx.run(q)
         mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) OUTPUT INSERTED.s, INSERTED.i, INSERTED.l, INSERTED.o, INSERTED.b VALUES (?, ?, ?, ?, ?)"
@@ -684,7 +684,7 @@ class SqlActionMacroSpec extends Spec {
         "embedded property" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o) OUTPUT INSERTED.i VALUES (?, ?, ?, ?)"
@@ -693,7 +693,7 @@ class SqlActionMacroSpec extends Spec {
         "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
           import ctx._
           val q = quote {
-            qr1Emb.insert(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
+            qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
           }
           val mirror = ctx.run(q)
           mirror.string mustEqual "INSERT INTO TestEntity (s,i,l,o) OUTPUT INSERTED.i, INSERTED.s VALUES (?, ?, ?, ?)"
@@ -1135,7 +1135,7 @@ class SqlActionMacroSpec extends Spec {
     import ctx._
     case class TestEntity4(intId: Int, textCol: String)
     val q = quote {
-      query[TestEntity4].insert(lift(TestEntity4(1, "s"))).returningGenerated(_.intId)
+      query[TestEntity4].insertValue(lift(TestEntity4(1, "s"))).returningGenerated(_.intId)
     }
     val mirror = ctx.run(q)
     mirror.string mustEqual "INSERT INTO test_entity4 (text_col) VALUES (?)"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/MySQLDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/MySQLDialectSpec.scala
@@ -77,20 +77,20 @@ class MySQLDialectSpec extends OnConflictSpec {
 
   "Insert with returning generated with single column table" in {
     val q = quote {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     }
     ctx.run(q).string mustEqual
       "INSERT INTO TestEntity4 (i) VALUES (DEFAULT)"
   }
   "Insert with returning generated - multiple fields - should not compile" in {
     val q = quote {
-      qr1.insert(lift(TestEntity("s", 1, 2L, Some(3), true)))
+      qr1.insertValue(lift(TestEntity("s", 1, 2L, Some(3), true)))
     }
     "ctx.run(q.returningGenerated(r => (r.i, r.l))).string" mustNot compile
   }
   "Insert with returning should not compile" in {
     val q = quote {
-      qr4.insert(lift(TestEntity4(0)))
+      qr4.insertValue(lift(TestEntity4(0)))
     }
     "ctx.run(q.returning(_.i)).string" mustNot compile
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
@@ -9,7 +9,7 @@ trait OnConflictSpec extends Spec {
 
   lazy val e = TestEntity("s1", 1, 1, None, true)
 
-  def ins = quote(query[TestEntity].insert(lift(e)))
+  def ins = quote(query[TestEntity].insertValue(lift(e)))
   def del = quote(query[TestEntity].delete)
 
   def `no target - ignore` = quote {
@@ -27,6 +27,6 @@ trait OnConflictSpec extends Spec {
   def insBatch = quote(liftQuery(Seq(e, TestEntity("s2", 1, 2L, Some(1), true))))
 
   def `no target - ignore batch` = quote {
-    insBatch.foreach(query[TestEntity].insert(_).onConflictIgnore)
+    insBatch.foreach(query[TestEntity].insertValue(_).onConflictIgnore)
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
@@ -20,7 +20,7 @@ class OracleDialectSpec extends Spec {
         """SELECT _t."_1", _t."_2" FROM "_UnderscoreEntity" "_t""""
     }
     "table and column insert" in {
-      ctx.run(query[_UnderscoreEntity].insert(lift(_UnderscoreEntity("foo", 1, 1)))).string mustEqual
+      ctx.run(query[_UnderscoreEntity].insertValue(lift(_UnderscoreEntity("foo", 1, 1)))).string mustEqual
         """INSERT INTO "_UnderscoreEntity" ("_1","_2","_3") VALUES (?, ?, ?)"""
     }
   }
@@ -28,7 +28,7 @@ class OracleDialectSpec extends Spec {
   "Insert with returning" - {
     "with single column table" in {
       val q = quote {
-        qr4.insert(lift(TestEntity4(0))).returning(_.i)
+        qr4.insertValue(lift(TestEntity4(0))).returning(_.i)
       }
       ctx.run(q).string mustEqual
         "INSERT INTO TestEntity4 (i) VALUES (?)"
@@ -36,34 +36,34 @@ class OracleDialectSpec extends Spec {
 
     "returning generated with single column table" in {
       val q = quote {
-        qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+        qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
       }
       ctx.run(q).string mustEqual
         "INSERT INTO TestEntity4 (i) VALUES (DEFAULT)"
     }
     "returning with multi column table" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 0, 0L, Some(3), true))).returning(r => (r.i, r.l))
+        qr1.insertValue(lift(TestEntity("s", 0, 0L, Some(3), true))).returning(r => (r.i, r.l))
       }
       ctx.run(q).string mustEqual
         "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)"
     }
     "returning generated with multi column table" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l))
+        qr1.insertValue(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l))
       }
       ctx.run(q).string mustEqual
         "INSERT INTO TestEntity (s,o,b) VALUES (?, ?, ?)"
     }
     "returning - multiple fields + operations - should not compile" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, Some(3), true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, Some(3), true)))
       }
       "ctx.run(q.returning(r => (r.i, r.l + 1))).string" mustNot compile
     }
     "returning generated - multiple fields + operations - should not compile" in {
       val q = quote {
-        qr1.insert(lift(TestEntity("s", 1, 2L, Some(3), true)))
+        qr1.insertValue(lift(TestEntity("s", 1, 2L, Some(3), true)))
       }
       "ctx.run(q.returningGenerated(r => (r.i, r.l + 1))).string" mustNot compile
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
@@ -129,21 +129,21 @@ class SQLServerDialectSpec extends Spec {
     "returning" - {
       "with single column table" in {
         val q = quote {
-          qr4.insert(lift(TestEntity4(0))).returning(_.i)
+          qr4.insertValue(lift(TestEntity4(0))).returning(_.i)
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity4 (i) OUTPUT INSERTED.i VALUES (?)"
       }
       "with multi column table" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 0L, Some(3), true))).returning(r => (r.i, r.l))
+          qr1.insertValue(lift(TestEntity("s", 0, 0L, Some(3), true))).returning(r => (r.i, r.l))
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity (s,i,l,o,b) OUTPUT INSERTED.i, INSERTED.l VALUES (?, ?, ?, ?, ?)"
       }
       "with multiple fields + operations" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 1, 2L, Some(3), true))).returning(r => (r.i, r.l + 1))
+          qr1.insertValue(lift(TestEntity("s", 1, 2L, Some(3), true))).returning(r => (r.i, r.l + 1))
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity (s,i,l,o,b) OUTPUT INSERTED.i, INSERTED.l + 1 VALUES (?, ?, ?, ?, ?)"
@@ -156,21 +156,21 @@ class SQLServerDialectSpec extends Spec {
     "returningGenerated" - {
       "returning generated with single column table" in {
         val q = quote {
-          qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+          qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity4 OUTPUT INSERTED.i DEFAULT VALUES"
       }
       "with multi column table" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l))
+          qr1.insertValue(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l))
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity (s,o,b) OUTPUT INSERTED.i, INSERTED.l VALUES (?, ?, ?)"
       }
       "with multiple fields + operations" in {
         val q = quote {
-          qr1.insert(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l + 1))
+          qr1.insertValue(lift(TestEntity("s", 0, 0L, Some(3), true))).returningGenerated(r => (r.i, r.l + 1))
         }
         ctx.run(q).string mustEqual
           "INSERT INTO TestEntity (s,o,b) OUTPUT INSERTED.i, INSERTED.l + 1 VALUES (?, ?, ?)"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
@@ -101,7 +101,7 @@ class SqlIdiomNamingSpec extends Spec {
 
     "actions" - {
       "insert" in {
-        db.run(query[SomeEntity].insert(lift(SomeEntity(1)))).string mustEqual
+        db.run(query[SomeEntity].insertValue(lift(SomeEntity(1)))).string mustEqual
           "INSERT INTO some_entity (some_column) VALUES (?)"
       }
       "update" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -757,7 +757,7 @@ class SqlIdiomSpec extends Spec {
         "not affected by variable name" - {
           "simple" in {
             val q = quote { (v: TestEntity) =>
-              query[TestEntity].insert(v)
+              query[TestEntity].insertValue(v)
             }
             val v = TestEntity("s", 1, 2L, Some(1), true)
             testContext.run(q(lift(v))).string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)"
@@ -765,14 +765,14 @@ class SqlIdiomSpec extends Spec {
           "returning" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
             import ctx._
             val q = quote { (v: TestEntity) =>
-              query[TestEntity].insert(v)
+              query[TestEntity].insertValue(v)
             }
             val v = TestEntity("s", 1, 2L, Some(1), true)
             ctx.run(q(lift(v)).returning(v => v.i)).string mustEqual "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)"
           }
           "returning generated" in {
             val q = quote { (v: TestEntity) =>
-              query[TestEntity].insert(v)
+              query[TestEntity].insertValue(v)
             }
             val v = TestEntity("s", 1, 2L, Some(1), true)
             testContext.run(q(lift(v)).returningGenerated(v => v.i)).string mustEqual "INSERT INTO TestEntity (s,l,o,b) VALUES (?, ?, ?, ?)"
@@ -780,13 +780,13 @@ class SqlIdiomSpec extends Spec {
           "foreach" in {
             val v = TestEntity("s", 1, 2L, Some(1), true)
             testContext.run(
-              liftQuery(List(v)).foreach(v => query[TestEntity].insert(v))
+              liftQuery(List(v)).foreach(v => query[TestEntity].insertValue(v))
             ).groups mustEqual List(("INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)", List(Row(v.productIterator.toList: _*))))
           }
           "foreach returning" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
             import ctx._
             val v = TestEntity("s", 1, 2L, Some(1), true)
-            ctx.run(liftQuery(List(v)).foreach(v => query[TestEntity].insert(v).returning(v => v.i))).groups mustEqual
+            ctx.run(liftQuery(List(v)).foreach(v => query[TestEntity].insertValue(v).returning(v => v.i))).groups mustEqual
               List(("INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)",
                 ReturnColumns(List("i")),
                 List(Row(v.productIterator.toList: _*))
@@ -795,7 +795,7 @@ class SqlIdiomSpec extends Spec {
           "foreach returning generated" in {
             val v = TestEntity("s", 1, 2L, Some(1), true)
             testContext.run(
-              liftQuery(List(v)).foreach(v => query[TestEntity].insert(v).returningGenerated(v => v.i))
+              liftQuery(List(v)).foreach(v => query[TestEntity].insertValue(v).returningGenerated(v => v.i))
             ).groups mustEqual
               List(("INSERT INTO TestEntity (s,l,o,b) VALUES (?, ?, ?, ?)",
                 ReturnColumns(List("i")),
@@ -820,14 +820,14 @@ class SqlIdiomSpec extends Spec {
         "returning" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
           import ctx._
           val q = quote {
-            query[TestEntity].insert(lift(TestEntity("s", 1, 2L, Some(1), true))).returning(_.l)
+            query[TestEntity].insertValue(lift(TestEntity("s", 1, 2L, Some(1), true))).returning(_.l)
           }
           val run = ctx.run(q).string mustEqual
             "INSERT INTO TestEntity (s,i,l,o,b) VALUES (?, ?, ?, ?, ?)"
         }
         "returning generated" in {
           val q = quote {
-            query[TestEntity].insert(lift(TestEntity("s", 1, 2L, Some(1), true))).returningGenerated(_.l)
+            query[TestEntity].insertValue(lift(TestEntity("s", 1, 2L, Some(1), true))).returningGenerated(_.l)
           }
           val run = testContext.run(q).string mustEqual
             "INSERT INTO TestEntity (s,i,o,b) VALUES (?, ?, ?, ?)"
@@ -835,14 +835,14 @@ class SqlIdiomSpec extends Spec {
         "returning with single column table" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
           import ctx._
           val q = quote {
-            qr4.insert(lift(TestEntity4(0))).returning(_.i)
+            qr4.insertValue(lift(TestEntity4(0))).returning(_.i)
           }
           ctx.run(q).string mustEqual
             "INSERT INTO TestEntity4 (i) VALUES (?)"
         }
         "returning generated with single column table" in {
           val q = quote {
-            qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+            qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
           }
           testContext.run(q).string mustEqual
             "INSERT INTO TestEntity4 DEFAULT VALUES"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ArrayMirrorEncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ArrayMirrorEncodingSpec.scala
@@ -14,7 +14,7 @@ class ArrayMirrorEncodingSpec extends ArrayEncodingBaseSpec {
   val q = quote(query[ArraysTestEntity])
 
   "Support all sql base types and `Seq` implementers" in {
-    val insertStr = ctx.run(q.insert(lift(e))).string
+    val insertStr = ctx.run(q.insertValue(lift(e))).string
     val selectStr = ctx.run(q).string
 
     insertStr mustEqual "INSERT INTO ArraysTestEntity (texts,decimals,bools,bytes,shorts,ints,longs,floats," +
@@ -27,7 +27,7 @@ class ArrayMirrorEncodingSpec extends ArrayEncodingBaseSpec {
   "Support Seq encoding basing on MappedEncoding" in {
     val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
 
-    val insertStr = ctx.run(wrapQ.insert(lift(wrapE))).string
+    val insertStr = ctx.run(wrapQ.insertValue(lift(wrapE))).string
     val selectStr = ctx.run(wrapQ).string
     insertStr mustEqual "INSERT INTO ArraysTestEntity (texts) VALUES (?)"
     selectStr mustEqual "SELECT x.texts FROM ArraysTestEntity x"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
@@ -30,7 +30,7 @@ class ObservationMirrorSpec extends Spec {
   }
 
   "insert query" in {
-    val r = ctx.run(obs.insert(lift(obsEntry)))
+    val r = ctx.run(obs.insertValue(lift(obsEntry)))
     r.string mustEqual "INSERT INTO observation (obs_value,obs_lat,obs_lon,foo,baz) VALUES (?, ?, ?, ?, ?)"
     r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None, Some("abc"))
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -46,7 +46,7 @@ class RenamePropertiesOverrideSpec extends Spec {
     "action" - {
       "insert" in {
         val q = quote {
-          e.insert(lift(TestEntity("a", 1, 1L, None, true)))
+          e.insertValue(lift(TestEntity("a", 1, 1L, None, true)))
         }
         testContextUpper.run(q).string mustEqual
           "INSERT INTO test_entity (field_s,field_i,L,O,B) VALUES (?, ?, ?, ?, ?)"
@@ -79,14 +79,14 @@ class RenamePropertiesOverrideSpec extends Spec {
             querySchema[TestEntity]("test_entity", _.s -> "field_s", _.i -> "field_i")
           }
           val q = quote {
-            e1.insert(lift(TestEntity("s", 1, 1L, None, true))).returning(_.i)
+            e1.insertValue(lift(TestEntity("s", 1, 1L, None, true))).returning(_.i)
           }
           val mirror = ctx.run(q)
           mirror.returningBehavior mustEqual ReturnRecord
         }
         "returning generated - alias" in {
           val q = quote {
-            e.insert(lift(TestEntity("s", 1, 1L, None, true))).returningGenerated(_.i)
+            e.insertValue(lift(TestEntity("s", 1, 1L, None, true))).returningGenerated(_.i)
           }
           val mirror = testContextUpper.run(q)
           mirror.returningBehavior mustEqual ReturnColumns(List("field_i"))

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -53,7 +53,7 @@ class RenamePropertiesSpec extends Spec {
     "action" - {
       "insert" in {
         val q = quote {
-          e.insert(lift(TestEntity("a", 1, 1L, None, true)))
+          e.insertValue(lift(TestEntity("a", 1, 1L, None, true)))
         }
         testContext.run(q).string mustEqual
           "INSERT INTO test_entity (field_s,field_i,l,o,b) VALUES (?, ?, ?, ?, ?)"
@@ -86,14 +86,14 @@ class RenamePropertiesSpec extends Spec {
             querySchema[TestEntity]("test_entity", _.s -> "field_s", _.i -> "field_i")
           }
           val q = quote {
-            e1.insert(lift(TestEntity("s", 1, 1L, None, true))).returning(_.i)
+            e1.insertValue(lift(TestEntity("s", 1, 1L, None, true))).returning(_.i)
           }
           val mirror = ctx.run(q)
           mirror.returningBehavior mustEqual ReturnRecord
         }
         "returning generated - alias" in {
           val q = quote {
-            e.insert(lift(TestEntity("s", 1, 1L, None, true))).returningGenerated(_.i)
+            e.insertValue(lift(TestEntity("s", 1, 1L, None, true))).returningGenerated(_.i)
           }
           val mirror = testContext.run(q)
           mirror.returningBehavior mustEqual ReturnColumns(List("field_i"))


### PR DESCRIPTION
Changing EntityQuery.insert to EntityQuery.insertValue due to lampepfl/dotty#14043. Technically the issue only affects protoquill but I want the APIs to be aligned as much as possible.