### PR TITLE
Switch to disable query sub-expansion

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -90,7 +90,11 @@ trait SqlIdiom extends Idiom {
         // for more details.
         // Right now we are not removing extra select clauses here (via RemoveUnusedSelects) since I am not sure what
         // kind of impact that could have on selects. Can try to do that in the future.
-        RemoveExtraAlias(strategy)(ExpandNestedQueries(SqlQuery(a))).token
+        if (Messages.querySubexpand)
+          RemoveExtraAlias(strategy)(ExpandNestedQueries(SqlQuery(a))).token
+        else
+          SqlQuery(a).token
+
       case a: Operation       => a.token
       case a: Infix           => a.token
       case a: Action          => a.token

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -27,6 +27,7 @@ object Messages {
   def traceAstSimple = cache("quill.trace.ast.simple", variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean)
   def traceQuats = cache("quill.trace.quat", QuatTrace(variable("quill.trace.quat", "quill_trace_quat", QuatTrace.None.value)))
   def cacheDynamicQueries = cache("quill.query.cacheDaynamic", variable("quill.query.cacheDaynamic", "query_query_cacheDaynamic", "true").toBoolean)
+  def querySubexpand = cache("quill.query.subexpand", variable("quill.query.subexpand", "query_query_subexpand", "true").toBoolean)
   def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "false")))
 
   sealed trait LogToFile


### PR DESCRIPTION
Mitigates: #2340

Query sub-expansion in `astTokenizer` adds column `AS col` suffixes via the additional steps `RemoveExtraAlias(strategy)(ExpandNestedQueries(SqlQuery(a)))` but these are not subject to the naming strategy as pointed out by #2340. 

Unfortunately this cannot be easily remedied by surrounding the query `a` with a CaseClass that has fields from it's quat because it is already surrounded by a tuple due to the Elaboration in materializeQueryMeta that happens before query expansion even starts. The in the `astTokenizer`, the variable `a` has the following value:
```scala
querySchema("TestEntity").filter(t => t.s == "a").map(t => (t.s, t.i, t.l, t.o, t.b))
```
Note that the end of it is wrapped into a tuple which we would probably need to peel off before accessing the Product-Quat in the actual query `querySchema("TestEntity").filter(t => t.s == "a")`. We could forcibly do this anyway just for this use-case but that feels hacky.

Now in #2381 we are exploring the idea of removing tuple-elaboration completely. Tuple elaboration was originally introduced before Quats existed due to the limitations of ExpandNestedQuery because selection from arbitrary Identifiers `select x` could not be elaborated into a set of columns `select x.name, x.age` since before Quats existed we had no idea that `x` was a product type with the fields `name` and `age`. Now that Quats exist this is no longer necessary.

(Also note that in ProtoQuill there is also a elaboration mechanism but it elaborates into case-classes and not tuples. If this experiment succeeds and we can remove Tuple elaboration in favor of quats then we should probably do the same thing in protoquill).

