### PR TITLE
Single path-element alias in top-level selects

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
@@ -167,7 +167,7 @@ object SqlQuery {
       case Map(GroupBy(q, x @ Ident(alias, _), g), a, p) =>
         val b = base(q, alias)
         //use ExpandSelection logic to break down OrderBy clause
-        val flatGroupByAsts = new ExpandSelection(b.from).apply(List(SelectValue(g))).map(_.ast)
+        val flatGroupByAsts = new ExpandSelection(b.from, false).apply(List(SelectValue(g))).map(_.ast)
         val groupByClause =
           if (flatGroupByAsts.length > 1) Tuple(flatGroupByAsts)
           else flatGroupByAsts.head
@@ -281,7 +281,7 @@ object SqlQuery {
       case (Tuple(properties), ord: PropertyOrdering) => properties.flatMap(orderByCriterias(_, ord, from))
       case (Tuple(properties), TupleOrdering(ord))    => properties.zip(ord).flatMap { case (a, o) => orderByCriterias(a, o, from) }
       //if its a quat product, use ExpandSelection to break it down into its component fields and apply the ordering to all of them
-      case (id @ Ident(_, _: Quat.Product), ord)      => new ExpandSelection(from).apply(List(SelectValue(ast))).map(_.ast).flatMap(orderByCriterias(_, ord, from))
+      case (id @ Ident(_, _: Quat.Product), ord)      => new ExpandSelection(from, false).apply(List(SelectValue(ast))).map(_.ast).flatMap(orderByCriterias(_, ord, from))
       case (a, o: PropertyOrdering)                   => List(OrderByCriteria(a, o))
       case other                                      => fail(s"Invalid order by criteria $ast")
     }

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveExtraAlias.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/RemoveExtraAlias.scala
@@ -3,20 +3,6 @@ package io.getquill.sql.norm
 import io.getquill.NamingStrategy
 import io.getquill.ast.{ Property, Renameable }
 import io.getquill.context.sql.{ FlattenSqlQuery, SelectValue }
-import io.getquill.sql.norm.RemoveExtraAlias.TopLevelRemove
-
-object RemoveExtraAlias {
-  sealed trait TopLevelRemove
-  case object TopLevelRemove {
-    /**
-     * Remove all top-level aliases. This is for top-level queries where aliases are not needed at all
-     * since Quill extractors use the position value instead
-     */
-    case object All extends TopLevelRemove
-    /** Remove only aliases on the top level that match the column name (same as rest of the query) */
-    case object OnlyMatching extends TopLevelRemove
-  }
-}
 
 /**
  * Remove aliases at the top level of the AST since they are not needed
@@ -24,7 +10,7 @@ object RemoveExtraAlias {
  * as well as entities whose aliases are the same as their selection e.g. "select x.foo as foo"
  * since this just adds syntactic noise.
  */
-case class RemoveExtraAlias(strategy: NamingStrategy, topLevel: TopLevelRemove = TopLevelRemove.All) extends StatelessQueryTransformer {
+case class RemoveExtraAlias(strategy: NamingStrategy) extends StatelessQueryTransformer {
   // Remove aliases that are the same as as the select values. Since a strategy may change the name,
   // use a heuristic where if the column naming strategy make the property name be different from the
   // alias, keep the column property name.
@@ -51,16 +37,7 @@ case class RemoveExtraAlias(strategy: NamingStrategy, topLevel: TopLevelRemove =
 
   override protected def expandNested(q: FlattenSqlQuery, isTopLevel: Boolean): FlattenSqlQuery = {
     val from = q.from.map(expandContext(_))
-    val select =
-      q.select
-        .map(removeUnneededAlias(_))
-        .map { sv =>
-          // If we are on the top-level query and instructed to remove all the aliases inside then do that
-          if (isTopLevel && topLevel == TopLevelRemove.All)
-            sv.copy(alias = None)
-          else
-            sv
-        }
+    val select = q.select.map(removeUnneededAlias(_))
     q.copy(select = select, from = from)(q.quat)
   }
 }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
@@ -255,7 +255,7 @@ class OrientDBIdiomSpec extends Spec {
         qr1.map(t => (t.i, t.s))
       }
       ctx.run(q).string mustEqual
-        "SELECT i, s FROM TestEntity"
+        "SELECT i _1, s _2 FROM TestEntity"
     }
     "caseclass" in {
       case class IntString(intProp: Int, stringProp: String)
@@ -263,7 +263,7 @@ class OrientDBIdiomSpec extends Spec {
         qr1.map(t => new IntString(t.i, t.s))
       }
       ctx.run(q).string mustEqual
-        "SELECT i, s FROM TestEntity"
+        "SELECT i intProp, s stringProp FROM TestEntity"
     }
     "null" in {
       val q = quote {

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBQuerySpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBQuerySpec.scala
@@ -26,7 +26,7 @@ class OrientDBQuerySpec extends Spec {
         qr1.map(t => (t.i, t.s))
       }
       mirrorContext.run(q).string mustEqual
-        "SELECT i, s FROM TestEntity"
+        "SELECT i _1, s _2 FROM TestEntity"
     }
     "other" in {
       val q = quote {

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -4,7 +4,7 @@ import io.getquill.NamingStrategy
 import io.getquill.ast.{ Ast, BinaryOperation, CaseClass, Constant, ExternalIdent, Ident, Operation, Property, Query, StringOperator, Tuple, Value }
 import io.getquill.context.spark.norm.EscapeQuestionMarks
 import io.getquill.context.sql.{ FlattenSqlQuery, SelectValue, SetOperationSqlQuery, SqlQuery, UnaryOperationSqlQuery }
-import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.context.sql.idiom.{ SqlIdiom }
 import io.getquill.context.sql.norm.SqlNormalize
 import io.getquill.idiom.StatementInterpolator._
 import io.getquill.idiom.Token

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
@@ -14,7 +14,7 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT 1, e.a, e.b FROM Emb e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT 1 AS id, e.a, e.b FROM Emb e"
     }
 
     "function property inside of nested distinct queries - tuple" in {
@@ -23,7 +23,7 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => (2, p)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT 2, e.id, e.emb1a, e.emb1b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT 2 AS _1, e.id, e.emb1a AS a, e.emb1b AS b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
     }
 
     "function property inside of nested distinct queries through tuples" in {
@@ -32,7 +32,7 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => (1, e)).distinct.map(t => Parent(t._1, t._2)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT e._1, e._2a, e._2b FROM (SELECT DISTINCT 1 AS _1, e.a AS _2a, e.b AS _2b FROM Emb e) AS e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT e._1 AS id, e._2a AS a, e._2b AS b FROM (SELECT DISTINCT 1 AS _1, e.a AS _2a, e.b AS _2b FROM Emb e) AS e"
     }
 
     "function property inside of nested distinct queries - twice" in {
@@ -42,7 +42,7 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT 2, e.idP, e.emb1a, e.emb1b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT 2 AS idG, e.idP, e.emb1a AS a, e.emb1b AS b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
     }
 
     "function property inside of nested distinct queries - twice - into tuple" in {
@@ -52,7 +52,7 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct.map(g => (3, g)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT 3, p.idG, p.paridP, p.paremb1a, p.paremb1b FROM (SELECT DISTINCT 2 AS idG, p.idP AS paridP, p.emb1a AS paremb1a, p.emb1b AS paremb1b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS p) AS p"
+      ctx.run(q).string mustEqual "SELECT DISTINCT 3 AS _1, p.idG, p.paridP AS idP, p.paremb1a AS a, p.paremb1b AS b FROM (SELECT DISTINCT 2 AS idG, p.idP AS paridP, p.emb1a AS paremb1a, p.emb1b AS paremb1b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS p) AS p"
     }
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
@@ -22,7 +22,7 @@ class GroupBySpec extends Spec {
           .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
       )
       testContext.run(q.dynamic).string mustEqual
-        "SELECT x11.name, COUNT(x01.*) FROM City x01 INNER JOIN Country x11 ON x01.countryId = x11.id GROUP BY x11.id, x11.name"
+        "SELECT x11.name AS _1, COUNT(x01.*) AS _2 FROM City x01 INNER JOIN Country x11 ON x01.countryId = x11.id GROUP BY x11.id, x11.name"
     }
     "with QuerySchema" in {
       implicit val citySchema = schemaMeta[City]("theCity", _.name -> "theCityName")
@@ -36,7 +36,7 @@ class GroupBySpec extends Spec {
           .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
       )
       testContext.run(q.dynamic).string mustEqual
-        "SELECT x12.theCountryName, COUNT(x05.*) FROM theCity x05 INNER JOIN theCountry x12 ON x05.countryId = x12.id GROUP BY x12.id, x12.theCountryName"
+        "SELECT x12.theCountryName AS _1, COUNT(x05.*) AS _2 FROM theCity x05 INNER JOIN theCountry x12 ON x05.countryId = x12.id GROUP BY x12.id, x12.theCountryName"
     }
     "nested" in {
       val q = quote(
@@ -48,7 +48,7 @@ class GroupBySpec extends Spec {
           .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
       )
       testContext.run(q.dynamic).string mustEqual
-        "SELECT x010._2id, x010._2name, COUNT(x010.*) FROM (SELECT x13.id AS _2id, x13.name AS _2name FROM City x09 INNER JOIN Country x13 ON x09.countryId = x13.id) AS x010 GROUP BY x010._2id, x010._2name"
+        "SELECT x010._2id AS id, x010._2name AS name, COUNT(x010.*) AS _2 FROM (SELECT x13.id AS _2id, x13.name AS _2name FROM City x09 INNER JOIN Country x13 ON x09.countryId = x13.id) AS x010 GROUP BY x010._2id, x010._2name"
     }
     "with QuerySchema nested" in {
       implicit val citySchema = schemaMeta[City]("theCity", _.name -> "theCityName")
@@ -62,7 +62,7 @@ class GroupBySpec extends Spec {
           .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
       )
       testContext.run(q.dynamic).string mustEqual
-        "SELECT x013._2id, x013._2theCountryName, COUNT(x013.*) FROM (SELECT x14.id AS _2id, x14.theCountryName AS _2theCountryName FROM theCity x012 INNER JOIN theCountry x14 ON x012.countryId = x14.id) AS x013 GROUP BY x013._2id, x013._2theCountryName"
+        "SELECT x013._2id AS id, x013._2theCountryName AS theCountryName, COUNT(x013.*) AS _2 FROM (SELECT x14.id AS _2id, x14.theCountryName AS _2theCountryName FROM theCity x012 INNER JOIN theCountry x14 ON x012.countryId = x14.id) AS x013 GROUP BY x013._2id, x013._2theCountryName"
     }
 
   }
@@ -84,10 +84,10 @@ class GroupBySpec extends Spec {
       testContext.run(q).string.collapseSpace mustEqual
         """
           |SELECT
-          |  x15.countryCode,
+          |  x15.countryCode AS _1,
           |  x15.name,
           |  x15.dialect,
-          |  COUNT(x015.*)
+          |  COUNT(x015.*) AS _2
           |FROM
           |  City x015
           |  INNER JOIN Country x15 ON x015.countryCode = x15.countryCode
@@ -109,10 +109,10 @@ class GroupBySpec extends Spec {
       testContext.run(q).string(true).collapseSpace mustEqual
         """
           |SELECT
-          |  x020._2countryCode,
-          |  x020._2languagename,
-          |  x020._2languagedialect,
-          |  COUNT(x020.*)
+          |  x020._2countryCode AS countryCode,
+          |  x020._2languagename AS name,
+          |  x020._2languagedialect AS dialect,
+          |  COUNT(x020.*) AS _2
           |FROM
           |  (
           |    SELECT
@@ -143,10 +143,10 @@ class GroupBySpec extends Spec {
       )
       testContext.run(q).string(true).collapseSpace mustEqual
         """|SELECT
-            |  x17.theCountryCode,
+            |  x17.theCountryCode AS _1,
             |  x17.TheLanguageName,
             |  x17.dialect,
-            |  COUNT(x022.*)
+            |  COUNT(x022.*) AS _2
             |FROM
             |  City x022
             |  INNER JOIN theCountry x17 ON x022.countryCode = x17.theCountryCode
@@ -171,10 +171,10 @@ class GroupBySpec extends Spec {
       testContext.run(q).string(true).collapseSpace mustEqual
         """
           |SELECT
-          |  x027._2theCountryCode,
-          |  x027._2languageTheLanguageName,
-          |  x027._2languagedialect,
-          |  COUNT(x027.*)
+          |  x027._2theCountryCode AS theCountryCode,
+          |  x027._2languageTheLanguageName AS TheLanguageName,
+          |  x027._2languagedialect AS dialect,
+          |  COUNT(x027.*) AS _2
           |FROM
           |  (
           |    SELECT
@@ -205,7 +205,7 @@ class GroupBySpec extends Spec {
         .map { case (language, cityLanguages) => (language, cityLanguages.size) }
     )
     testContext.run(q.dynamic).string mustEqual
-      "SELECT x19.countryCode, x19.language, COUNT(*) FROM City x029 INNER JOIN CountryLanguage x19 ON x029.countryCode = x19.countryCode GROUP BY x19.countryCode, x19.language"
+      "SELECT x19.countryCode, x19.language, COUNT(*) AS _2 FROM City x029 INNER JOIN CountryLanguage x19 ON x029.countryCode = x19.countryCode GROUP BY x19.countryCode, x19.language"
   }
 
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
@@ -33,7 +33,7 @@ class NestedDistinctSpec extends Spec {
             .nested
         }
 
-        ctx.run(q).string mustEqual "SELECT x.myEmbname FROM (SELECT DISTINCT f.name AS myEmbname FROM MyParent f WHERE f.name = 'test') AS x"
+        ctx.run(q).string mustEqual "SELECT x.myEmbname AS name FROM (SELECT DISTINCT f.name AS myEmbname FROM MyParent f WHERE f.name = 'test') AS x"
       }
 
       "first operation nesting with filter before and after" in {
@@ -44,7 +44,7 @@ class NestedDistinctSpec extends Spec {
             .filter(_.myEmb.name == "test")
         }
 
-        ctx.run(q).string mustEqual "SELECT x3.myEmbname FROM (SELECT DISTINCT x2.name AS myEmbname FROM MyParent x2 WHERE x2.name = 'firstTest') AS x3 WHERE x3.myEmbname = 'test'"
+        ctx.run(q).string mustEqual "SELECT x3.myEmbname AS name FROM (SELECT DISTINCT x2.name AS myEmbname FROM MyParent x2 WHERE x2.name = 'firstTest') AS x3 WHERE x3.myEmbname = 'test'"
       }
 
       "first operation nesting with filter before and after - groupBy" in { //hello
@@ -72,7 +72,7 @@ class NestedDistinctSpec extends Spec {
             .sortBy(p => p.myEmb.name)
         }
 
-        ctx.run(q).string mustEqual "SELECT x8.myEmbname FROM (SELECT DISTINCT x7.name AS myEmbname FROM MyParent x7 WHERE x7.name = 'firstTest') AS x8 WHERE x8.myEmbname = 'test' ORDER BY x8.myEmbname ASC NULLS FIRST"
+        ctx.run(q).string mustEqual "SELECT x8.myEmbname AS name FROM (SELECT DISTINCT x7.name AS myEmbname FROM MyParent x7 WHERE x7.name = 'firstTest') AS x8 WHERE x8.myEmbname = 'test' ORDER BY x8.myEmbname ASC NULLS FIRST"
       }
 
       "first operation nesting with filter before and after - limit" in {
@@ -84,7 +84,7 @@ class NestedDistinctSpec extends Spec {
             .take(7)
         }
 
-        ctx.run(q).string mustEqual "SELECT x10.myEmbname FROM (SELECT DISTINCT x9.name AS myEmbname FROM MyParent x9 WHERE x9.name = 'firstTest') AS x10 WHERE x10.myEmbname = 'test' LIMIT 7"
+        ctx.run(q).string mustEqual "SELECT x10.myEmbname AS name FROM (SELECT DISTINCT x9.name AS myEmbname FROM MyParent x9 WHERE x9.name = 'firstTest') AS x10 WHERE x10.myEmbname = 'test' LIMIT 7"
       }
 
       "first operation nesting with filter before and after - offset" in {
@@ -96,7 +96,7 @@ class NestedDistinctSpec extends Spec {
             .drop(7)
         }
 
-        ctx.run(q).string mustEqual "SELECT x12.myEmbname FROM (SELECT DISTINCT x11.name AS myEmbname FROM MyParent x11 WHERE x11.name = 'firstTest') AS x12 WHERE x12.myEmbname = 'test' OFFSET 7"
+        ctx.run(q).string mustEqual "SELECT x12.myEmbname AS name FROM (SELECT DISTINCT x11.name AS myEmbname FROM MyParent x11 WHERE x11.name = 'firstTest') AS x12 WHERE x12.myEmbname = 'test' OFFSET 7"
       }
 
       "first operation nesting with filter - nested" in {
@@ -106,7 +106,7 @@ class NestedDistinctSpec extends Spec {
             .filter(_.myEmb.name == "test")
         }
 
-        ctx.run(q).string mustEqual "SELECT x13.myEmbname FROM (SELECT x.name AS myEmbname FROM MyParent x) AS x13 WHERE x13.myEmbname = 'test'"
+        ctx.run(q).string mustEqual "SELECT x13.myEmbname AS name FROM (SELECT x.name AS myEmbname FROM MyParent x) AS x13 WHERE x13.myEmbname = 'test'"
       }
 
       "first operation nesting with filter before and after - nested" in {
@@ -117,7 +117,7 @@ class NestedDistinctSpec extends Spec {
             .filter(_.myEmb.name == "test")
         }
 
-        ctx.run(q).string mustEqual "SELECT x15.myEmbname FROM (SELECT x14.name AS myEmbname FROM MyParent x14 WHERE x14.name = 'firstTest') AS x15 WHERE x15.myEmbname = 'test'"
+        ctx.run(q).string mustEqual "SELECT x15.myEmbname AS name FROM (SELECT x14.name AS myEmbname FROM MyParent x14 WHERE x14.name = 'firstTest') AS x15 WHERE x15.myEmbname = 'test'"
       }
     }
 
@@ -135,7 +135,7 @@ class NestedDistinctSpec extends Spec {
           .map(e => SimpleEnt2(e.a + 2, e.b))
           .distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT e.a + 2, e.b FROM (SELECT DISTINCT e.field_a + 1 AS a, e.b FROM CustomEnt e) AS e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT e.a + 2 AS aa, e.b AS bb FROM (SELECT DISTINCT e.field_a + 1 AS a, e.b FROM CustomEnt e) AS e"
     }
 
     "works with explicitly nested infixes" in {
@@ -183,7 +183,7 @@ class NestedDistinctSpec extends Spec {
           query[Parent].map(p => (p.emb, 1)).distinct.map(e => (e._1.name, e._1.id))
         }
 
-        ctx.run(q).string mustEqual "SELECT p._1theName, p._1id FROM (SELECT DISTINCT p.id AS _1id, p.theName AS _1theName, 1 AS _2 FROM Parent p) AS p"
+        ctx.run(q).string mustEqual "SELECT p._1theName AS _1, p._1id AS _2 FROM (SELECT DISTINCT p.id AS _1id, p.theName AS _1theName, 1 AS _2 FROM Parent p) AS p"
       }
 
       "embedded can be propagated across distinct inside case class with naming intact" in {
@@ -193,28 +193,28 @@ class NestedDistinctSpec extends Spec {
           query[Parent].map(p => SuperParent(p.emb, 1)).distinct.map(e => (e.emb.name, e.emb.id))
         }
 
-        ctx.run(q).string mustEqual "SELECT p.embtheName, p.embid FROM (SELECT DISTINCT p.id AS embid, p.theName AS embtheName, 1 AS id FROM Parent p) AS p"
+        ctx.run(q).string mustEqual "SELECT p.embtheName AS _1, p.embid AS _2 FROM (SELECT DISTINCT p.id AS embid, p.theName AS embtheName, 1 AS id FROM Parent p) AS p"
       }
 
       "can be propagated across query with naming intact" in {
         val q = quote {
           query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id))
         }
-        ctx.run(q).string mustEqual "SELECT p.embtheName, p.embid FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
+        ctx.run(q).string mustEqual "SELECT p.embtheName AS _1, p.embid AS _2 FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
       }
 
       "can be propogated across query with naming intact and then used further" in {
         val q = quote {
           query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct.map(tup => (tup._1, tup._2)).distinct
         }
-        ctx.run(q).string mustEqual "SELECT DISTINCT e.theName, e.id FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
+        ctx.run(q).string mustEqual "SELECT DISTINCT e.theName AS _1, e.id AS _2 FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
       }
 
       "can be propogated across query with naming intact and then used further - nested" in {
         val q = quote {
           query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id)).nested.map(tup => (tup._1, tup._2)).nested
         }
-        ctx.run(q).string mustEqual "SELECT p.embtheName, p.embid FROM (SELECT x.embid, x.embtheName FROM (SELECT x.embid, x.embtheName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS x) AS x) AS p"
+        ctx.run(q).string mustEqual "SELECT p.embtheName AS _1, p.embid AS _2 FROM (SELECT x.embid, x.embtheName FROM (SELECT x.embid, x.embtheName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS x) AS x) AS p"
       }
 
       "can be propogated across query with naming intact - returned as single property" in {
@@ -228,7 +228,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => p.emb).nested.map(e => e)
         }
