### PR TITLE
Change Quat-Verification to Strict in build. Fix Spark failure cases.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -23,7 +23,7 @@ export CASSANDRA_DC=datacenter1
 export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
-export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$SCALA_VERSION -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+export JVM_OPTS="-Dquill.macro.log=false -Dquill.quat.strict=true -Dquill.scala.version=$SCALA_VERSION -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 modules=$1
 echo "Start build modules: $modules"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -320,17 +320,17 @@ trait Parsing extends ValueComputation with QuatMaking {
 
   val infixParser: Parser[Ast] = Parser[Ast] {
     case q"$infix.pure.asCondition" =>
-      combinedInfixParser(true, Quat.BooleanExpression)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, Quat.BooleanExpression)(infix))
     case q"$infix.asCondition" =>
-      combinedInfixParser(false, Quat.BooleanExpression)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(false, Quat.BooleanExpression)(infix))
     case q"$infix.generic.pure.as[$t]" =>
-      combinedInfixParser(true, Quat.Generic)(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, Quat.Generic)(infix))
     case q"$infix.pure.as[$t]" =>
-      combinedInfixParser(true, inferQuat(q"$t".tpe))(infix)
+      Quat.improveInfixQuat(combinedInfixParser(true, inferQuat(q"$t".tpe))(infix))
     case q"$infix.as[$t]" =>
-      combinedInfixParser(false, inferQuat(q"$t".tpe))(infix)
+      Quat.improveInfixQuat(combinedInfixParser(false, inferQuat(q"$t".tpe))(infix))
     case `impureInfixParser`(value) =>
-      value
+      Quat.improveInfixQuat(value)
   }
 
   val impureInfixParser = combinedInfixParser(false, Quat.Value) // TODO Verify Quat in what cases does this come up?

