### PR TITLE
Option to Disable Nested Subexpansion

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -153,20 +153,20 @@ object SeedRenames extends StatelessTransformer {
 // Represents a nested property path to an identity i.e. Property(Property(... Ident(), ...))
 object PropertyMatroshka {
 
-  def traverse(initial: Property): Option[(Ast, List[String])] =
+  def traverse(initial: Property): Option[(Ast, List[String], List[Renameable])] =
     initial match {
       // If it's a nested-property walk inside and append the name to the result (if something is returned)
-      case Property(inner: Property, name) =>
-        traverse(inner).map { case (id, list) => (id, list :+ name) }
+      case Property.Opinionated(inner: Property, name, ren, _) =>
+        traverse(inner).map { case (id, list, renameable) => (id, list :+ name, renameable :+ ren) }
       // If it's a property with ident in the core, return that
-      case Property(inner, name) if !inner.isInstanceOf[Property] =>
-        Some((inner, List(name)))
+      case Property.Opinionated(inner, name, ren, _) if !inner.isInstanceOf[Property] =>
+        Some((inner, List(name), List(ren)))
       // Otherwise an ident property is not inside so don't return anything
       case _ =>
         None
     }
 
-  def unapply(ast: Property): Option[(Ast, List[String])] =
+  def unapply(ast: Property): Option[(Ast, List[String], List[Renameable])] =
     ast match {
       case p: Property => traverse(p)
       case _           => None

--- a/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -138,7 +138,7 @@ object RepropagateQuats extends StatelessTransformer {
             case OnConflict.Properties(props) =>
               val propsR = props.map {
                 // Recreate the assignment with new idents but only if we need to repropagate
-                case prop @ PropertyMatroshka(ident: Ident, _) =>
+                case prop @ PropertyMatroshka(ident: Ident, _, _) =>
                   trace"Repropagate OnConflict.Properties Quat ${oca.quat.suppress(msg)} from $oca into:" andReturn
                     BetaReduction(prop, RWR, ident -> ident.retypeQuatFrom(oca.quat)).asInstanceOf[Property]
                 case other =>

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveUnusedSelects.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveUnusedSelects.scala
@@ -65,7 +65,7 @@ object RemoveUnusedSelects {
 
   private def filterUnused(select: List[SelectValue], references: Set[Property]): List[SelectValue] = {
     val usedAliases = references.map {
-      case PropertyMatroshka(_, list) => list.mkString
+      case PropertyMatroshka(_, list, _) => list.mkString
     }.toSet
     select.filter(sv =>
       sv.alias.forall(aliasValue => usedAliases.contains(aliasValue)) ||

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -27,6 +27,7 @@ object Messages {
   def traceAstSimple = cache("quill.trace.ast.simple", variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean)
   def traceQuats = cache("quill.trace.quat", QuatTrace(variable("quill.trace.quat", "quill_trace_quat", QuatTrace.None.value)))
   def cacheDynamicQueries = cache("quill.query.cacheDaynamic", variable("quill.query.cacheDaynamic", "query_query_cacheDaynamic", "true").toBoolean)
+  def querySubexpand = cache("quill.query.subexpand", variable("quill.query.subexpand", "query_query_subexpand", "true").toBoolean)
   def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "false")))
 
   sealed trait LogToFile

--- a/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
@@ -28,6 +28,14 @@ class SqlDslSpec extends Spec {
     testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s = 'a' FOR UPDATE"
   }
 
+  "forUpdate naming schema" in {
+
+    val q: Quoted[Query[TestEntity]] = quote {
+      query[TestEntity].filter(t => t.s == "a").forUpdate
+    }
+    testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s = 'a' FOR UPDATE"
+  }
+
   case class Person(name: String, age: Int)
 
   "insert with subselects" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.sql.norm
 
-import io.getquill.{ MirrorSqlDialect, Query, SnakeCase, Spec, SqlMirrorContext }
+import io.getquill.{ MirrorSqlDialect, Query, Quoted, SnakeCase, Spec, SqlMirrorContext }
 import io.getquill.context.sql.{ testContext, testContextUpperEscapeColumn }
 import io.getquill.context.sql.util.StringOps._
 
@@ -638,8 +638,21 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "should be handled correctly in a regular schema" in {
       case class Person(firstName: String, lastName: String)
-      testContext.run(infix"fromSomewhere()".as[Query[Person]]).string mustEqual
+      val q = quote {
+        infix"fromSomewhere()".as[Query[Person]]
+      }
+      testContext.run(q).string mustEqual
         "SELECT x.first_name, x.last_name FROM (fromSomewhere()) AS x"
+    }
+
+    "should be handled correctly in a regular schema - nested" in {
+      case class Name(firstName: String, lastName: String) extends Embedded
+      case class Person(name: Name, theAge: Int)
+      val q = quote {
+        infix"fromSomewhere()".as[Query[Person]]
+      }
+      testContext.run(q).string mustEqual
+        "SELECT x.first_name, x.last_name, x.the_age FROM (fromSomewhere()) AS x"
     }
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -3,8 +3,7 @@ package io.getquill.context.sql.norm
 import io.getquill.ReturnAction.{ ReturnColumns, ReturnRecord }
 import io.getquill.context.sql.testContextUpper
 import io.getquill.context.sql.testContextUpper._
-import io.getquill.{ MirrorSqlDialectWithReturnClause, Spec }
-import io.getquill.Query
+import io.getquill.{ EntityQuery, MirrorSqlDialectWithReturnClause, Query, Quoted, Spec }
 
 class RenamePropertiesOverrideSpec extends Spec {
 
@@ -321,9 +320,9 @@ class RenamePropertiesOverrideSpec extends Spec {
       }
     }
 
-    "operation" - {
+    "operation" - { //
       "unary" in {
-        val q = quote {
+        val q: Quoted[EntityQuery[Index]] = quote {
           e.filter(a => e.filter(b => b.i > 0).isEmpty).map(_.i)
         }
         testContextUpper.run(q).string mustEqual


### PR DESCRIPTION
Option to disable nested expansion of SqlQuery in SqlIdiom
(this supersedes #2380).

Also there are a couple of changes that need to happen `FlattenNestedProperty` in `ExpandNestedQueries` where properties that are already set to `Fixed` are not reset as `Renameable`. What this means for properties inside properties where some are potentially non-renameable is undecided but in general, properties from sub-selects should not be affected by NameStrategy.