-        ctx.run(q).string mustEqual "SELECT p.embid, p.embtheName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
+        ctx.run(q).string mustEqual "SELECT p.embid AS id, p.embtheName AS theName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
       }
 
       "can be propogated across distinct with naming intact - and the immediately returned" in {
@@ -242,14 +242,14 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => p.emb).distinct.map(e => Parent(1, e))
         }
-        ctx.run(q).string mustEqual "SELECT 1, e.id, e.theName FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
+        ctx.run(q).string mustEqual "SELECT 1 AS idP, e.id, e.theName FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
       }
 
       "can be propogated across query with naming intact and then re-wrapped in tuple" in {
         val q = quote {
           query[Parent].map(p => p.emb).nested.map(e => Parent(1, e))
         }
-        ctx.run(q).string mustEqual "SELECT 1, p.embid, p.embtheName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
+        ctx.run(q).string mustEqual "SELECT 1 AS idP, p.embid AS id, p.embtheName AS theName FROM (SELECT x.id AS embid, x.theName AS embtheName FROM Parent x) AS p"
       }
     }
 
@@ -265,7 +265,7 @@ class NestedDistinctSpec extends Spec {
             .map(g => g.par).distinct
             .map(p => p.emb).map(p => p.name).distinct
         }
-        ctx.run(q).string mustEqual "SELECT DISTINCT p.embtheName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
+        ctx.run(q).string mustEqual "SELECT DISTINCT p.embtheName AS theName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
       }
 
       "fully unwrapped name propagates with side property" in {
@@ -276,7 +276,7 @@ class NestedDistinctSpec extends Spec {
             .map(tup => (tup._1, tup._2)).distinct
         }
         ctx.run(q).string mustEqual
-          "SELECT DISTINCT p.theParentName, p.embid, p.embtheName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
+          "SELECT DISTINCT p.theParentName AS _1, p.embid AS id, p.embtheName AS theName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
       }
 
       "fully unwrapped name propagates with side property - nested" in {
@@ -289,9 +289,9 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  g.partheParentName,
-            |  g.parembid,
-            |  g.parembtheName
+            |  g.partheParentName AS _1,
+            |  g.parembid AS id,
+            |  g.parembtheName AS theName
             |FROM
             |  (
             |    SELECT
@@ -328,11 +328,11 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT p.theParentName,
-            |  p.embid,
-            |  p.embtheName,
-            |  p.id,
-            |  p.embid
+            |  DISTINCT p.theParentName AS _1,
+            |  p.embid AS id,
+            |  p.embtheName AS theName,
+            |  p.id AS _3,
+            |  p.embid AS _4
             |FROM
             |  (
             |    SELECT
@@ -357,11 +357,11 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT p.theParentName,
-            |  p.embid,
-            |  p.embtheName,
-            |  p.id,
-            |  p.embid
+            |  DISTINCT p.theParentName AS _1,
+            |  p.embid AS id,
+            |  p.embtheName AS theName,
+            |  p.id AS _3,
+            |  p.embid AS _4
             |FROM
             |  (
             |    SELECT
@@ -391,11 +391,11 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  tup._1,
-            |  tup._2id,
-            |  tup._2name,
-            |  tup._2embid,
-            |  tup._2embname
+            |  tup._1 AS id,
+            |  tup._2id AS id,
+            |  tup._2name AS name,
+            |  tup._2embid AS id,
+            |  tup._2embname AS name
             |FROM
             |  (
             |    SELECT
@@ -460,7 +460,7 @@ class NestedDistinctSpec extends Spec {
 
         }
         ctx.run(q).string.collapseSpace mustEqual
-          """SELECT g.id, g.parid, g.partheParentName, g.parembid, g.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.id AS parid, x.theParentName AS partheParentName, x.id AS parembid, x.theName AS parembtheName FROM GrandParent x) AS x) AS x) AS x) AS x) AS x) AS g""".collapseSpace
+          """SELECT g.id, g.parid AS id, g.partheParentName AS name, g.parembid AS id, g.parembtheName AS name FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.parid, x.partheParentName, x.parembid, x.parembtheName FROM (SELECT x.id, x.id AS parid, x.theParentName AS partheParentName, x.id AS parembid, x.theName AS parembtheName FROM GrandParent x) AS x) AS x) AS x) AS x) AS x) AS g""".collapseSpace
       }
 
       "fully unwrapped and fully re-wrapped - nested and distinct" in {
@@ -477,7 +477,7 @@ class NestedDistinctSpec extends Spec {
 
         }
         ctx.run(q).string.collapseSpace mustEqual
-          """SELECT tup._1, tup._2id, tup._2name, tup._2embid, tup._2embname
+          """SELECT tup._1 AS id, tup._2id AS id, tup._2name AS name, tup._2embid AS id, tup._2embname AS name
             |FROM (SELECT DISTINCT tup._1, tup._2 AS _2id, tup._3 AS _2name, tup._4 AS _2embid, tup._5 AS _2embname
             |      FROM (SELECT DISTINCT tup._1, tup._2, tup._3, tup._4id AS _4, tup._4theName AS _5
             |            FROM (SELECT DISTINCT g.id               AS _1,
@@ -512,7 +512,7 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT 'Joe',
+            |  DISTINCT 'Joe' AS name,
             |  norm.name,
             |  norm.id,
             |  mod.theName,
@@ -543,8 +543,8 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  feb._1theName,
-            |  feb._2bame
+            |  feb._1theName AS _1,
+            |  feb._2bame AS _2
             |FROM
             |  (
             |    SELECT
@@ -591,9 +591,9 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  web._1_2name,
-            |  web._1_1theName,
-            |  web._2bame
+            |  web._1_2name AS _1,
+            |  web._1_1theName AS _2,
+            |  web._2bame AS _3
             |FROM
             |  (
             |    SELECT
@@ -633,7 +633,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Emb].map(e => Parent(1, e)).distinct.map(p => p.emb1.a)
         }
-        ctx.run(q).string mustEqual "SELECT e.emb1a FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
+        ctx.run(q).string mustEqual "SELECT e.emb1a AS a FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
       }
 
       "should not use override from parent schema level - nested" in {
@@ -642,7 +642,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Emb].map(e => Parent(1, e)).distinct.map(p => p.emb1)
         }
-        ctx.run(q).string mustEqual "SELECT e.emb1a, e.emb1b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
+        ctx.run(q).string mustEqual "SELECT e.emb1a AS a, e.emb1b AS b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
       }
 
       "with a schema" - {
@@ -652,28 +652,28 @@ class NestedDistinctSpec extends Spec {
           val q = quote {
             query[Emb].map(e => (1, e)).distinct.map(p => p._2)
           }
-          ctx.run(q).string mustEqual "SELECT e._2field_a, e._2b FROM (SELECT DISTINCT 1 AS _1, e.field_a AS _2field_a, e.b AS _2b FROM EmbTable e) AS e"
+          ctx.run(q).string mustEqual "SELECT e._2field_a AS field_a, e._2b AS b FROM (SELECT DISTINCT 1 AS _1, e.field_a AS _2field_a, e.b AS _2b FROM EmbTable e) AS e"
         }
 
         "should use override from child schema level - nested - reversed" in {
           val q = quote {
             query[Emb].map(e => (e, 1)).distinct.map(p => p._1)
           }
-          ctx.run(q).string mustEqual "SELECT e._1field_a, e._1b FROM (SELECT DISTINCT e.field_a AS _1field_a, e.b AS _1b, 1 AS _2 FROM EmbTable e) AS e"
+          ctx.run(q).string mustEqual "SELECT e._1field_a AS field_a, e._1b AS b FROM (SELECT DISTINCT e.field_a AS _1field_a, e.b AS _1b, 1 AS _2 FROM EmbTable e) AS e"
         }
 
         "should use override from child schema level - nested - case class" in {
           val q = quote {
             query[Emb].map(e => Parent(1, e)).distinct.map(p => p.emb1)
           }
-          ctx.run(q).string mustEqual "SELECT e.emb1field_a, e.emb1b FROM (SELECT DISTINCT 1 AS id, e.field_a AS emb1field_a, e.b AS emb1b FROM EmbTable e) AS e"
+          ctx.run(q).string mustEqual "SELECT e.emb1field_a AS field_a, e.emb1b AS b FROM (SELECT DISTINCT 1 AS id, e.field_a AS emb1field_a, e.b AS emb1b FROM EmbTable e) AS e"
         }
 
         "should use override from child schema level - nested - case class - reversed" in {
           val q = quote {
             query[Emb].map(e => Parent2(e, 1)).distinct.map(p => p.emb1)
           }
-          ctx.run(q).string mustEqual "SELECT e.emb1field_a, e.emb1b FROM (SELECT DISTINCT e.field_a AS emb1field_a, e.b AS emb1b, 1 AS id FROM EmbTable e) AS e"
+          ctx.run(q).string mustEqual "SELECT e.emb1field_a AS field_a, e.emb1b AS b FROM (SELECT DISTINCT e.field_a AS emb1field_a, e.b AS emb1b, 1 AS id FROM EmbTable e) AS e"
         }
       }
     }
@@ -693,7 +693,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Emb].map(e => Parent("Joe", e, e)).distinct.map(p => p.emb1)
         }
-        ctx.run(q).string mustEqual "SELECT e.emb1name, e.emb1id FROM (SELECT DISTINCT 'Joe' AS name, e.name AS emb1name, e.id AS emb1id, e.name AS emb2name, e.id AS emb2id FROM Emb e) AS e"
+        ctx.run(q).string mustEqual "SELECT e.emb1name AS name, e.emb1id AS id FROM (SELECT DISTINCT 'Joe' AS name, e.name AS emb1name, e.id AS emb1id, e.name AS emb2name, e.id AS emb2id FROM Emb e) AS e"
       }
 
       "schema on parent should not override children - from grandparent ad-hoc cc" in {
@@ -701,7 +701,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => GrandParent("GJoe", p)).distinct.map(p => (p.par.emb1, p.par.name))
         }
