### PR TITLE
Continue solving sheathing issues in infix subqueries

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -153,20 +153,20 @@ object SeedRenames extends StatelessTransformer {
 // Represents a nested property path to an identity i.e. Property(Property(... Ident(), ...))
 object PropertyMatroshka {
 
-  def traverse(initial: Property): Option[(Ast, List[String])] =
+  def traverse(initial: Property): Option[(Ast, List[String], List[Renameable])] =
     initial match {
       // If it's a nested-property walk inside and append the name to the result (if something is returned)
-      case Property(inner: Property, name) =>
-        traverse(inner).map { case (id, list) => (id, list :+ name) }
+      case Property.Opinionated(inner: Property, name, ren, _) =>
+        traverse(inner).map { case (id, list, renameable) => (id, list :+ name, renameable :+ ren) }
       // If it's a property with ident in the core, return that
-      case Property(inner, name) if !inner.isInstanceOf[Property] =>
-        Some((inner, List(name)))
+      case Property.Opinionated(inner, name, ren, _) if !inner.isInstanceOf[Property] =>
+        Some((inner, List(name), List(ren)))
       // Otherwise an ident property is not inside so don't return anything
       case _ =>
         None
     }
 
-  def unapply(ast: Property): Option[(Ast, List[String])] =
+  def unapply(ast: Property): Option[(Ast, List[String], List[Renameable])] =
     ast match {
       case p: Property => traverse(p)
       case _           => None

--- a/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -138,7 +138,7 @@ object RepropagateQuats extends StatelessTransformer {
             case OnConflict.Properties(props) =>
               val propsR = props.map {
                 // Recreate the assignment with new idents but only if we need to repropagate
-                case prop @ PropertyMatroshka(ident: Ident, _) =>
+                case prop @ PropertyMatroshka(ident: Ident, _, _) =>
                   trace"Repropagate OnConflict.Properties Quat ${oca.quat.suppress(msg)} from $oca into:" andReturn
                     BetaReduction(prop, RWR, ident -> ident.retypeQuatFrom(oca.quat)).asInstanceOf[Property]
                 case other =>

--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -105,7 +105,6 @@ trait SqlIdiom extends Idiom {
     RemoveExtraAlias(strategy)(ExpandNestedQueries(SqlQuery(transformed)))
   }
 
-
   def astTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ast] =
     Tokenizer[Ast] {
       case a: Query =>

--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -114,7 +114,10 @@ trait SqlIdiom extends Idiom {
         // for more details.
         // Right now we are not removing extra select clauses here (via RemoveUnusedSelects) since I am not sure what
         // kind of impact that could have on selects. Can try to do that in the future.
-        subexpandNestedQuery(a, strategy).token
+        if (Messages.querySubexpand)
+          subexpandNestedQuery(a, strategy).token
+        else
+          SqlQuery(a).token
 
       case a: Operation       => a.token
       case a: Infix           => a.token

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveUnusedSelects.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveUnusedSelects.scala
@@ -65,7 +65,7 @@ object RemoveUnusedSelects {
 
   private def filterUnused(select: List[SelectValue], references: Set[Property]): List[SelectValue] = {
     val usedAliases = references.map {
-      case PropertyMatroshka(_, list) => list.mkString
+      case PropertyMatroshka(_, list, _) => list.mkString
     }.toSet
     select.filter(sv =>
       sv.alias.forall(aliasValue => usedAliases.contains(aliasValue)) ||

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
@@ -50,9 +50,9 @@ case class InContext(from: List[FromContext]) {
   def contextReferenceType(ast: Ast) = {
     val references = collectTableAliases(from)
     ast match {
-      case Ident(v, _)                       => references.get(v)
-      case PropertyMatroshka(Ident(v, _), _) => references.get(v)
-      case _                                 => None
+      case Ident(v, _)                          => references.get(v)
+      case PropertyMatroshka(Ident(v, _), _, _) => references.get(v)
+      case _                                    => None
     }
   }
 
@@ -104,7 +104,7 @@ case class SelectPropertyProtractor(from: List[FromContext]) {
         }
       // Assuming a property contains only an Ident, Infix or Constant at this point
       // and all situations where there is a case-class, tuple, etc... inside have already been beta-reduced
-      case prop @ PropertyMatroshka(id @ Core(), _) =>
+      case prop @ PropertyMatroshka(id @ Core(), _, _) =>
         val isEntity = inContext.isEntityReference(id)
         prop.quat match {
           case p: Quat.Product =>

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -27,6 +27,7 @@ object Messages {
   def traceAstSimple = cache("quill.trace.ast.simple", variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean)
   def traceQuats = cache("quill.trace.quat", QuatTrace(variable("quill.trace.quat", "quill_trace_quat", QuatTrace.None.value)))
   def cacheDynamicQueries = cache("quill.query.cacheDaynamic", variable("quill.query.cacheDaynamic", "query_query_cacheDaynamic", "true").toBoolean)
+  def querySubexpand = cache("quill.query.subexpand", variable("quill.query.subexpand", "query_query_subexpand", "true").toBoolean)
   def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "false")))
 
   sealed trait LogToFile

--- a/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/dsl/SqlDslSpec.scala
@@ -28,6 +28,14 @@ class SqlDslSpec extends Spec {
     testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s = 'a' FOR UPDATE"
   }
 
+  "forUpdate naming schema" in {
+
+    val q: Quoted[Query[TestEntity]] = quote {
+      query[TestEntity].filter(t => t.s == "a").forUpdate
+    }
+    testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t WHERE t.s = 'a' FOR UPDATE"
+  }
+
   case class Person(name: String, age: Int)
 
   "insert with subselects" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -3,8 +3,7 @@ package io.getquill.context.sql.norm
 import io.getquill.ReturnAction.{ ReturnColumns, ReturnRecord }
 import io.getquill.context.sql.testContextUpper
 import io.getquill.context.sql.testContextUpper._
-import io.getquill.{ MirrorSqlDialectWithReturnClause, Spec }
-import io.getquill.Query
+import io.getquill.{ EntityQuery, MirrorSqlDialectWithReturnClause, Query, Quoted, Spec }
 
 class RenamePropertiesOverrideSpec extends Spec {
 
@@ -323,7 +322,7 @@ class RenamePropertiesOverrideSpec extends Spec {
 
     "operation" - {
       "unary" in {
-        val q = quote {
+        val q: Quoted[EntityQuery[Index]] = quote {
           e.filter(a => e.filter(b => b.i > 0).isEmpty).map(_.i)
         }
         testContextUpper.run(q).string mustEqual

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -320,7 +320,7 @@ class RenamePropertiesOverrideSpec extends Spec {
       }
     }
 
-    "operation" - {
+    "operation" - { //
       "unary" in {
         val q: Quoted[EntityQuery[Index]] = quote {
           e.filter(a => e.filter(b => b.i > 0).isEmpty).map(_.i)


### PR DESCRIPTION
After initially looking problems with the #2335 fix (for #2328) that were presented in #2340 the problem seems deeper then it originally seemed. The 1st problem was that materializeQueryMeta added an additional map clause to the query making any solution in `SqlIdiom` via `case a: Query =>` more difficult. For example, in `forUpdate` in SqlDslSpec instead of this:
```scala
query[TestEntity].filter(t => t.s == "a")
```
The `a` parameter will be this:
```scala
query[TestEntity].filter(t => t.s == "a").map(x => (x.s, x.i, x.l, x.o))
```
This is problematic because if we want to use a NamingSchema e.g. `io.getquill.naming.UpperCase` we can introduce a Ast CaseClass:
```scala
CaseClass("S"->x.s, "I"->x.i, "L"->x.l, "O"->x.o)
```
Doing this after `.map(x => (x.s, x.i, x.l, x.o))` makes no sense, this map clause is introduced by materializeQueryMeta.

Now materializeQueryMeta originally was introduced to expand aliases in queries for example in:
```scala
run( query[Person].map(p => p) )
// SELECT p.* FROM Person p
```
We need to expand that query to `SELECT p.name, p.age FROM Person p` in ExpandNestedQueries however if we just have `Ident(p)` in the SelectValue with no further information we do not know enough information to perform the expansion. This why materializeQueryMeta was introduced i.e. to add `query[Person].map(p => p).map(p => (p.name, p.age))` to the query so that the correct SelectValue clauses could be introduced.
However, now since we have Quat information on identifiers, we know what fields are on `Ident(p)` (i.e. `Ident(p, CC(name:V,age:V))`) so we can just expand the fields normally. This has already been implemented in previous iterations in ExpandNestedQueries making the materializeQueryMeta component no longer necessary however it was kept in case the quat-based mechanism does not work. Now since there is a good use-case to remove it, this has been done in #2381.

Now what remains is to implement Implement the CaseClass wrapping as has been mentioned before. This has been attempted but so far is not working.

Additionally, even if this is implemented, the wrapping will not account for schemaMetas. This will likely be done in later steps.

