### PR TITLE
Remove deprecated APIs

### DIFF
--- a/quill-core/jvm/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -24,12 +24,12 @@ class DynamicQueryDslMacro(val c: MacroContext) {
 
   def insertValue(value: Tree): Tree =
     q"""
-      DynamicInsert(${c.prefix}.q.insert(lift($value)))
+      DynamicInsert(${c.prefix}.q.insertValue(lift($value)))
     """
 
   def updateValue(value: Tree): Tree =
     q"""
-      DynamicUpdate(${c.prefix}.q.update(lift($value)))
+      DynamicUpdate(${c.prefix}.q.updateValue(lift($value)))
     """
 }
 


### PR DESCRIPTION
Need to remove deprecated EntityQuery.insert/update APIs to be compatible with upstream Dotty functionality.