-        ctx.run(q).string mustEqual "SELECT p.paremb1name, p.paremb1id, p.partheName FROM (SELECT DISTINCT 'GJoe' AS name, p.theName AS partheName, p.name AS paremb1name, p.id AS paremb1id, p.name AS paremb2name, p.id AS paremb2id FROM ParentEnt p) AS p"
+        ctx.run(q).string mustEqual "SELECT p.paremb1name AS name, p.paremb1id AS id, p.partheName AS _2 FROM (SELECT DISTINCT 'GJoe' AS name, p.theName AS partheName, p.name AS paremb1name, p.id AS paremb1id, p.name AS paremb2name, p.id AS paremb2id FROM ParentEnt p) AS p"
       }
 
       // Schema on child should propagate to children
@@ -710,7 +710,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Emb].map(e => Parent("Joe", e, e)).distinct.map(p => p.emb1)
         }
-        ctx.run(q).string mustEqual "SELECT e.emb1theName, e.emb1id FROM (SELECT DISTINCT 'Joe' AS name, e.theName AS emb1theName, e.id AS emb1id, e.theName AS emb2theName, e.id AS emb2id FROM ChildEnt e) AS e"
+        ctx.run(q).string mustEqual "SELECT e.emb1theName AS theName, e.emb1id AS id FROM (SELECT DISTINCT 'Joe' AS name, e.theName AS emb1theName, e.id AS emb1id, e.theName AS emb2theName, e.id AS emb2id FROM ChildEnt e) AS e"
       }
 
       //Try parent and embedded children with same name, schema on one of children
@@ -725,7 +725,7 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT 'Joe',
+            |  DISTINCT 'Joe' AS name,
             |  norm.name,
             |  norm.id,
             |  mod.theName,
@@ -748,7 +748,7 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT 'Joe',
+            |  DISTINCT 'Joe' AS name,
             |  mod.theName,
             |  mod.id,
             |  norm.name,
@@ -771,7 +771,7 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT 'Joe',
+            |  DISTINCT 'Joe' AS name,
             |  mod.theName,
             |  mod.id,
             |  norm.theName,
@@ -794,7 +794,7 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT 'Joe',
+            |  DISTINCT 'Joe' AS name,
             |  mod.theSecondName,
             |  mod.id,
             |  norm.theFirstName,

--- a/quill-sql/src/test/scala/io/getquill/context/sql/PrepareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/PrepareSpec.scala
@@ -53,7 +53,7 @@ class PrepareSpec extends Spec {
         } yield (a, b, c.map(c => c.i))
       }
       testContext.run(q).string mustEqual
-        "SELECT a.s, a.i, a.l, a.o, a.b, b.s, b.i, b.l, b.o, c.i FROM TestEntity a INNER JOIN TestEntity2 b ON a.i = a.i RIGHT JOIN TestEntity c ON c.i = a.i"
+        "SELECT a.s, a.i, a.l, a.o, a.b, b.s, b.i, b.l, b.o, c.i AS _3 FROM TestEntity a INNER JOIN TestEntity2 b ON a.i = a.i RIGHT JOIN TestEntity c ON c.i = a.i"
     }
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQueryMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQueryMacroSpec.scala
@@ -24,7 +24,7 @@ class SqlQueryMacroSpec extends Spec {
         val mirror = testContext.run(q)
         mirror.prepareRow mustEqual Row()
         mirror.extractor(Row("s", 1, 2L), MirrorSession.default) mustEqual (("s", 1, 2L))
-        mirror.string mustEqual "SELECT t.s, t.i, t.l FROM TestEntity t"
+        mirror.string mustEqual "SELECT t.s AS _1, t.i AS _2, t.l AS _3 FROM TestEntity t"
       }
       "with flatMap" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -5,6 +5,7 @@ import io.getquill.context.sql.testContext._
 import io.getquill.Literal
 import io.getquill.Query
 import io.getquill.Ord
+import io.getquill.context.sql.util.StringOps._
 
 class SqlQuerySpec extends Spec {
 
@@ -22,7 +23,7 @@ class SqlQuerySpec extends Spec {
         }
       }
       testContext.run(q).string mustEqual
