### PR TITLE
Use relative paths and remove timestamp in queries.sql

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ After installing Docker and Docker Compose you have to setup databases:
 docker-compose run --rm setup
 ```
 
-After that you are ready to build and test the project. The following setp describes how to test the project with
+After that you are ready to build and test the project. The following setup describes how to test the project with
 sbt built within docker image. If you would like to use your local sbt,
 please visit [Building locally](#building-locally-using-docker-only-for-databases). This is highly recommended
 when running Docker on non-linux OS due to high IO overhead from running 
@@ -164,7 +164,7 @@ Finally, you can use `sbt` locally.
 
 ### All In One ###
 
-To restart the database services, rebuild them, and start with locally explosed ports run:
+To restart the database services, rebuild them, and start with locally exposed ports run:
 
 docker-compose down && docker-compose build && docker-compose run --rm --service-ports setup
 

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -32,11 +32,13 @@ object Messages {
   sealed trait LogToFile
   object LogToFile {
     case class Enabled(file: String) extends LogToFile
+    case object ProjectDir extends LogToFile
     case object Disabled extends LogToFile
     def apply(switch: String): LogToFile =
       switch.trim match {
-        case "false" => Disabled
-        case other   => Enabled(other)
+        case "false"       => Disabled
+        case "PROJECT_DIR" => ProjectDir
+        case other         => Enabled(other)
       }
   }
 


### PR DESCRIPTION
In this small PR I want to fix a few of the issues we've had with the queries.sql file. Specifically, I've removed the timestamp from the log, relativized all paths to the project root and added a new config option for the log file location to use the project root directory, which should fix #2323. The absolute paths and timestamps have been a problem for us because because we intended to track the queries.sql file in Git so that we can see changes in the generated queries inside a PR but some of our developers complained that the file was constantly changing to due usernames and timestamps in the file. That said, I'm not sure if that use case is even relevant anymore seeing that you moved the queries.sql file to `/target` by default and subsequent compilations seem to append duplicate log lines to the file instead of overwriting them as before (which makes tracking it in Git pointless).

@getquill/maintainers
