### PR TITLE
Fix Infix Ast Quat issues

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -320,17 +320,17 @@ trait Parsing extends ValueComputation with QuatMaking {
 
   val infixParser: Parser[Ast] = Parser[Ast] {
     case q"$infix.pure.asCondition" =>
-      combinedInfixParser(true, Quat.BooleanExpression)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, Quat.BooleanExpression)(infix))
     case q"$infix.asCondition" =>
-      combinedInfixParser(false, Quat.BooleanExpression)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(false, Quat.BooleanExpression)(infix))
     case q"$infix.generic.pure.as[$t]" =>
-      combinedInfixParser(true, Quat.Generic)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, Quat.Generic)(infix))
     case q"$infix.pure.as[$t]" =>
-      combinedInfixParser(true, inferQuat(q"$t".tpe))(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, inferQuat(q"$t".tpe))(infix))
     case q"$infix.as[$t]" =>
-      combinedInfixParser(false, inferQuat(q"$t".tpe))(infix)
+      Quat.improveInfixQuat(combinedInfixParser(false, inferQuat(q"$t".tpe))(infix))
     case `impureInfixParser`(value) =>
-      value
+      Quat.improveInfixQuat(value)
   }
 
   val impureInfixParser = combinedInfixParser(false, Quat.Value) // TODO Verify Quat in what cases does this come up?

--- a/quill-engine/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-engine/src/main/scala/io/getquill/AstPrinter.scala
@@ -53,6 +53,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
       }
     def withQuat(q: Quat): treemake = toContent.andWith(treemake.Quat(q))
     def withTree(t: pprint.Tree): treemake = toContent.andWith(treemake.Tree(t))
+    def withElem(a: Any): treemake = toContent.andWith(treemake.Elem(a))
     private def treeifyList: List[Tree] =
       toContent.list.flatMap {
         case e: treemake.Quat =>
@@ -61,11 +62,11 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
             case QuatTrace.Short                => List(Tree.Literal(e.q.shortString.take(10)))
             case QuatTrace.None                 => List()
           }
-        case treemake.Elem(value)   => List(pprint.treeify(value))
+        case treemake.Elem(value)   => List(treeify(value))
         case treemake.Tree(value)   => List(value)
         case treemake.Content(list) => list.flatMap(_.treeifyList)
       }
-    def treeify: Iterator[Tree] = treeifyList.iterator
+    def make: Iterator[Tree] = treeifyList.iterator
   }
   private object treemake {
     private case class Quat(q: io.getquill.quat.Quat) extends treemake
@@ -91,14 +92,17 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
         Tree.Literal("" + past) // Do not blow up if it is null
 
       case i: Ident =>
-        Tree.Apply("Id", treemake(i.name).withQuat(i.bestQuat).treeify)
+        Tree.Apply("Id", treemake(i.name).withQuat(i.bestQuat).make)
+
+      case i: Infix =>
+        Tree.Apply("Infix", treemake(i.parts).withElem(treemake(i.params)).withQuat(i.bestQuat).make)
 
       case e: Entity if (!traceOpinions) =>
-        Tree.Apply("Entity", treemake(e.name, e.properties).withQuat(e.bestQuat).treeify)
+        Tree.Apply("Entity", treemake(e.name, e.properties).withQuat(e.bestQuat).make)
 
       case q: Quat            => Tree.Literal(q.shortString)
 
-      case s: ScalarValueLift => Tree.Apply("ScalarValueLift", treemake("..." + s.name.reverse.take(15).reverse).withQuat(s.bestQuat).treeify)
+      case s: ScalarValueLift => Tree.Apply("ScalarValueLift", treemake("..." + s.name.reverse.take(15).reverse).withQuat(s.bestQuat).make)
 
       case p: Property if (traceOpinions) =>
         TreeApplyList("Property", l(treeify(p.ast)) ++ l(treeify(p.name)) ++
@@ -116,7 +120,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
             ))
 
       case e: Entity if (traceOpinions) =>
-        Tree.Apply("Entity", treemake(e.name, e.properties).withTree(printRenameable(e.renameable)).withQuat(e.bestQuat).treeify)
+        Tree.Apply("Entity", treemake(e.name, e.properties).withTree(printRenameable(e.renameable)).withQuat(e.bestQuat).make)
 
       case ast: Ast =>
         if (traceAllQuats)