-        "SELECT a.i, b.i FROM TestEntity a, TestEntity2 b WHERE a.s IS NOT NULL AND b.i > a.i"
+        "SELECT a.i AS _1, b.i AS _2 FROM TestEntity a, TestEntity2 b WHERE a.s IS NOT NULL AND b.i > a.i"
     }
 
     "outer join query" in {
@@ -43,7 +44,7 @@ class SqlQuerySpec extends Spec {
             .filter(_._2.forall(_ == 1))
         }
         testContext.run(q).string mustEqual
-          "SELECT a.i, b.i FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i = 1"
+          "SELECT a.i AS _1, b.i AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i = 1"
       }
       "null-checked" in {
         val q = quote {
@@ -54,7 +55,7 @@ class SqlQuerySpec extends Spec {
             .filter(_._2.forall(v => if (v == "value") true else false))
         }
         testContext.run(q).string mustEqual
-          "SELECT a.i, b.s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.s IS NULL OR b.s IS NOT NULL AND CASE WHEN b.s = 'value' THEN true ELSE false END"
+          "SELECT a.i AS _1, b.s AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.s IS NULL OR b.s IS NOT NULL AND CASE WHEN b.s = 'value' THEN true ELSE false END"
       }
     }
 
@@ -80,8 +81,43 @@ class SqlQuerySpec extends Spec {
             }
         }
       }
-      testContext.run(q).string mustEqual
-        "SELECT ab._1s, ab._1field_i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS _1s, a.field_i AS _1field_i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM CustomEntity a LEFT JOIN TestEntity2 b ON a.field_i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1field_i AND ab._2i = c.i"
+      testContext.run(q).string(true).collapseSpace mustEqual
+        """
+          |SELECT
+          |  ab._1s AS s,
+          |  ab._1field_i AS field_i,
+          |  ab._1l AS l,
+          |  ab._1o AS o,
+          |  ab._1b AS b,
+          |  ab._2s AS s,
+          |  ab._2i AS i,
+          |  ab._2l AS l,
+          |  ab._2o AS o,
+          |  c.s,
+          |  c.i,
+          |  c.l,
+          |  c.o
+          |FROM
+          |  (
+          |    SELECT
+          |      a.s AS _1s,
+          |      a.field_i AS _1field_i,
+          |      a.l AS _1l,
+          |      a.o AS _1o,
+          |      a.b AS _1b,
+          |      b.s AS _2s,
+          |      b.i AS _2i,
+          |      b.l AS _2l,
+          |      b.o AS _2o
+          |    FROM
+          |      CustomEntity a
+          |      LEFT JOIN TestEntity2 b ON a.field_i = b.i
+          |    WHERE
+          |      b.l = 3
+          |  ) AS ab
+          |  LEFT JOIN TestEntity3 c ON ab._2i = ab._1field_i
+          |  AND ab._2i = c.i
+          |""".collapseSpace
     }
 
     "nested join - named variables - map to case class" in {
@@ -103,8 +139,42 @@ class SqlQuerySpec extends Spec {
             }
         }
       }
-      testContext.run(q).string mustEqual
-        "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+      testContext.run(q).string(true).collapseSpace mustEqual
+        """SELECT
+          |  ab._1s AS s,
+          |  ab._1i AS i,
+          |  ab._1l AS l,
+          |  ab._1o AS o,
+          |  ab._1b AS b,
+          |  ab._2s AS s,
+          |  ab._2i AS i,
+          |  ab._2l AS l,
+          |  ab._2o AS o,
+          |  c.s,
+          |  c.i,
+          |  c.l,
+          |  c.o
+          |FROM
+          |  (
+          |    SELECT
+          |      a.s AS _1s,
+          |      a.i AS _1i,
+          |      a.l AS _1l,
+          |      a.o AS _1o,
+          |      a.b AS _1b,
+          |      b.s AS _2s,
+          |      b.i AS _2i,
+          |      b.l AS _2l,
+          |      b.o AS _2o
+          |    FROM
+          |      TestEntity a
+          |      LEFT JOIN TestEntity2 b ON a.i = b.i
+          |    WHERE
+          |      b.l = 3
+          |  ) AS ab
+          |  LEFT JOIN TestEntity3 c ON ab._2i = ab._1i
+          |  AND ab._2i = c.i
+          |""".collapseSpace
     }
 
     "nested join - named variables" in {
@@ -126,8 +196,42 @@ class SqlQuerySpec extends Spec {
             }
         }
       }
-      testContext.run(q).string mustEqual
-        "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+      testContext.run(q).string(true).collapseSpace mustEqual
+        """SELECT
+          |  ab._1s AS s,
+          |  ab._1i AS i,
+          |  ab._1l AS l,
+          |  ab._1o AS o,
+          |  ab._1b AS b,
+          |  ab._2s AS s,
+          |  ab._2i AS i,
+          |  ab._2l AS l,
+          |  ab._2o AS o,
+          |  c.s,
+          |  c.i,
+          |  c.l,
+          |  c.o
+          |FROM
+          |  (
+          |    SELECT
+          |      a.s AS _1s,
+          |      a.i AS _1i,
+          |      a.l AS _1l,
+          |      a.o AS _1o,
+          |      a.b AS _1b,
+          |      b.s AS _2s,
+          |      b.i AS _2i,
+          |      b.l AS _2l,
+          |      b.o AS _2o
+          |    FROM
+          |      TestEntity a
+          |      LEFT JOIN TestEntity2 b ON a.i = b.i
+          |    WHERE
+          |      b.l = 3
+          |  ) AS ab
+          |  LEFT JOIN TestEntity3 c ON ab._2i = ab._1i
+          |  AND ab._2i = c.i
+          |""".collapseSpace
     }
 
     "nested join" in {
@@ -143,8 +247,42 @@ class SqlQuerySpec extends Spec {
             b.map(_.i).contains(a.i) && b.map(_.i).contains(c.i)
         }
       }
-      testContext.run(q).string mustEqual
-        "SELECT x02._1s, x02._1i, x02._1l, x02._1o, x02._1b, x02._2s, x02._2i, x02._2l, x02._2o, x12.s, x12.i, x12.l, x12.o FROM (SELECT x01.s AS _1s, x01.i AS _1i, x01.l AS _1l, x01.o AS _1o, x01.b AS _1b, x11.s AS _2s, x11.i AS _2i, x11.l AS _2l, x11.o AS _2o FROM TestEntity x01 LEFT JOIN TestEntity2 x11 ON x01.i = x11.i WHERE x11.l = 3) AS x02 LEFT JOIN TestEntity3 x12 ON x02._2i = x02._1i AND x02._2i = x12.i"
+      testContext.run(q).string(true).collapseSpace mustEqual
+        """SELECT
+          |  x02._1s AS s,
+          |  x02._1i AS i,
+          |  x02._1l AS l,
+          |  x02._1o AS o,
+          |  x02._1b AS b,
+          |  x02._2s AS s,
+          |  x02._2i AS i,
+          |  x02._2l AS l,
+          |  x02._2o AS o,
+          |  x12.s,
+          |  x12.i,
+          |  x12.l,
+          |  x12.o
+          |FROM
+          |  (
+          |    SELECT
+          |      x01.s AS _1s,
+          |      x01.i AS _1i,
+          |      x01.l AS _1l,
+          |      x01.o AS _1o,
+          |      x01.b AS _1b,
+          |      x11.s AS _2s,
+          |      x11.i AS _2i,
+          |      x11.l AS _2l,
+          |      x11.o AS _2o
+          |    FROM
+          |      TestEntity x01
+          |      LEFT JOIN TestEntity2 x11 ON x01.i = x11.i
+          |    WHERE
+          |      x11.l = 3
+          |  ) AS x02
+          |  LEFT JOIN TestEntity3 x12 ON x02._2i = x02._1i
+          |  AND x02._2i = x12.i
+          |""".collapseSpace
     }
 
     "flat-join" - {
@@ -156,7 +294,7 @@ class SqlQuerySpec extends Spec {
           } yield (e1.i, e2.map(e => e.i))
         }
         testContext.run(q).string mustEqual
-          "SELECT e1.i, e2.i FROM TestEntity e1 LEFT JOIN TestEntity2 e2 ON e2.i = e1.i"
+          "SELECT e1.i AS _1, e2.i AS _2 FROM TestEntity e1 LEFT JOIN TestEntity2 e2 ON e2.i = e1.i"
       }
 
       "flat join without map" in {
@@ -360,7 +498,7 @@ class SqlQuerySpec extends Spec {
           qr1.groupBy(t => (t.i, t.l)).map(t => t._1)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.i, t.l FROM TestEntity t GROUP BY t.i, t.l"
+          "SELECT t.i AS _1, t.l AS _2 FROM TestEntity t GROUP BY t.i, t.l"
       }
       "aggregated" - {
         "simple" in {
@@ -370,7 +508,7 @@ class SqlQuerySpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i, COUNT(t.*) FROM TestEntity t GROUP BY t.i"
+            "SELECT t.i AS _1, COUNT(t.*) AS _2 FROM TestEntity t GROUP BY t.i"
         }
         "mapped" in {
           val q = quote {
@@ -379,7 +517,7 @@ class SqlQuerySpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i, MAX(t.l) FROM TestEntity t GROUP BY t.i"
+            "SELECT t.i AS _1, MAX(t.l) AS _2 FROM TestEntity t GROUP BY t.i"
         }
         "distinct" in {
           val q = quote {
@@ -388,7 +526,7 @@ class SqlQuerySpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.s, COUNT(DISTINCT t.i) FROM TestEntity t GROUP BY t.s"
+            "SELECT t.s AS _1, COUNT(DISTINCT t.i) AS _2 FROM TestEntity t GROUP BY t.s"
         }
       }
       "with map" - {
@@ -402,7 +540,7 @@ class SqlQuerySpec extends Spec {
               }
           }
           testContext.run(q).string mustEqual
-            "SELECT b.i, SUM(a.i) FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s GROUP BY b.i"
+            "SELECT b.i AS _1, SUM(a.i) AS _2 FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s GROUP BY b.i"
         }
         "nested" in {
           val q = quote {
@@ -415,7 +553,7 @@ class SqlQuerySpec extends Spec {
               }
           }
           testContext.run(q).string mustEqual
-            "SELECT t._2i, SUM(t._1i) FROM (SELECT a.i AS _1i, b.i AS _2i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t._2i"
+            "SELECT t._2i AS _1, SUM(t._1i) AS _2 FROM (SELECT a.i AS _1i, b.i AS _2i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t._2i"
         }
       }
     }
@@ -470,7 +608,7 @@ class SqlQuerySpec extends Spec {
             .on((a, b) => a.i == b)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.s, a.i, a.l, a.o, a.b, q21._1 FROM TestEntity a INNER JOIN (SELECT DISTINCT q2.i AS _1 FROM TestEntity2 q2) AS q21 ON a.i = q21._1"
+          "SELECT a.s, a.i, a.l, a.o, a.b, q21._1 AS _2 FROM TestEntity a INNER JOIN (SELECT DISTINCT q2.i AS _1 FROM TestEntity2 q2) AS q21 ON a.i = q21._1"
       }
 
       // If you look inside BetaReduction, you will see that tuple values that are the same are collapsed via 'distinct'.
@@ -651,11 +789,11 @@ class SqlQuerySpec extends Spec {
 
         "take" in {
           testContext.run(q.take(3)).string mustEqual
-            "SELECT q1.i, q2.i, q1.s, q2.s FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i LIMIT 3"
+            "SELECT q1.i AS _1, q2.i AS _2, q1.s AS _3, q2.s AS _4 FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i LIMIT 3"
         }
         "drop" in {
           testContext.run(q.drop(3)).string mustEqual
-            "SELECT q1.i, q2.i, q1.s, q2.s FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i OFFSET 3"
+            "SELECT q1.i AS _1, q2.i AS _2, q1.s AS _3, q2.s AS _4 FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i OFFSET 3"
         }
       }
     }
@@ -816,7 +954,7 @@ class SqlQuerySpec extends Spec {
           }
         }
         testContext.run(q).string mustEqual
-          "SELECT b.s FROM TestEntity a, TestEntity2 b WHERE b.i > a.i"
+          "SELECT b.s AS str FROM TestEntity a, TestEntity2 b WHERE b.i > a.i"
       }
 
       "in union" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/BooleanLiteralSupportSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/BooleanLiteralSupportSpec.scala
@@ -16,7 +16,7 @@ class BooleanLiteralSupportSpec extends Spec {
         query[Ent].map(e => (e.name, if (e.b == e.bb) e.bc else e.b == e.bb))
       }
       ctx.run(q).string mustEqual
