### PR TITLE
Fix Spark Test Context

### DIFF
--- a/quill-spark/src/test/scala/io/getquill/context/spark/package.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/package.scala
@@ -10,7 +10,8 @@ package object spark {
       .builder()
       .config("spark.sql.shuffle.partitions", 2) // Default shuffle partitions is 200, too much for tests
       .config("spark.ui.enabled", "false")
-      .master("local[1]")
+      .config("spark.driver.bindAddress", "127.0.0.1")
+      .master("local[*]")
       .appName("spark test")
       .getOrCreate()
 


### PR DESCRIPTION
Getting exceptions from spark intermittently:
```
Exception in thread "main" java.net.BindException: Can't assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.
    at sun.nio.ch.Net.bind0(Native Method)
    at sun.nio.ch.Net.bind(Net.java:433)
    at sun.nio.ch.Net.bind(Net.java:425)
```
Looking at solutions here: https://stackoverflow.com/questions/52133731/how-to-solve-cant-assign-requested-address-service-sparkdriver-failed-after

Trying to apply.