--- a/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -1,6 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.{ Action, Assignment, AssignmentDual, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
+import io.getquill.ast.{ Action, Assignment, AssignmentDual, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Infix, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
 import io.getquill.quat.Quat
 import io.getquill.quat.Quat.Product
 import io.getquill.util.Interpolator
@@ -63,6 +63,14 @@ object RepropagateQuats extends StatelessTransformer {
     val cr = BetaReduction(c, RWR, b -> br)
     trace"Repropagate ${a.quat.suppress(msg)} from ${a} into:" andReturn f(ar, br, apply(cr))
   }
+
+  override def apply(e: Ast): Ast =
+    e match {
+      case Infix(parts, params, pure, quat) =>
+        val newParams = params.map(apply)
+        Quat.improveInfixQuat(Infix(parts, newParams, pure, quat))
+      case _ => super.apply(e)
+    }
 
   override def apply(e: Query): Query = {
     e match {

--- a/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
@@ -1,6 +1,6 @@
 package io.getquill.quat
 
-import io.getquill.ast.Ast
+import io.getquill.ast.{ Ast, Infix }
 import io.getquill.quotation.QuatException
 import io.getquill.util.Messages.TraceType
 
@@ -155,6 +155,21 @@ object Quat {
   object Is {
     def unapply(ast: Ast) = Some(ast.quat)
   }
+
+  def improveInfixQuat(ast: Ast) =
+    ast match {
+      case Infix(parts, params, pure, Quat.Generic | Quat.Unknown) =>
+        val possiblyBetterQuat = params.foldLeft(Quat.Generic: Quat)((currQuat, param) => currQuat.leastUpperType(param.quat).getOrElse(currQuat))
+        val bestQuat =
+          possiblyBetterQuat match {
+            case Quat.Unknown => Quat.Unknown
+            case Quat.Value   => Quat.Generic
+            case other        => other
+          }
+        Infix(parts, params, pure, bestQuat)
+      case _ =>
+        ast
+    }
 
   import LinkedHashMapOps._
 

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
@@ -1,0 +1,46 @@
+package io.getquill.quat
+
+import io.getquill._
+
+class QuatRunSpec extends Spec {
+
+  val testContext = new SqlMirrorContext(PostgresDialect, Literal)
+  import testContext._
+
+  "should refine quats from generic infixes and express during execution" - {
+    case class MyPerson(name: String, age: Int)
+    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
+
+    "from extension methods" in {
+      implicit class QueryOps[Q <: Query[_]](q: Q) {
+        def appendFoo = quote(infix"$q APPEND FOO".pure.as[Q])
+      }
+      val q = quote(query[MyPerson].appendFoo)
+      q.ast.quat mustEqual MyPersonQuat // I.e ReifyLiftings runs RepropagateQuats to take care of this
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "from extension methods - generic marker" in {
+      implicit class QueryOps[Q <: Query[_]](q: Q) {
+        def appendFoo = quote(infix"$q APPEND FOO".generic.pure.as[Q])
+      }
+      val q = quote(query[MyPerson].appendFoo)
+      q.ast.quat mustEqual MyPersonQuat // I.e ReifyLiftings runs RepropagateQuats to take care of this
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "should support query-ops function" in {
+      def appendFooFun[Q <: Query[_]]: Quoted[Q => Q] = quote { (q: Q) => infix"$q APPEND FOO".pure.as[Q] }
+      val q = quote(appendFooFun(query[MyPerson]))
+      q.ast.quat mustEqual Quat.Unknown
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "should support query-ops function - dynamic function" in {
+      def appendFooFun[Q <: Query[_]] = quote { (q: Q) => infix"$q APPEND FOO".pure.as[Q] }
+      val q = quote(appendFooFun(query[MyPerson]))
+      q.ast.quat mustEqual MyPersonQuat
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+  }
+}


### PR DESCRIPTION
Issue where infix query that produced Quat.Unknown (or Quat.Generic) would cause wrong query expansion (i.e. a `x.*`) which could cause encoder issues.

Basically it's just this:
```scala
implicit class QueryOps[Q <: Query[_]](q: Q) {
  def appendFoo = quote(infix"$q APPEND FOO".pure.as[Q])
}

val q = quote(query[MyPerson].appendFoo)
q.ast // Infix(List("", "appendFoo"), List(Entity("MyPerson", CC(name:V,age:V)), true, <U>)
```
Note that despite the fact that Entity has the right Quat, the quat of q.ast is Unknown (i.e. `<U>`. Need to modify various phases to check what quats things inside of Infix have (if the infix's Quat is Generic and update the Infix's Quat).

This was encountered by a quill-cassandra-zio example:
```scala
case class EntityRow(
  entityType: String,
  tenantId: String,
  openId: String,
  stages: Map[String, EntityStage],
  createTime: Instant,
  updateTime: Instant,
  deleteTime: Option[Instant]
)

object MyCassandraZioContext extends CassandraZioContext(SnakeCase) {
  implicit class InstantOps(dt: Instant) {

    val >= = quote { (right: Instant) =>
      infix"$dt >= $right".as[Boolean]
    }

    val < = quote { (right: Instant) =>
      infix"$dt < $right".as[Boolean]
    }

  }

  implicit class QueryOps[Q <: Query[_]](q: Q) {
    def allowFiltering = quote(infix"$q ALLOW FILTERING".generic.pure.as[Q])
  }
}

val query: CStream[EntityRow] = 
  querySchema[EntityRow]("entity")
      .filter(_.tenantId == lift(tenantId))
      .filter(_.entityType == lift(entityType))
      .filter(_.updateTime >= lift(updateStart))
      .filter(_.updateTime < lift(updateEnd))
      .allowFiltering
```
It cause the following exception:
```
com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException: Codec not found for requested operation: [TIMESTAMP <-> java.util.Map<java.lang.String, com.datastax.oss.driver.api.core.data.UdtValue>]
```