-        "SELECT e.name, CASE WHEN e.b = e.bb THEN e.bc WHEN e.b = e.bb THEN 1 ELSE 0 END FROM Ent e"
+        "SELECT e.name AS _1, CASE WHEN e.b = e.bb THEN e.bc WHEN e.b = e.bb THEN 1 ELSE 0 END AS _2 FROM Ent e"
     }
 
     "map-clause" in {
@@ -38,21 +38,21 @@ class BooleanLiteralSupportSpec extends Spec {
         query[Ent].map(e => ("foo", e.bb == true))
       }
       ctx.run(q).string mustEqual
-        "SELECT 'foo', CASE WHEN e.bb = 1 THEN 1 ELSE 0 END FROM Ent e"
+        "SELECT 'foo' AS _1, CASE WHEN e.bb = 1 THEN 1 ELSE 0 END AS _2 FROM Ent e"
     }
     "tuple-multi" in {
       val q = quote {
         query[Ent].map(e => (e.bb == true, e.bc == false, e.num > 1))
       }
       ctx.run(q).string mustEqual
-        "SELECT CASE WHEN e.bb = 1 THEN 1 ELSE 0 END, CASE WHEN e.bc = 0 THEN 1 ELSE 0 END, CASE WHEN e.num > 1 THEN 1 ELSE 0 END FROM Ent e"
+        "SELECT CASE WHEN e.bb = 1 THEN 1 ELSE 0 END AS _1, CASE WHEN e.bc = 0 THEN 1 ELSE 0 END AS _2, CASE WHEN e.num > 1 THEN 1 ELSE 0 END AS _3 FROM Ent e"
     }
     "case-class" in {
       val q = quote {
         query[Ent].map(e => Status("foo", e.bb == true))
       }
       ctx.run(q).string mustEqual
-        "SELECT 'foo', CASE WHEN e.bb = 1 THEN 1 ELSE 0 END FROM Ent e"
+        "SELECT 'foo' AS name, CASE WHEN e.bb = 1 THEN 1 ELSE 0 END AS value FROM Ent e"
     }
   }
 
@@ -93,7 +93,7 @@ class BooleanLiteralSupportSpec extends Spec {
         }.dynamic
         println(io.getquill.util.Messages.qprint(q.ast))
         ctx.run(q).string mustEqual
-          "SELECT 'baz', e._2 FROM (SELECT DISTINCT e._1, e._2 FROM (SELECT 'foo' AS _1, CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _2 FROM Ent e) AS e) AS e"
+          "SELECT 'baz' AS _1, e._2 FROM (SELECT DISTINCT e._1, e._2 FROM (SELECT 'foo' AS _1, CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _2 FROM Ent e) AS e) AS e"
       }
 
       "distinct tuple map-clause" in {
@@ -119,7 +119,7 @@ class BooleanLiteralSupportSpec extends Spec {
         }
         println(io.getquill.util.Messages.qprint(q.ast))
         ctx.run(q).string mustEqual
-          "SELECT 'baz', e._2 FROM (SELECT DISTINCT 'foo' AS _1, CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _2 FROM Ent e) AS e"
+          "SELECT 'baz' AS _1, e._2 FROM (SELECT DISTINCT 'foo' AS _1, CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _2 FROM Ent e) AS e"
       }
 
       "pure map-clause - double element" in {
@@ -127,7 +127,7 @@ class BooleanLiteralSupportSpec extends Spec {
           query[Ent].map(e => infix"${e.i} > 123".pure.asCondition).distinct.map(r => (r, r))
         }.dynamic
         ctx.run(q).string mustEqual
-          "SELECT e._1, e._1 FROM (SELECT DISTINCT CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _1 FROM Ent e) AS e"
+          "SELECT e._1, e._1 AS _2 FROM (SELECT DISTINCT CASE WHEN e.i > 123 THEN 1 ELSE 0 END AS _1 FROM Ent e) AS e"
       }
     }
 
@@ -206,7 +206,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.filter(t => t.o.exists(_ => if (false) false else true)).map(t => (t.b, true))
       }
       ctx.run(q).string mustEqual
-        "SELECT t.b, 1 FROM TestEntity t WHERE t.o IS NOT NULL AND (1 = 0 AND 1 = 0 OR NOT (1 = 0) AND 1 = 1)"
+        "SELECT t.b AS _1, 1 AS _2 FROM TestEntity t WHERE t.o IS NOT NULL AND (1 = 0 AND 1 = 0 OR NOT (1 = 0) AND 1 = 1)"
     }
 
     "exists - lifted" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -215,7 +215,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.filter(t => t.o.exists(_ => if (lift(false)) lift(false) else lift(true))).map(t => (t.b, true))
       }
       ctx.run(q).string mustEqual
-        "SELECT t.b, 1 FROM TestEntity t WHERE t.o IS NOT NULL AND (1 = ? AND 1 = ? OR NOT (1 = ?) AND 1 = ?)"
+        "SELECT t.b AS _1, 1 AS _2 FROM TestEntity t WHERE t.o IS NOT NULL AND (1 = ? AND 1 = ? OR NOT (1 = ?) AND 1 = ?)"
     }
   }
 
@@ -228,7 +228,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, t._2.map(_.s), false))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, b.s, 0 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, b.s AS _2, 0 AS _3 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map (with conditional)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -237,7 +237,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.map(_.i > 20) === true) false else true))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, CASE WHEN CASE WHEN b.i > 20 THEN 1 ELSE 0 END = 1 THEN 0 ELSE 1 END FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, CASE WHEN CASE WHEN b.i > 20 THEN 1 ELSE 0 END = 1 THEN 0 ELSE 1 END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map (with conditional comparison)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -246,7 +246,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.forall(_.i > 20)) false else true))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, CASE WHEN b IS NULL OR b.i > 20 THEN 0 ELSE 1 END FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, CASE WHEN b IS NULL OR b.i > 20 THEN 0 ELSE 1 END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map (with conditional comparison lifted)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -255,7 +255,7 @@ class BooleanLiteralSupportSpec extends Spec {
         qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.forall(_.i > 20)) lift(false) else lift(true)))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, CASE WHEN b IS NULL OR b.i > 20 THEN ? ELSE ? END FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, CASE WHEN b IS NULL OR b.i > 20 THEN ? ELSE ? END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map + filter" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -268,7 +268,7 @@ class BooleanLiteralSupportSpec extends Spec {
           .filter(_._2.forall(v => if (true) true else false))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, b.s, 0 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 0 WHERE b.s IS NULL OR b.s IS NOT NULL AND (1 = 1 AND 1 = 1 OR NOT (1 = 1) AND 1 = 0)"
+        "SELECT a.i AS _1, b.s AS _2, 0 AS _3 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 0 WHERE b.s IS NULL OR b.s IS NOT NULL AND (1 = 1 AND 1 = 1 OR NOT (1 = 1) AND 1 = 0)"
     }
 
     "join + map + filter (lifted)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
@@ -281,7 +281,7 @@ class BooleanLiteralSupportSpec extends Spec {
           .filter(_._2.forall(v => if (lift(true)) lift(true) else lift(false)))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i, b.s, 0 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 0 WHERE b.s IS NULL OR b.s IS NOT NULL AND (1 = ? AND 1 = ? OR NOT (1 = ?) AND 1 = ?)"
+        "SELECT a.i AS _1, b.s AS _2, 0 AS _3 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 0 WHERE b.s IS NULL OR b.s IS NOT NULL AND (1 = ? AND 1 = ? OR NOT (1 = ?) AND 1 = ?)"
     }
 
     "for-comprehension with constant" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
@@ -20,7 +20,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextEscape.run(q).string mustEqual
-        """SELECT p._1id, p._1name, p._2 FROM (SELECT p."id" AS _1id, p."name" AS _1name, foobar AS _2 FROM "Person" p) AS p WHERE p._1id = 1"""
+        """SELECT p._1id AS id, p._1name AS name, p._2 FROM (SELECT p."id" AS _1id, p."name" AS _1name, foobar AS _2 FROM "Person" p) AS p WHERE p._1id = 1"""
     }
 
     "inner aliases should use naming strategy only when instructed" in {
@@ -31,7 +31,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextEscapeElements.run(q).string mustEqual
-        """SELECT "p"."_1id", "p"."_1name", "p"."_2" FROM (SELECT "p"."id" AS "_1id", "p"."name" AS "_1name", foobar AS "_2" FROM "Person" "p") AS "p" WHERE "p"."_1id" = 1"""
+        """SELECT "p"."_1id" AS "id", "p"."_1name" AS "name", "p"."_2" FROM (SELECT "p"."id" AS "_1id", "p"."name" AS "_1name", foobar AS "_2" FROM "Person" "p") AS "p" WHERE "p"."_1id" = 1"""
     }
   }
 
@@ -46,7 +46,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT p._1id, p._1name, p._2 FROM (SELECT p.ID AS _1id, p.NAME AS _1name, foobar AS _2 FROM PERSON p) AS p WHERE p._1id = 1"
+        "SELECT p._1id AS id, p._1name AS name, p._2 FROM (SELECT p.ID AS _1id, p.NAME AS _1name, foobar AS _2 FROM PERSON p) AS p WHERE p._1id = 1"
     }
 
     "inner aliases should use naming strategy with override" in {
@@ -60,7 +60,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT p._1theId, p._1theName, p._2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1"
+        "SELECT p._1theId AS theId, p._1theName AS theName, p._2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1"
     }
 
     "inner aliases should use naming strategy with override - two tables" in {
@@ -79,7 +79,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT ab._1theId, ab._1theName, ab._2id, ab._2name, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.ID AS _2id, b.NAME AS _2name, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
+        "SELECT ab._1theId AS theId, ab._1theName AS theName, ab._2id AS id, ab._2name AS name, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.ID AS _2id, b.NAME AS _2name, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
     }
 
     "inner alias should nest properly in multiple levels" in {
@@ -92,7 +92,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
       }
 
       testContextUpper.run(q).string mustEqual
-        "SELECT p._1_1id, p._1_1name, p._1_2, p._2 FROM (SELECT p._1id AS _1_1id, p._1name AS _1_1name, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.ID AS _1id, p.NAME AS _1name, foobar AS _2 FROM PERSON p) AS p WHERE p._1id = 1) AS p WHERE p._1_1id = 2"
+        "SELECT p._1_1id AS id, p._1_1name AS name, p._1_2 AS _2, p._2 FROM (SELECT p._1id AS _1_1id, p._1name AS _1_1name, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.ID AS _1id, p.NAME AS _1name, foobar AS _2 FROM PERSON p) AS p WHERE p._1id = 1) AS p WHERE p._1_1id = 2"
     }
 
     "inner alias should nest properly in multiple levels - with query schema" in {
@@ -110,7 +110,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
       }
 
       testContextUpper.run(q).string mustEqual
