### PR TITLE
Add a common module for Upstream Quill functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ lazy val jsModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
 lazy val baseModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-engine-jvm`,
   `quill-core-jvm`,
-  `quill-sql-jvm`, `quill-monix`, `quill-zio`
+  `quill-sql-jvm`, `quill-monix`, `quill-zio`,
+  `quill-util`
 )
 
 lazy val dbModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
@@ -84,10 +85,10 @@ lazy val scala213Modules = baseModules ++ jsModules ++ dbModules ++ codegenModul
 )
 
 lazy val notScala211Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
-  `quill-cassandra-alpakka`
+  `quill-cassandra-alpakka`, `quill-util`
 )
 
-lazy val scala3Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](`quill-engine-jvm`)
+lazy val scala3Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](`quill-engine-jvm`, `quill-util`)
 
 def isScala213 = {
   val scalaVersion = sys.props.get("quill.scala.version")
@@ -195,6 +196,33 @@ lazy val `quill` =
 
 `quill` / publishArtifact := false
 
+lazy val `quill-util` =
+  (project in file("quill-util"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      Test / fork := true,
+      libraryDependencies ++= Seq(
+        ("org.scalameta" %% "scalafmt-core" % "3.1.0")
+          .excludeAll(
+            (Seq(
+              ExclusionRule(organization = "com.lihaoyi", name = "sourcecode_2.13"),
+              ExclusionRule(organization = "com.lihaoyi", name = "fansi_2.13"),
+              ExclusionRule(organization = "com.lihaoyi", name = "pprint_2.13"),
+            ) ++ {
+              if (isScala3)
+                Seq(
+                  ExclusionRule(organization = "org.scala-lang.modules")
+                )
+              else
+                Seq()
+            }): _*
+          )
+          .cross(CrossVersion.for3Use2_13)
+      )
+    )
+    .enablePlugins(MimaPlugin)
+
 lazy val superPure = new sbtcrossproject.CrossType {
   def projectDir(crossBase: File, projectType: String): File =
     projectType match {
@@ -228,6 +256,8 @@ lazy val ultraPure = new sbtcrossproject.CrossType {
       case JSPlatform  => crossBase / ".js"
     }
 }
+
+
 
 lazy val `quill-engine` =
   crossProject(JVMPlatform, JSPlatform).crossType(ultraPure)

--- a/quill-util/src/main/scala/io/getquill/util/ScalafmtFormat.scala
+++ b/quill-util/src/main/scala/io/getquill/util/ScalafmtFormat.scala
@@ -1,0 +1,28 @@
+package io.getquill.util
+
+import io.getquill.util.ThrowableOps._
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.{ Formatted, Scalafmt }
+
+/**
+ * Based on ScalaFmt210 from scalafmt cli
+ */
+object ScalafmtFormat {
+  def apply(code: String, showErrorTrace: Boolean = false): String = {
+    val style = ScalafmtConfig.default
+    Scalafmt.format(code, style, Set.empty, "<input>") match {
+      case Formatted.Success(formattedCode) =>
+        formattedCode
+      case Formatted.Failure(e) =>
+        if (showErrorTrace)
+          println(
+            s"""===== Failed to format the code ====
+               |$code
+               |---
+               |${e.stackTraceToString}.
+               |""".stripMargin
+          )
+        code
+    }
+  }
+}

--- a/quill-util/src/main/scala/io/getquill/util/ThrowableOps.scala
+++ b/quill-util/src/main/scala/io/getquill/util/ThrowableOps.scala
@@ -1,0 +1,15 @@
+package io.getquill.util
+
+import java.io.ByteArrayOutputStream
+
+object ThrowableOps {
+  implicit class ThrowableOpsMethods(t: Throwable) {
+    def stackTraceToString = {
+      val stream = new ByteArrayOutputStream()
+      val writer = new java.io.BufferedWriter(new java.io.OutputStreamWriter(stream))
+      t.printStackTrace(new java.io.PrintWriter(writer))
+      writer.flush
+      stream.toString
+    }
+  }
+}


### PR DESCRIPTION
In ProtoQuill things like ScalaFmt support are needed to debug various issues but it should not necessarily be required that these modules are needed for downstream dependencies. I could set the SBT libraries to "Provided" but that doesn't help anything because ClassNotFound errors would happen unless they (i.e. ScalaFmt) are included by downstream dependencies. What needs to happen is that these things need to be invoked reflectively and exceptions from the reflection can fail. This was previously done in the ProtoQuill's [Format class](https://github.com/zio/zio-protoquill/blob/126248d926feb839f744875fd3999e4006388366/quill-sql/src/main/scala/io/getquill/util/Format.scala).

However since the `ScalaFmt210` was taken out of ScalaFmt we needed to import ScalaFmt and then use it directly in [ScalafmtFormat.scala](https://github.com/zio/zio-protoquill/blob/f76d3b24126e311876a01bd86b6554c0c9015399/quill-sql/src/main/scala/io/getquill/util/ScalafmtFormat.scala), we need to have an equivalent of this that ProtoQuill can reflectively use that does not require physical ScalaFmt imports.
Therefore I have decided to create a `quill-util` module here for that and other potential shared upstream dependencies.
