### PR TITLE
Revert to old pprint due to upstream Scalafmt compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,7 +249,7 @@ lazy val `quill-engine` =
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "com.lihaoyi" %%% "pprint" % "0.7.1",
+        "com.lihaoyi" %%% "pprint" % "0.6.6",
         "org.scala-js" %%% "scalajs-java-time" % "1.0.0",
         "org.scala-lang.modules" %%% "scala-collection-compat" % "2.2.0"
       ) ++ {
@@ -278,7 +278,7 @@ lazy val `quill-core` =
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "com.lihaoyi" %%% "pprint" % "0.7.1"
+        "com.lihaoyi" %%% "pprint" % "0.6.6"
       ),
       unmanagedSources / excludeFilter := new SimpleFileFilter(file => file.getName == "DynamicQuerySpec.scala"),
       coverageExcludedPackages := ".*"
@@ -816,7 +816,7 @@ lazy val basicSettings = Seq(
   scalaVersion := scala_v_12,
   crossScalaVersions := Seq(scala_v_11, scala_v_12, scala_v_13, scala_v_30),
   libraryDependencies ++= Seq(
-    "com.lihaoyi"     %% "pprint"         % "0.7.1",
+    "com.lihaoyi"     %% "pprint"         % "0.6.6",
     "org.scalatest"   %%% "scalatest"     % "3.2.10"          % Test,
     "com.google.code.findbugs" % "jsr305" % "3.0.2"          % Provided // just to avoid warnings during compilation
   ) ++ {

--- a/quill-engine/src/main/scala/io/getquill/norm/SheathLeafClauses.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/SheathLeafClauses.scala
@@ -1,6 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.{ Aggregation, Ast, CaseClass, ConcatMap, Distinct, Filter, FlatMap, GroupBy, Ident, Join, Map, Property, Query, StatefulTransformerWithStack, Tuple, Union, UnionAll }
+import io.getquill.ast.{ Aggregation, Ast, CaseClass, ConcatMap, Distinct, Filter, FlatMap, GroupBy, Ident, Join, Map, Property, Query, StatefulTransformerWithStack, Union, UnionAll }
 import io.getquill.ast.Ast.LeafQuat
 import io.getquill.ast.StatefulTransformerWithStack.History
 import io.getquill.util.Interpolator


### PR DESCRIPTION
Scalafmt latest as of now is 3.3.3 which uses pprint 0.6.6. Can't use 0.7.1 or failures will happen in protoquill which now imports quill-engine.