-        "SELECT p._1_1theId, p._1_1theName, p._1_2, p._2 FROM (SELECT p._1theId AS _1_1theId, p._1theName AS _1_1theName, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1) AS p WHERE p._1_1theId = 2"
+        "SELECT p._1_1theId AS theId, p._1_1theName AS theName, p._1_2 AS _2, p._2 FROM (SELECT p._1theId AS _1_1theId, p._1theName AS _1_1theName, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1) AS p WHERE p._1_1theId = 2"
     }
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
@@ -126,20 +126,20 @@ class OracleDialectSpec extends Spec {
     "boolean values" - {
       "uses 1 instead of true" in {
         ctx.run(qr4.map(t => (t.i, true))).string mustEqual
-          "SELECT t.i, 1 FROM TestEntity4 t"
+          """SELECT t.i AS "_1", 1 AS "_2" FROM TestEntity4 t"""
       }
       "uses 0 instead of false" in {
         ctx.run(qr4.map(t => (t.i, false))).string mustEqual
-          "SELECT t.i, 0 FROM TestEntity4 t"
+          """SELECT t.i AS "_1", 0 AS "_2" FROM TestEntity4 t"""
       }
       "uses 0 and 1 altogether" in {
         ctx.run(qr4.map(t => (t.i, true, false))).string mustEqual
-          "SELECT t.i, 1, 0 FROM TestEntity4 t"
+          """SELECT t.i AS "_1", 1 AS "_2", 0 AS "_3" FROM TestEntity4 t"""
       }
     }
     "boolean values and expressions together" in {
       ctx.run(qr4.filter(t => true).filter(t => false).map(t => (t.i, false, true))).string mustEqual
-        "SELECT t.i, 0, 1 FROM TestEntity4 t WHERE 1 = 1 AND 1 = 0"
+        """SELECT t.i AS "_1", 0 AS "_2", 1 AS "_3" FROM TestEntity4 t WHERE 1 = 1 AND 1 = 0"""
     }
     "if" - {
       "simple booleans" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
@@ -46,20 +46,20 @@ class SQLServerDialectSpec extends Spec {
     "boolean values" - {
       "uses 1 instead of true" in {
         ctx.run(qr4.map(t => (t.i, true))).string mustEqual
-          "SELECT t.i, 1 FROM TestEntity4 t"
+          "SELECT t.i AS _1, 1 AS _2 FROM TestEntity4 t"
       }
       "uses 0 instead of false" in {
         ctx.run(qr4.map(t => (t.i, false))).string mustEqual
-          "SELECT t.i, 0 FROM TestEntity4 t"
+          "SELECT t.i AS _1, 0 AS _2 FROM TestEntity4 t"
       }
       "uses 0 and 1 altogether" in {
         ctx.run(qr4.map(t => (t.i, true, false))).string mustEqual
-          "SELECT t.i, 1, 0 FROM TestEntity4 t"
+          "SELECT t.i AS _1, 1 AS _2, 0 AS _3 FROM TestEntity4 t"
       }
     }
     "boolean values and expressions together" in {
       ctx.run(qr4.filter(t => true).filter(t => false).map(t => (t.i, false, true))).string mustEqual
-        "SELECT t.i, 0, 1 FROM TestEntity4 t WHERE 1 = 1 AND 1 = 0"
+        "SELECT t.i AS _1, 0 AS _2, 1 AS _3 FROM TestEntity4 t WHERE 1 = 1 AND 1 = 0"
     }
     "if" - {
       "simple booleans" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
@@ -33,13 +33,13 @@ class SqlIdiomNamingSpec extends Spec {
       val db = new SqlMirrorContext(MirrorSqlDialect, SnakeCase)
       import db._
       db.run(query[SomeEntity]).string mustEqual
-        "SELECT x.some_column FROM some_entity x"
+        "SELECT x.some_column AS someColumn FROM some_entity x"
     }
     "mutiple transformations" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, NamingStrategy(SnakeCase, UpperCase, Escape))
       import db._
       db.run(query[SomeEntity]).string mustEqual
-        """SELECT x."SOME_COLUMN" FROM "SOME_ENTITY" x"""
+        """SELECT x."SOME_COLUMN" AS someColumn FROM "SOME_ENTITY" x"""
     }
     "specific table strategy - dynamic" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, CustomTableStrategy)
@@ -50,7 +50,7 @@ class SqlIdiomNamingSpec extends Spec {
       }
 
       db.run(q.dynamic).string mustEqual
-        "SELECT t.some_column FROM t_someentity t"
+        "SELECT t.some_column AS someColumn FROM t_someentity t"
     }
     "specific table strategy" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, CustomTableStrategy)
@@ -61,7 +61,7 @@ class SqlIdiomNamingSpec extends Spec {
       }
 
       db.run(q).string mustEqual
-        "SELECT t.some_column FROM t_someentity t"
+        "SELECT t.some_column AS someColumn FROM t_someentity t"
     }
     "specific column strategy - dynamic" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, CustomColumnStrategy)
@@ -72,7 +72,7 @@ class SqlIdiomNamingSpec extends Spec {
       }
 
       db.run(q.dynamic).string mustEqual
-        "SELECT t.c_somecolumn FROM some_entity t"
+        "SELECT t.c_somecolumn AS someColumn FROM some_entity t"
     }
     "specific column strategy" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, CustomColumnStrategy)
@@ -83,7 +83,7 @@ class SqlIdiomNamingSpec extends Spec {
       }
 
       db.run(q).string mustEqual
-        "SELECT t.c_somecolumn FROM some_entity t"
+        "SELECT t.c_somecolumn AS someColumn FROM some_entity t"
     }
     "do not apply strategy to select ident" in {
       val db = new SqlMirrorContext(MirrorSqlDialect, CustomDefaultStrategy)
@@ -92,7 +92,7 @@ class SqlIdiomNamingSpec extends Spec {
         query[SomeEntity].distinct
       }
       db.run(q.dynamic).string mustEqual
-        "SELECT DISTINCT x.d_somecolumn FROM d_someentity x"
+        "SELECT DISTINCT x.d_somecolumn AS someColumn FROM d_someentity x"
     }
 
     val db = new SqlMirrorContext(MirrorSqlDialect, SnakeCase)
@@ -117,7 +117,7 @@ class SqlIdiomNamingSpec extends Spec {
       "property empty check" in {
         case class SomeEntity(optionValue: Option[Int])
         db.run(query[SomeEntity].filter(t => t.optionValue.isEmpty)).string mustEqual
-          "SELECT t.option_value FROM some_entity t WHERE t.option_value IS NULL"
+          "SELECT t.option_value AS optionValue FROM some_entity t WHERE t.option_value IS NULL"
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -125,7 +125,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => (i.i, i.l)).distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT DISTINCT i.i, i.l FROM TestEntity i"
+            "SELECT DISTINCT i.i AS _1, i.l AS _2 FROM TestEntity i"
         }
 
         "caseclass constructor" in {
@@ -201,7 +201,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.s, t1.i FROM (SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t ORDER BY t.s ASC NULLS FIRST) AS t, (SELECT t1.s, t1.i, t1.l, t1.o FROM TestEntity2 t1 ORDER BY t1.i ASC NULLS FIRST) AS t1"
+            "SELECT t.s AS _1, t1.i AS _2 FROM (SELECT t.s, t.i, t.l, t.o, t.b FROM TestEntity t ORDER BY t.s ASC NULLS FIRST) AS t, (SELECT t1.s, t1.i, t1.l, t1.o FROM TestEntity2 t1 ORDER BY t1.i ASC NULLS FIRST) AS t1"
         }
         "asc" in {
           val q = quote {
@@ -268,7 +268,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i, COUNT(t.*) FROM TestEntity t GROUP BY t.i"
+            "SELECT t.i AS _1, COUNT(t.*) AS _2 FROM TestEntity t GROUP BY t.i"
         }
         "nested" in {
           val q = quote {
@@ -381,7 +381,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i, (COUNT(t.*)) + 1 FROM TestEntity t GROUP BY t.i"
+            "SELECT t.i AS _1, (COUNT(t.*)) + 1 AS _2 FROM TestEntity t GROUP BY t.i"
         }
       }
       "unary operation" - {
@@ -412,7 +412,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT a.s, b.i FROM (SELECT x.s, x.i, x.l, x.o, x.b FROM TestEntity x LIMIT 1) AS a, (SELECT x.s, x.i, x.l, x.o FROM TestEntity2 x LIMIT 2) AS b"
+            "SELECT a.s AS _1, b.i AS _2 FROM (SELECT x.s, x.i, x.l, x.o, x.b FROM TestEntity x LIMIT 1) AS a, (SELECT x.s, x.i, x.l, x.o FROM TestEntity2 x LIMIT 2) AS b"
         }
       }
       "union" - {
@@ -443,7 +443,7 @@ class SqlIdiomSpec extends Spec {
             j.union(j).map(u => (u._1.s, u._2.i))
           }
           testContext.run(q).string mustEqual
-            "SELECT u._1s, u._2i FROM ((SELECT a.s AS _1s, b.i AS _2i FROM TestEntity a, TestEntity2 b) UNION (SELECT a1.s AS _1s, b1.i AS _2i FROM TestEntity a1, TestEntity2 b1)) AS u"
+            "SELECT u._1s AS _1, u._2i AS _2 FROM ((SELECT a.s AS _1s, b.i AS _2i FROM TestEntity a, TestEntity2 b) UNION (SELECT a1.s AS _1s, b1.i AS _2i FROM TestEntity a1, TestEntity2 b1)) AS u"
         }
       }
       "unionAll" - {
@@ -513,7 +513,7 @@ class SqlIdiomSpec extends Spec {
               qr1.map(y => y.s).join(qr2).on((a, b) => a == b.s)
             }
             testContext.run(q).string mustEqual
-              "SELECT y.s, b.s, b.i, b.l, b.o FROM TestEntity y INNER JOIN TestEntity2 b ON y.s = b.s"
+              "SELECT y.s AS _1, b.s, b.i, b.l, b.o FROM TestEntity y INNER JOIN TestEntity2 b ON y.s = b.s"
           }
         }
       }
@@ -938,7 +938,7 @@ class SqlIdiomSpec extends Spec {
           qr1.map(t => (1, 2))
         }
         testContext.run(q).string mustEqual
-          "SELECT 1, 2 FROM TestEntity t"
+          "SELECT 1 AS _1, 2 AS _2 FROM TestEntity t"
       }
       "caseclass" in {
         case class TwoInts(one: Int, two: Int)
@@ -946,7 +946,7 @@ class SqlIdiomSpec extends Spec {
           qr1.map(t => new TwoInts(1, 2))
         }
         testContext.run(q).string mustEqual
-          "SELECT 1, 2 FROM TestEntity t"
+          "SELECT 1 AS one, 2 AS two FROM TestEntity t"
       }
       "caseclass companion" in {
         case class TwoInts(one: Int, two: Int)
@@ -954,14 +954,14 @@ class SqlIdiomSpec extends Spec {
           qr1.map(t => TwoInts(1, 2))
         }
         testContext.run(q).string mustEqual
-          "SELECT 1, 2 FROM TestEntity t"
+          "SELECT 1 AS one, 2 AS two FROM TestEntity t"
       }
       "caseclass companion class scope" in {
         val q = quote {
           qr1.map(t => TwoIntsClassScope(1, 2))
         }
         testContext.run(q).string mustEqual
-          "SELECT 1, 2 FROM TestEntity t"
+          "SELECT 1 AS one, 2 AS two FROM TestEntity t"
       }
     }
     "property" - {
@@ -1145,7 +1145,7 @@ class SqlIdiomSpec extends Spec {
           }
         }
         testContext.run(q).string mustEqual