--- a/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -36,6 +36,20 @@ class QuatSpec extends Spec {
     case class MyPerson(name: String, age: Int)
     val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
 
+    "abstract quat" in {
+      trait AbstractPerson { def name: String }
+      case class MyPerson(name: String, age: Int) extends AbstractPerson
+      def personName = quote {
+        (p: AbstractPerson) => p.name
+      }
+      def passFilter = quote {
+        (q: Query[AbstractPerson], f: AbstractPerson => String) => q.filter(p => f(p) == "Joe")
+      }
+
+      val p = quote(passFilter(query[MyPerson], personName).map(p => infix"${p}".pure.as[{ def age: Int }].age))
+      println(p.ast.quat)
+    }
+
     "from extension methods" in {
       implicit class QueryOps[Q <: Query[_]](q: Q) {
         def appendFoo = quote(infix"$q APPEND FOO".pure.as[Q])

--- a/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -36,20 +36,6 @@ class QuatSpec extends Spec {
     case class MyPerson(name: String, age: Int)
     val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
 
-    "abstract quat" in {
-      trait AbstractPerson { def name: String }
-      case class MyPerson(name: String, age: Int) extends AbstractPerson
-      def personName = quote {
-        (p: AbstractPerson) => p.name
-      }
-      def passFilter = quote {
-        (q: Query[AbstractPerson], f: AbstractPerson => String) => q.filter(p => f(p) == "Joe")
-      }
-
-      val p = quote(passFilter(query[MyPerson], personName).map(p => infix"${p}".pure.as[{ def age: Int }].age))
-      println(p.ast.quat)
-    }
-
     "from extension methods" in {
       implicit class QueryOps[Q <: Query[_]](q: Q) {
         def appendFoo = quote(infix"$q APPEND FOO".pure.as[Q])

--- a/quill-engine/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-engine/src/main/scala/io/getquill/AstPrinter.scala
@@ -53,6 +53,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
       }
     def withQuat(q: Quat): treemake = toContent.andWith(treemake.Quat(q))
     def withTree(t: pprint.Tree): treemake = toContent.andWith(treemake.Tree(t))
+    def withElem(a: Any): treemake = toContent.andWith(treemake.Elem(a))
     private def treeifyList: List[Tree] =
       toContent.list.flatMap {
         case e: treemake.Quat =>
@@ -61,11 +62,11 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
             case QuatTrace.Short                => List(Tree.Literal(e.q.shortString.take(10)))
             case QuatTrace.None                 => List()
           }
-        case treemake.Elem(value)   => List(pprint.treeify(value))
+        case treemake.Elem(value)   => List(treeify(value))
         case treemake.Tree(value)   => List(value)
         case treemake.Content(list) => list.flatMap(_.treeifyList)
       }
-    def treeify: Iterator[Tree] = treeifyList.iterator
+    def make: Iterator[Tree] = treeifyList.iterator
   }
   private object treemake {
     private case class Quat(q: io.getquill.quat.Quat) extends treemake
@@ -91,14 +92,17 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
         Tree.Literal("" + past) // Do not blow up if it is null
 
       case i: Ident =>
-        Tree.Apply("Id", treemake(i.name).withQuat(i.bestQuat).treeify)
+        Tree.Apply("Id", treemake(i.name).withQuat(i.bestQuat).make)
+
+      case i: Infix =>
+        Tree.Apply("Infix", treemake(i.parts).withElem(treemake(i.params)).withQuat(i.bestQuat).make)
 
       case e: Entity if (!traceOpinions) =>
-        Tree.Apply("Entity", treemake(e.name, e.properties).withQuat(e.bestQuat).treeify)
+        Tree.Apply("Entity", treemake(e.name, e.properties).withQuat(e.bestQuat).make)
 
       case q: Quat            => Tree.Literal(q.shortString)
 
-      case s: ScalarValueLift => Tree.Apply("ScalarValueLift", treemake("..." + s.name.reverse.take(15).reverse).withQuat(s.bestQuat).treeify)
+      case s: ScalarValueLift => Tree.Apply("ScalarValueLift", treemake("..." + s.name.reverse.take(15).reverse).withQuat(s.bestQuat).make)
 
       case p: Property if (traceOpinions) =>
         TreeApplyList("Property", l(treeify(p.ast)) ++ l(treeify(p.name)) ++
@@ -116,7 +120,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: Qu
             ))
 
       case e: Entity if (traceOpinions) =>
-        Tree.Apply("Entity", treemake(e.name, e.properties).withTree(printRenameable(e.renameable)).withQuat(e.bestQuat).treeify)
+        Tree.Apply("Entity", treemake(e.name, e.properties).withTree(printRenameable(e.renameable)).withQuat(e.bestQuat).make)
 
       case ast: Ast =>
         if (traceAllQuats)

--- a/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -1,6 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.{ Action, Assignment, AssignmentDual, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
+import io.getquill.ast.{ Action, Assignment, AssignmentDual, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Infix, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
 import io.getquill.quat.Quat
 import io.getquill.quat.Quat.Product
 import io.getquill.util.Interpolator
@@ -63,6 +63,14 @@ object RepropagateQuats extends StatelessTransformer {
     val cr = BetaReduction(c, RWR, b -> br)
     trace"Repropagate ${a.quat.suppress(msg)} from ${a} into:" andReturn f(ar, br, apply(cr))
   }
+
+  override def apply(e: Ast): Ast =
+    e match {
+      case Infix(parts, params, pure, quat) =>
+        val newParams = params.map(apply)
+        Quat.improveInfixQuat(Infix(parts, newParams, pure, quat))
+      case _ => super.apply(e)
+    }
 
   override def apply(e: Query): Query = {
     e match {

--- a/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
@@ -1,6 +1,6 @@
 package io.getquill.quat
 
-import io.getquill.ast.Ast
+import io.getquill.ast.{ Ast, Infix }
 import io.getquill.quotation.QuatException
 import io.getquill.util.Messages.TraceType
 
@@ -155,6 +155,21 @@ object Quat {
   object Is {
     def unapply(ast: Ast) = Some(ast.quat)
   }
+
+  def improveInfixQuat(ast: Ast) =
+    ast match {
+      case Infix(parts, params, pure, Quat.Generic | Quat.Unknown) =>
+        val possiblyBetterQuat = params.foldLeft(Quat.Generic: Quat)((currQuat, param) => currQuat.leastUpperType(param.quat).getOrElse(currQuat))
+        val bestQuat =
+          possiblyBetterQuat match {
+            case Quat.Unknown => Quat.Unknown
+            case Quat.Value   => Quat.Generic
+            case other        => other
+          }
+        Infix(parts, params, pure, bestQuat)
+      case _ =>
+        ast
+    }
 
   import LinkedHashMapOps._
 

--- a/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/Quat.scala
@@ -221,9 +221,6 @@ object Quat {
       val oneQuatIsAbstract = this.tpe == Product.Type.Abstract || other.tpe == Product.Type.Abstract
       val newFieldsIter =
         fields.zipWith(other.fields) {
-          // If one or both of the quats are abstract merge the values
-          // can't find a test to reproduce this. Don't think is needed
-          case (key, thisQuat, None) if (oneQuatIsAbstract) => (key, Some(thisQuat))
           case (key, thisQuat, Some(otherQuat)) => (key, thisQuat.leastUpperType(otherQuat))
         }.collect {
           case (key, Some(value)) => (key, value)

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
@@ -1,0 +1,46 @@
+package io.getquill.quat
+
+import io.getquill._
+
+class QuatRunSpec extends Spec {
+
+  val testContext = new SqlMirrorContext(PostgresDialect, Literal)
+  import testContext._
+
+  "should refine quats from generic infixes and express during execution" - {
+    case class MyPerson(name: String, age: Int)
+    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
+
+    "from extension methods" in {
+      implicit class QueryOps[Q <: Query[_]](q: Q) {
+        def appendFoo = quote(infix"$q APPEND FOO".pure.as[Q])
+      }
+      val q = quote(query[MyPerson].appendFoo)
+      q.ast.quat mustEqual MyPersonQuat // I.e ReifyLiftings runs RepropagateQuats to take care of this
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "from extension methods - generic marker" in {
+      implicit class QueryOps[Q <: Query[_]](q: Q) {
+        def appendFoo = quote(infix"$q APPEND FOO".generic.pure.as[Q])
+      }
+      val q = quote(query[MyPerson].appendFoo)
+      q.ast.quat mustEqual MyPersonQuat // I.e ReifyLiftings runs RepropagateQuats to take care of this
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "should support query-ops function" in {
+      def appendFooFun[Q <: Query[_]]: Quoted[Q => Q] = quote { (q: Q) => infix"$q APPEND FOO".pure.as[Q] }
+      val q = quote(appendFooFun(query[MyPerson]))
+      q.ast.quat mustEqual Quat.Unknown
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+
+    "should support query-ops function - dynamic function" in {
+      def appendFooFun[Q <: Query[_]] = quote { (q: Q) => infix"$q APPEND FOO".pure.as[Q] }
+      val q = quote(appendFooFun(query[MyPerson]))
+      q.ast.quat mustEqual MyPersonQuat
+      testContext.run(q).string mustEqual "SELECT x.name, x.age FROM MyPerson x APPEND FOO"
+    }
+  }
+}


### PR DESCRIPTION
Spark has some failures due to abstract quats. Relax rules for property lookup in abstract product quats (i.e. where Quat.Product.Type.Concrete is the type).