-          "SELECT x.i, x.l, x.i * x.l FROM TestEntity x"
+          "SELECT x.i AS _1, x.l AS _2, x.i * x.l AS _3 FROM TestEntity x"
       }
       "nested" in {
         val q = quote {
@@ -1162,7 +1162,7 @@ class SqlIdiomSpec extends Spec {
           } yield (a, b, c, inner)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.s, a.i, a.l, a.o, a.b, b.s, b.i, b.l, b.o, t.s, t.i, t.l, t.o, 1 + t.i FROM TestEntity a, TestEntity2 b, TestEntity3 t WHERE a.i = b.i AND t.i = 1 AND b.i = t.i"
+          "SELECT a.s, a.i, a.l, a.o, a.b, b.s, b.i, b.l, b.o, t.s, t.i, t.l, t.o, 1 + t.i AS _4 FROM TestEntity a, TestEntity2 b, TestEntity3 t WHERE a.i = b.i AND t.i = 1 AND b.i = t.i"
       }
       "aggregated" in {
         val q = quote {
@@ -1175,7 +1175,7 @@ class SqlIdiomSpec extends Spec {
           }
         }
         testContext.run(q).string mustEqual
-          "SELECT (SELECT SUM(t.i) FROM TestEntity2 t), (SELECT SUM(t1.i) FROM TestEntity3 t1), (SELECT SUM((a.i + t2.i) + t3.i) FROM TestEntity2 t2, TestEntity3 t3) FROM TestEntity a"
+          "SELECT (SELECT SUM(t.i) FROM TestEntity2 t) AS _1, (SELECT SUM(t1.i) FROM TestEntity3 t1) AS _2, (SELECT SUM((a.i + t2.i) + t3.i) FROM TestEntity2 t2, TestEntity3 t3) AS _3 FROM TestEntity a"
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqliteDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqliteDialectSpec.scala
@@ -32,7 +32,7 @@ class SqliteDialectSpec extends OnConflictSpec {
 
   "transforms boolean literals into 0/1" in {
     ctx.run(qr1.map(t => (true, false))).string mustEqual
-      "SELECT 1, 0 FROM TestEntity t"
+      "SELECT 1 AS _1, 0 AS _2 FROM TestEntity t"
   }
 
   "OnConflict" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinComplexSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinComplexSpec.scala
@@ -18,7 +18,7 @@ class JoinComplexSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+      "SELECT ab._1s AS s, ab._1i AS i, ab._1l AS l, ab._1o AS o, ab._1b AS b, ab._2s AS s, ab._2i AS i, ab._2l AS l, ab._2o AS o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
   }
 
   "ExpandJoin should behave normally with: join + distinct + leftjoin - with additional filter" in {
@@ -31,7 +31,7 @@ class JoinComplexSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM (SELECT a.s, a.i, a.l, a.o, a.b FROM TestEntity a WHERE a.i = 1) AS a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+      "SELECT ab._1s AS s, ab._1i AS i, ab._1l AS l, ab._1o AS o, ab._1b AS b, ab._2s AS s, ab._2i AS i, ab._2l AS l, ab._2o AS o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM (SELECT a.s, a.i, a.l, a.o, a.b FROM TestEntity a WHERE a.i = 1) AS a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
   }
 
   "FlatJoin should function properly when plugged in with a shadow" - {
@@ -52,7 +52,7 @@ class JoinComplexSpec extends Spec {
 
     "using map" in {
       testContext.run(first(query[FooEntity].map(a => TestEntity(a.fs, a.fi, a.fl, a.fo, a.fb)))).string mustEqual
-        "SELECT a.fs, a.fi, a.fl, a.fo, a.fb, a1.s, a1.i, a1.l, a1.o FROM FooEntity a INNER JOIN TestEntity3 a1 ON a1.i = a.fi"
+        "SELECT a.fs AS s, a.fi AS i, a.fl AS l, a.fo AS o, a.fb AS b, a1.s, a1.i, a1.l, a1.o FROM FooEntity a INNER JOIN TestEntity3 a1 ON a1.i = a.fi"
     }
 
     val second = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.context.sql.norm
 import io.getquill.Spec
 import io.getquill.context.sql.testContext._
 import io.getquill.context.sql.testContext
+import io.getquill.context.sql.util.StringOps._
 
 class JoinSpec extends Spec {
 
@@ -34,7 +35,7 @@ class JoinSpec extends Spec {
         .filter(_._2.forall(_ == 1))
     }
     testContext.run(q).string mustEqual
-      "SELECT a.i, b.i FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i = 1"
+      "SELECT a.i AS _1, b.i AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i = 1"
   }
 
   "join + map + filter with null-check" in {
@@ -45,7 +46,7 @@ class JoinSpec extends Spec {
         .filter(_._2.forall(b => if (b == 1) true else false))
     }
     testContext.run(q).string mustEqual
-      "SELECT a.i, b.i FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i IS NOT NULL AND CASE WHEN b.i = 1 THEN true ELSE false END"
+      "SELECT a.i AS _1, b.i AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.i IS NULL OR b.i IS NOT NULL AND CASE WHEN b.i = 1 THEN true ELSE false END"
   }
 
   "join + filter + leftjoin" in {
@@ -60,8 +61,42 @@ class JoinSpec extends Spec {
           ab._2.map(_.i).contains(ab._1.i) && ab._2.map(_.i).contains(c.i)
       }
     }
-    testContext.run(q).string mustEqual
-      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+    testContext.run(q).string(true).collapseSpace mustEqual
+      """SELECT
+        |  ab._1s AS s,
+        |  ab._1i AS i,
+        |  ab._1l AS l,
+        |  ab._1o AS o,
+        |  ab._1b AS b,
+        |  ab._2s AS s,
+        |  ab._2i AS i,
+        |  ab._2l AS l,
+        |  ab._2o AS o,
+        |  c.s,
+        |  c.i,
+        |  c.l,
+        |  c.o
+        |FROM
+        |  (
+        |    SELECT
+        |      a.s AS _1s,
+        |      a.i AS _1i,
+        |      a.l AS _1l,
+        |      a.o AS _1o,
+        |      a.b AS _1b,
+        |      b.s AS _2s,
+        |      b.i AS _2i,
+        |      b.l AS _2l,
+        |      b.o AS _2o
+        |    FROM
+        |      TestEntity a
+        |      LEFT JOIN TestEntity2 b ON a.i = b.i
+        |    WHERE
+        |      b.l = 3
+        |  ) AS ab
+        |  LEFT JOIN TestEntity3 c ON ab._2i = ab._1i
+        |  AND ab._2i = c.i
+        |""".collapseSpace
   }
 
   "join + distinct + leftjoin" in {
@@ -73,8 +108,40 @@ class JoinSpec extends Spec {
           ab._2.map(_.i).contains(ab._1.i) && ab._2.map(_.i).contains(c.i)
       }
     }
-    testContext.run(q).string mustEqual
-      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._1b, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, a.b AS _1b, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
+    testContext.run(q).string(true).collapseSpace mustEqual
+      """SELECT
+        |  ab._1s AS s,
+        |  ab._1i AS i,
+        |  ab._1l AS l,
+        |  ab._1o AS o,
+        |  ab._1b AS b,
+        |  ab._2s AS s,
+        |  ab._2i AS i,
+        |  ab._2l AS l,
+        |  ab._2o AS o,
+        |  c.s,
+        |  c.i,
+        |  c.l,
+        |  c.o
+        |FROM
+        |  (
+        |    SELECT
+        |      DISTINCT a.s AS _1s,
+        |      a.i AS _1i,
+        |      a.l AS _1l,
+        |      a.o AS _1o,
+        |      a.b AS _1b,
+        |      b.s AS _2s,
+        |      b.i AS _2i,
+        |      b.l AS _2l,
+        |      b.o AS _2o
+        |    FROM
+        |      TestEntity a
+        |      LEFT JOIN TestEntity2 b ON a.i = b.i
+        |  ) AS ab
+        |  LEFT JOIN TestEntity3 c ON ab._2i = ab._1i
+        |  AND ab._2i = c.i
+        |""".collapseSpace
   }
 
   "multiple joins + filter + map + distinct" in {
@@ -91,7 +158,7 @@ class JoinSpec extends Spec {
         .distinct
     }
     testContext.run(q).string mustEqual
-      "SELECT DISTINCT a.s, d.l, n.i FROM TestEntity d INNER JOIN TestEntity2 a ON d.i = a.i INNER JOIN (SELECT rp.i, rp.l FROM TestEntity3 rp WHERE rp.s = ?) AS rp ON d.i = rp.i LEFT JOIN TestEntity4 n ON rp.l = n.i"
+      "SELECT DISTINCT a.s AS _1, d.l AS _2, n.i AS _3 FROM TestEntity d INNER JOIN TestEntity2 a ON d.i = a.i INNER JOIN (SELECT rp.i, rp.l FROM TestEntity3 rp WHERE rp.s = ?) AS rp ON d.i = rp.i LEFT JOIN TestEntity4 n ON rp.l = n.i"
   }
 
   "multiple joins + map" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -29,7 +29,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         tup.map(t => (t._1, t._2))
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT t.field_s, t._2 FROM test_tuple t"
+        "SELECT t.field_s AS _1, t._2 FROM test_tuple t"
     }
     "mapped to caseclass and filtered" in {
       case class StringInt(strProp: String, intProp: Int)
@@ -37,7 +37,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         tup.map(t => new StringInt(t._1, t._2)).filter(_.strProp == "foo")
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT t.field_s, t._2 FROM test_tuple t WHERE t.field_s = 'foo'"
+        "SELECT t.field_s AS strProp, t._2 AS intProp FROM test_tuple t WHERE t.field_s = 'foo'"
     }
   }
 
@@ -98,7 +98,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.flatMap(t => qr2.filter(u => u.s == t.s))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT u.S, u.I, u.L, u.O FROM test_entity t, TESTENTITY2 u WHERE u.S = t.field_s"
+          "SELECT u.S AS s, u.I AS i, u.L AS l, u.O AS o FROM test_entity t, TESTENTITY2 u WHERE u.S = t.field_s"
       }
       "transitive" in {
         val q = quote {
@@ -117,7 +117,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           }
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_s, a.field_i, a.L, a.O, a.B, b.S, b.I, b.L, b.O FROM test_entity a, TESTENTITY2 b WHERE a.field_s = b.S"
+          "SELECT a.field_s, a.field_i, a.L AS l, a.O AS o, a.B AS b, b.S AS s, b.I AS i, b.L AS l, b.O AS o FROM test_entity a, TESTENTITY2 b WHERE a.field_s = b.S"
       }
     }
     "concatMap" in {
@@ -133,7 +133,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.map(t => (t.i, t.l))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_i, t.L FROM test_entity t"
+          "SELECT t.field_i AS _1, t.L AS _2 FROM test_entity t"
       }
       "body with caseclass" in {
         case class IntLongCase(im: Int, lm: Long)
@@ -141,7 +141,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.map(t => new IntLongCase(t.i, t.l))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_i, t.L FROM test_entity t"
+          "SELECT t.field_i AS im, t.L AS lm FROM test_entity t"
       }
       "body with caseclass companion constructed" in {
         case class IntLongCase(im: Int, lm: Long)
@@ -149,21 +149,21 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.map(t => IntLongCase(t.i, t.l))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_i, t.L FROM test_entity t"
+          "SELECT t.field_i AS im, t.L AS lm FROM test_entity t"
       }
       "body with caseclass companion in class scope" in {
         val q = quote {
           e.map(t => IntLongCaseClassScope(t.i, t.l))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_i, t.L FROM test_entity t"
+          "SELECT t.field_i AS im, t.L AS lm FROM test_entity t"
       }
       "transitive" in {
         val q = quote {
           e.map(t => t).filter(t => t.i == 1)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_s, t.field_i, t.L, t.O, t.B FROM test_entity t WHERE t.field_i = 1"
+          "SELECT t.field_s, t.field_i, t.L AS l, t.O AS o, t.B AS b FROM test_entity t WHERE t.field_i = 1"
       }
     }
     "filter" - {
@@ -172,7 +172,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.filter(t => t.i == 1)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_s, t.field_i, t.L, t.O, t.B FROM test_entity t WHERE t.field_i = 1"
+          "SELECT t.field_s, t.field_i, t.L AS l, t.O AS o, t.B AS b FROM test_entity t WHERE t.field_i = 1"
       }
       "transitive" in {
         val q = quote {
@@ -188,7 +188,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.sortBy(t => t.i)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT t.field_s, t.field_i, t.L, t.O, t.B FROM test_entity t ORDER BY t.field_i ASC NULLS FIRST"
+          "SELECT t.field_s, t.field_i, t.L AS l, t.O AS o, t.B AS b FROM test_entity t ORDER BY t.field_i ASC NULLS FIRST"
       }
       "transitive" in {
         val q = quote {
@@ -204,7 +204,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.take(1)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.L, x.O, x.B FROM test_entity x LIMIT 1"
+          "SELECT x.field_s, x.field_i, x.L AS l, x.O AS o, x.B AS b FROM test_entity x LIMIT 1"
       }
       "transitive" in {
         val q = quote {
@@ -220,7 +220,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.drop(1)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.L, x.O, x.B FROM test_entity x OFFSET 1"
+          "SELECT x.field_s, x.field_i, x.L AS l, x.O AS o, x.B AS b FROM test_entity x OFFSET 1"
       }
       "transitive" in {
         val q = quote {
@@ -231,12 +231,12 @@ class RenamePropertiesOverrideSpec extends Spec {
       }
     }
     "distinct" - {
-      "body" in { //hello
+      "body" in {
         val q = quote {
           e.distinct
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT DISTINCT x.field_s, x.field_i, x.L, x.O, x.B FROM test_entity x"
+          "SELECT DISTINCT x.field_s, x.field_i, x.L AS l, x.O AS o, x.B AS b FROM test_entity x"
       }
       "transitive" in {
         val q = quote {
@@ -253,7 +253,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.leftJoin(e).on((a, b) => a.s == b.s).map(t => (t._1.s, t._2.map(_.s)))
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_s, b.field_s FROM test_entity a LEFT JOIN test_entity b ON a.field_s = b.field_s"
+          "SELECT a.field_s AS _1, b.field_s AS _2 FROM test_entity a LEFT JOIN test_entity b ON a.field_s = b.field_s"
       }
       "inner" in {
         val q = quote {
@@ -284,7 +284,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           } yield (x.s, x.i)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT b.field_s, b.field_i FROM TESTENTITY2 a INNER JOIN test_entity b ON a.S = b.field_s"
+          "SELECT b.field_s AS _1, b.field_i AS _2 FROM TESTENTITY2 a INNER JOIN test_entity b ON a.S = b.field_s"
       }
       "flat left" in {
         val q = quote {
@@ -294,7 +294,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           } yield x.map(x => x.i -> x.s)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT b.field_i, b.field_s FROM TESTENTITY2 a LEFT JOIN test_entity b ON a.S = b.field_s"
+          "SELECT b.field_i AS _1, b.field_s AS _2 FROM TESTENTITY2 a LEFT JOIN test_entity b ON a.S = b.field_s"
       }
       "flat right" in {
         val q = quote {
@@ -304,7 +304,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           } yield x.map(x => x.i -> x.s)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT b.field_i, b.field_s FROM TESTENTITY2 a RIGHT JOIN test_entity b ON a.S = b.field_s"
+          "SELECT b.field_i AS _1, b.field_s AS _2 FROM TESTENTITY2 a RIGHT JOIN test_entity b ON a.S = b.field_s"
       }
     }
 
@@ -316,24 +316,24 @@ class RenamePropertiesOverrideSpec extends Spec {
           }
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_s, SUM(a.field_i) FROM test_entity a GROUP BY a.field_s"
+          "SELECT a.field_s AS _1, SUM(a.field_i) AS _2 FROM test_entity a GROUP BY a.field_s"
       }
     }
 
-    "operation" - { //
+    "operation" - {
       "unary" in {
         val q: Quoted[EntityQuery[Index]] = quote {
           e.filter(a => e.filter(b => b.i > 0).isEmpty).map(_.i)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.field_s, b.field_i, b.L, b.O, b.B FROM test_entity b WHERE b.field_i > 0)"
+          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.field_s, b.field_i, b.L AS l, b.O AS o, b.B AS b FROM test_entity b WHERE b.field_i > 0)"
       }
       "binary" in {
         val q = quote {
           e.filter(a => e.filter(b => b.i > 0).isEmpty && a.s == "test").map(_.i)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.field_s, b.field_i, b.L, b.O, b.B FROM test_entity b WHERE b.field_i > 0) AND a.field_s = 'test'"
+          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.field_s, b.field_i, b.L AS l, b.O AS o, b.B AS b FROM test_entity b WHERE b.field_i > 0) AND a.field_s = 'test'"
       }
       "query body" in {
         val q = quote {
@@ -351,7 +351,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         case class B(c: Int) extends Embedded
         case class A(b: B)
         testContextUpper.run(query[A]).string mustEqual
-          "SELECT x.C FROM A x"
+          "SELECT x.C AS c FROM A x"
       }
       "with schema" in {
         case class B(c: Int) extends Embedded
@@ -368,7 +368,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         case class B(c1: Int, c2: Int) extends Embedded
         case class A(b: Option[B])
         testContextUpper.run(query[A]).string mustEqual
-          "SELECT x.C1, x.C2 FROM A x"
+          "SELECT x.C1 AS c1, x.C2 AS c2 FROM A x"
       }
       "with schema" in {
         case class B(c1: Int, c2: Int) extends Embedded
@@ -430,7 +430,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         }
 
         testContextUpper.run(q).string mustEqual
-          "SELECT x.U, x.m, x.n FROM C x LIMIT 10"
+          "SELECT x.U AS u, x.m, x.n FROM C x LIMIT 10"
       }
       "with filter" in {
         val q = quote {
@@ -438,7 +438,7 @@ class RenamePropertiesOverrideSpec extends Spec {
         }
 
         testContextUpper.run(q).string mustEqual
-          "SELECT x.U, x.m, x.n FROM C x WHERE x.m = 1 LIMIT 10"
+          "SELECT x.U AS u, x.m, x.n FROM C x WHERE x.m = 1 LIMIT 10"
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -37,7 +37,7 @@ class RenamePropertiesSpec extends Spec {
         tup.map(t => (t._1, t._2))
       }
       testContext.run(q).string mustEqual
-        "SELECT t.field_s, t.field_i FROM test_tuple t"
+        "SELECT t.field_s AS _1, t.field_i AS _2 FROM test_tuple t"
     }
     "mapped to caseclass and filtered" in {
       case class StringInt(strProp: String, intProp: Int)
@@ -45,7 +45,7 @@ class RenamePropertiesSpec extends Spec {
         tup.map(t => new StringInt(t._1, t._2)).filter(_.strProp == "foo")
       }
       testContext.run(q).string mustEqual
-        "SELECT t.field_s, t.field_i FROM test_tuple t WHERE t.field_s = 'foo'"
+        "SELECT t.field_s AS strProp, t.field_i AS intProp FROM test_tuple t WHERE t.field_s = 'foo'"
     }
   }
 
@@ -141,7 +141,7 @@ class RenamePropertiesSpec extends Spec {
           e.map(t => (t.i, t.l))
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_i, t.l FROM test_entity t"
+          "SELECT t.field_i AS _1, t.l AS _2 FROM test_entity t"
       }
       "body with caseclass" in {
         case class IntLongCase(im: Int, lm: Long)
@@ -149,7 +149,7 @@ class RenamePropertiesSpec extends Spec {
           e.map(t => new IntLongCase(t.i, t.l))
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_i, t.l FROM test_entity t"
+          "SELECT t.field_i AS im, t.l AS lm FROM test_entity t"
       }
       "body with caseclass companion constructed" in {
         case class IntLongCase(im: Int, lm: Long)
@@ -157,14 +157,14 @@ class RenamePropertiesSpec extends Spec {
           e.map(t => IntLongCase(t.i, t.l))
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_i, t.l FROM test_entity t"
+          "SELECT t.field_i AS im, t.l AS lm FROM test_entity t"
       }
       "body with caseclass companion in class scope" in {
         val q = quote {
           e.map(t => IntLongCaseClassScope(t.i, t.l))
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_i, t.l FROM test_entity t"
+          "SELECT t.field_i AS im, t.l AS lm FROM test_entity t"
       }
       "transitive" in {
         val q = quote {
@@ -275,7 +275,7 @@ class RenamePropertiesSpec extends Spec {
           e.leftJoin(e).on((a, b) => a.s == b.s).map(t => (t._1.s, t._2.map(_.s)))
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s, b.field_s FROM test_entity a LEFT JOIN test_entity b ON a.field_s = b.field_s"
+          "SELECT a.field_s AS _1, b.field_s AS _2 FROM test_entity a LEFT JOIN test_entity b ON a.field_s = b.field_s"
       }
       "inner" in {
         val q = quote {
@@ -306,7 +306,7 @@ class RenamePropertiesSpec extends Spec {
           } yield (x.s, x.i)
         }
         testContext.run(q).string mustEqual
-          "SELECT b.field_s, b.field_i FROM TestEntity2 a INNER JOIN test_entity b ON a.s = b.field_s"
+          "SELECT b.field_s AS _1, b.field_i AS _2 FROM TestEntity2 a INNER JOIN test_entity b ON a.s = b.field_s"
       }
       "flat left" in {
         val q = quote {
@@ -316,7 +316,7 @@ class RenamePropertiesSpec extends Spec {
           } yield x.map(x => x.i -> x.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT b.field_i, b.field_s FROM TestEntity2 a LEFT JOIN test_entity b ON a.s = b.field_s"
+          "SELECT b.field_i AS _1, b.field_s AS _2 FROM TestEntity2 a LEFT JOIN test_entity b ON a.s = b.field_s"
       }
       "flat right" in {
         val q = quote {
@@ -326,7 +326,7 @@ class RenamePropertiesSpec extends Spec {
           } yield x.map(x => x.i -> x.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT b.field_i, b.field_s FROM TestEntity2 a RIGHT JOIN test_entity b ON a.s = b.field_s"
+          "SELECT b.field_i AS _1, b.field_s AS _2 FROM TestEntity2 a RIGHT JOIN test_entity b ON a.s = b.field_s"
       }
       "nested flatMap in flatJoin" in {
 
@@ -360,7 +360,7 @@ class RenamePropertiesSpec extends Spec {
           }
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s, SUM(a.field_i) FROM test_entity a GROUP BY a.field_s"
+          "SELECT a.field_s AS _1, SUM(a.field_i) AS _2 FROM test_entity a GROUP BY a.field_s"
       }
     }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/SheathLeafClausesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/SheathLeafClausesSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.sql.norm
 
 import io.getquill.norm.SheathLeafClauses
-import io.getquill.{ MirrorSqlDialect, Query, SnakeCase, Spec, SqlMirrorContext }
+import io.getquill.{ MirrorSqlDialect, Query, Quoted, SnakeCase, Spec, SqlMirrorContext }
 
 class SheathLeafClausesSpec extends Spec {
 
@@ -101,12 +101,13 @@ class SheathLeafClausesSpec extends Spec {
 
       // Technically this worked before SheathLeafClauses was introduced but this kind of query is impacted so test it here
       "concatMap(leaf).join(concatMap(leaf))" in {
-        val q = quote(
+        val q: Quoted[Query[(String, String)]] = quote(
           query[Person]
             .concatMap(p => p.firstName.split(" "))
             .join(query[Person].concatMap(t => t.firstName.split(" ")))
             .on { case (a, b) => a == b }
         )
+        // TODO star idenfiers should not have aliases
         ctx.run(q).string mustEqual "SELECT x01.*, x11.* FROM (SELECT UNNEST(SPLIT(p.first_name, ' ')) AS x FROM person p) AS x01 INNER JOIN (SELECT UNNEST(SPLIT(t.first_name, ' ')) AS x FROM person t) AS x11 ON x01.x = x11.x"
       }
 


### PR DESCRIPTION
All top-level selects should have a alias but in the case of a nested (i.e. embedded object) only the last element will be used.
For example:
```scala
case class Name(first: String, last: String)
case class Person(name: Name, age: Int)

run(query[Person])
// SELECT p.first, p.last, p.age FROM Person p
```
In situations where things are re-wrapped in tuples, this will be resolved based on the name of the innermost property name of the thing in which each field is coming from:
```scala
run(query[Person].map(p => (p.name.first, p.name.last, p.age))
// SELECT p.first AS _1, p.last AS _2, p.age AS _3 FROM Person p
```
This applies with nested objects that are mapped as well. For example if Name is nested within an output tuple, the "last path element" of both `p.first` and `p.last` will be what they are in the Name object:
```scala
run(query[Person].map(p => (p.name, p.age))
// SELECT p.first AS first, p.last AS last, p.age AS _2 FROM Person p
// (age is AS _2 because it is a value-level thing that gets wrapped into a tuple)
// since aliases are redundant it gets simplified to:
// SELECT p.first, p.last, p.age AS _2 FROM Person p
```
In subselects this gets a bit more complex because subselect aliases have to be unique (e.g. imagine if the Name property appeared twice) so in order to know which one is which we propagate the whole path from in the nested object. That means that on the top level this must be re-aliased back into the last path element:
```scala
run(query[Person].map(p => (p.name, p.age).nested)
// SELECT p.namefirst AS FIRST, p.namelast as LAST, p.age AS _2 FROM (SELECT x.first AS namefirst, x.last AS namelast, x.age FROM Person p) AS p
```