### PR TITLE
Remove deprecated EntityQuery.update/insert APIs

### DIFF
--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/CaseClassQueryCassandraSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/CaseClassQueryCassandraSpec.scala
@@ -8,7 +8,7 @@ class CaseClassQueryCassandraSpec extends CassandraAlpakkaSpec {
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
 
   val peopleInsert =
-    quote((p: Contact) => query[Contact].insert(p))
+    quote((p: Contact) => query[Contact].insertValue(p))
 
   val peopleEntries = List(
     Contact(1, "Alex", "Jones", 60, 2, "foo"),
@@ -17,7 +17,7 @@ class CaseClassQueryCassandraSpec extends CassandraAlpakkaSpec {
   )
 
   val addressInsert =
-    quote((c: Address) => query[Address].insert(c))
+    quote((c: Address) => query[Address].insertValue(c))
 
   val addressEntries = List(
     Address(1, "123 Fake Street", 11234, "something"),

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/DecodeNullSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/DecodeNullSpec.scala
@@ -10,7 +10,7 @@ class DecodeNullSpec extends CassandraAlpakkaSpec {
     val result =
       for {
         _ <- testDB.run(writeEntities.delete)
-        _ <- testDB.run(writeEntities.insert(lift(insertValue)))
+        _ <- testDB.run(writeEntities.insertValue(lift(insertValue)))
         result <- testDB.run(query[DecodeNullTestEntity])
       } yield {
         result

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/EncodingSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/EncodingSpec.scala
@@ -12,7 +12,7 @@ class EncodingSpec extends EncodingSpecHelper with CassandraAlpakkaSpec {
       import testDB._
       for {
         _ <- testDB.run(query[EncodingTestEntity].delete)
-        _ <- testDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         result <- testDB.run(query[EncodingTestEntity])
       } yield {
         verify(result)
@@ -29,7 +29,7 @@ class EncodingSpec extends EncodingSpecHelper with CassandraAlpakkaSpec {
     await {
       for {
         _ <- testDB.run(query[EncodingTestEntity].delete)
-        _ <- testDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testDB.run(q(liftQuery(insertValues.map(_.id))))
       } yield {
         verify(r)
@@ -79,7 +79,7 @@ class EncodingSpec extends EncodingSpecHelper with CassandraAlpakkaSpec {
       await {
         for {
           _ <- ctx.run(jq.delete)
-          _ <- ctx.run(jq.insert(lift(j)))
+          _ <- ctx.run(jq.insertValue(lift(j)))
           r <- ctx.run(cq)
         } yield {
           r.headOption mustBe Some(c)
@@ -89,7 +89,7 @@ class EncodingSpec extends EncodingSpecHelper with CassandraAlpakkaSpec {
       await {
         for {
           _ <- ctx.run(cq.delete)
-          _ <- ctx.run(cq.insert(lift(c)))
+          _ <- ctx.run(cq.insertValue(lift(c)))
           r <- ctx.run(jq)
         } yield {
           r.headOption mustBe Some(j)

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/ListsEncodingSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/ListsEncodingSpec.scala
@@ -34,7 +34,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
   "List encoders/decoders for CassandraTypes and CassandraMappers" in {
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -49,7 +49,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -64,7 +64,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -79,7 +79,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -94,7 +94,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 4))
       } yield {
         res.head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
@@ -106,7 +106,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
     val e = ListFrozen(List(1, 2))
     await {
       for {
-        _ <- ctx.run(listFroz.insert(lift(e)))
+        _ <- ctx.run(listFroz.insertValue(lift(e)))
         res1 <- ctx.run(listFroz.filter(_.id == lift(List(1, 2))))
         res2 <- ctx.run(listFroz.filter(_.id == lift(List(1))))
       } yield {
@@ -116,7 +116,7 @@ class ListsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
     }
     await {
       for {
-        _ <- ctx.run(listFroz.insert(lift(e)))
+        _ <- ctx.run(listFroz.insertValue(lift(e)))
         res1 <- ctx.run(listFroz.filter(_.id.contains(2)).allowFiltering)
         res2 <- ctx.run(listFroz.filter(_.id.contains(3)).allowFiltering)
       } yield {

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/MapsEncodingSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/MapsEncodingSpec.scala
@@ -26,7 +26,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
   "Map encoders/decoders" in {
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -46,7 +46,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -61,7 +61,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -76,7 +76,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -89,7 +89,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(mapFroz.insert(lift(e)))
+        _ <- ctx.run(mapFroz.insertValue(lift(e)))
         res1 <- ctx.run(mapFroz.filter(_.id == lift(Map(1 -> true))))
         res2 <- ctx.run(mapFroz.filter(_.id == lift(Map(1 -> false))))
       } yield {
@@ -99,7 +99,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
     }
     await {
       for {
-        _ <- ctx.run(mapFroz.insert(lift(e)))
+        _ <- ctx.run(mapFroz.insertValue(lift(e)))
         res1 <- ctx.run(mapFroz.filter(_.id.contains(1)).allowFiltering)
         res2 <- ctx.run(mapFroz.filter(_.id.contains(2)).allowFiltering)
       } yield {
@@ -114,7 +114,7 @@ class MapsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(mapFroz.insert(lift(e)))
+        _ <- ctx.run(mapFroz.insertValue(lift(e)))
         res1 <- ctx.run(mapFroz.filter(_.id.containsValue(true)).allowFiltering)
         res2 <- ctx.run(mapFroz.filter(_.id.containsValue(false)).allowFiltering)
       } yield {

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/PeopleCassandraSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/PeopleCassandraSpec.scala
@@ -22,7 +22,7 @@ class PeopleCassandraSpec extends CassandraAlpakkaSpec {
       testDB.run(query[Person].delete)
     }
     await {
-      testDB.run(liftQuery(entries).foreach(e => query[Person].insert(e)))
+      testDB.run(liftQuery(entries).foreach(e => query[Person].insertValue(e)))
     }
     ()
   }

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/SetsEncodingSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/SetsEncodingSpec.scala
@@ -31,7 +31,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
   "Set encoders/decoders for CassandraTypes and CassandraMappers" in {
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -46,7 +46,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -61,7 +61,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -76,7 +76,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 1))
       } yield {
         res.head mustBe e
@@ -91,7 +91,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
 
     await {
       for {
-        _ <- ctx.run(q.insert(lift(e)))
+        _ <- ctx.run(q.insertValue(lift(e)))
         res <- ctx.run(q.filter(_.id == 4))
       } yield {
         res.head.blobs.map(_.toSet) mustBe e.blobs.map(_.toSet)
@@ -103,7 +103,7 @@ class SetsEncodingSpec extends CollectionsSpec with CassandraAlpakkaSpec {
     val e = SetFrozen(Set(1, 2))
     await {
       for {
-        _ <- ctx.run(setFroz.insert(lift(e)))
+        _ <- ctx.run(setFroz.insertValue(lift(e)))
         res1 <- ctx.run(setFroz.filter(_.id == lift(Set(1, 2))))
         res2 <- ctx.run(setFroz.filter(_.id == lift(Set(1))))
       } yield {

--- a/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/udt/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra-alpakka/src/test/scala/io/getquill/context/cassandra/alpakka/udt/UdtEncodingSessionContextSpec.scala
@@ -57,7 +57,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec with CassandraAlpakkaSpec {
 
       await {
         for {
-          _ <- ctx1.run(query[WithEverything].insert(lift(e)))
+          _ <- ctx1.run(query[WithEverything].insertValue(lift(e)))
           res <- ctx1.run(query[WithEverything].filter(_.id == 1))
         } yield {
           res.headOption must contain(e)
@@ -73,7 +73,7 @@ class UdtEncodingSessionContextSpec extends UdtSpec with CassandraAlpakkaSpec {
 
       await {
         for {
-          _ <- ctx1.run(query[WithEverything].insert(lift(e)))
+          _ <- ctx1.run(query[WithEverything].insertValue(lift(e)))
           res <- ctx1.run(query[WithEverything].filter(_.id == 2))
         } yield {
           res.headOption must contain(e)

--- a/quill-core/js/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/js/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -24,12 +24,12 @@ class DynamicQueryDslMacro(val c: MacroContext) {
 
   def insertValue(value: Tree): Tree =
     q"""
-      DynamicInsert(${c.prefix}.q.insert(lift($value)))
+      DynamicInsert(${c.prefix}.q.insertValue(lift($value)))
     """
 
   def updateValue(value: Tree): Tree =
     q"""
-      DynamicUpdate(${c.prefix}.q.update(lift($value)))
+      DynamicUpdate(${c.prefix}.q.updateValue(lift($value)))
     """
 }
 

--- a/quill-core/jvm/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -24,12 +24,12 @@ class DynamicQueryDslMacro(val c: MacroContext) {
 
   def insertValue(value: Tree): Tree =
     q"""
-      DynamicInsert(${c.prefix}.q.insert(lift($value)))
+      DynamicInsert(${c.prefix}.q.insertValue(lift($value)))
     """
 
   def updateValue(value: Tree): Tree =
     q"""
-      DynamicUpdate(${c.prefix}.q.update(lift($value)))
+      DynamicUpdate(${c.prefix}.q.updateValue(lift($value)))
     """
 }
 

--- a/quill-core/src/main/scala/io/getquill/ModelMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/ModelMacro.scala
@@ -12,13 +12,9 @@ sealed trait EntityQuery[T]
   override def map[R](f: T => R): EntityQuery[R] = NonQuotedException()
 
   def insertValue(value: T): Insert[T] = macro QueryDslMacro.expandInsert[T]
-  @deprecated("EntityQuery.insert(value) is deprecated due to upstream Scala 3 requirements. Use EntityQuery.insertValue(value) instead.", "3.13.0")
-  def insert(value: T): Insert[T] = macro QueryDslMacro.expandInsert[T]
   def insert(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Insert[T]
 
   def updateValue(value: T): Update[T] = macro QueryDslMacro.expandUpdate[T]
-  @deprecated("EntityQuery.update(value) is deprecated due to upstream Scala 3 requirements. Use EntityQuery.updateValue(value) instead.", "3.13.0")
-  def update(value: T): Update[T] = macro QueryDslMacro.expandUpdate[T]
   def update(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Update[T]
 
   def delete: Delete[T]

--- a/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/ArrayAsyncEncodingSpec.scala
+++ b/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/ArrayAsyncEncodingSpec.scala
@@ -13,7 +13,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
   val q = quote(query[ArraysTestEntity])
 
   "Support all sql base types and `Iterable` implementers" in {
-    runSyncUnsafe(context.run(q.insert(lift(e))))
+    runSyncUnsafe(context.run(q.insertValue(lift(e))))
     val actual = runSyncUnsafe(context.run(q)).head
     actual mustEqual e
     baseEntityDeepCheck(actual, e)
@@ -23,7 +23,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
     case class JodaTimes(timestamps: Seq[JodaLocalDateTime], dates: Seq[JodaLocalDate])
     val jE = JodaTimes(Seq(JodaLocalDateTime.now()), Seq(JodaLocalDate.now()))
     val jQ = quote(querySchema[JodaTimes]("ArraysTestEntity"))
-    runSyncUnsafe(context.run(jQ.insert(lift(jE))))
+    runSyncUnsafe(context.run(jQ.insertValue(lift(jE))))
     val actual = runSyncUnsafe(context.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
     actual.dates mustBe jE.dates
@@ -33,7 +33,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
     case class JodaTimes(timestamps: Seq[JodaDateTime])
     val jE = JodaTimes(Seq(JodaDateTime.now()))
     val jQ = quote(querySchema[JodaTimes]("ArraysTestEntity"))
-    runSyncUnsafe(context.run(jQ.insert(lift(jE))))
+    runSyncUnsafe(context.run(jQ.insertValue(lift(jE))))
     val actual = runSyncUnsafe(context.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
   }
@@ -42,7 +42,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
     case class Java8Times(timestamps: Seq[LocalDateTime], dates: Seq[LocalDate])
     val jE = Java8Times(Seq(LocalDateTime.now()), Seq(LocalDate.now()))
     val jQ = quote(querySchema[Java8Times]("ArraysTestEntity"))
-    runSyncUnsafe(context.run(jQ.insert(lift(jE))))
+    runSyncUnsafe(context.run(jQ.insertValue(lift(jE))))
     val actual = runSyncUnsafe(context.run(jQ)).head
     actual.timestamps mustBe jE.timestamps
     actual.dates mustBe jE.dates
@@ -50,7 +50,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
 
   "Support Iterable encoding basing on MappedEncoding" in {
     val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
-    runSyncUnsafe(context.run(wrapQ.insert(lift(wrapE))))
+    runSyncUnsafe(context.run(wrapQ.insertValue(lift(wrapE))))
     runSyncUnsafe(context.run(wrapQ)).head mustBe wrapE
   }
 
@@ -61,7 +61,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
         arrayDecoder[LocalDate, LocalDate, Col](identity)
     }
     import newCtx._
-    runSyncUnsafe(newCtx.run(query[ArraysTestEntity].insert(lift(e))))
+    runSyncUnsafe(newCtx.run(query[ArraysTestEntity].insertValue(lift(e))))
     intercept[FiberFailure] {
       runSyncUnsafe(newCtx.run(query[ArraysTestEntity])).head mustBe e
     }
@@ -69,7 +69,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
   }
 
   "Arrays in where clause" in {
-    runSyncUnsafe(context.run(q.insert(lift(e))))
+    runSyncUnsafe(context.run(q.insertValue(lift(e))))
     val actual1 = runSyncUnsafe(context.run(q.filter(_.texts == lift(List("test")))))
     val actual2 = runSyncUnsafe(context.run(q.filter(_.texts == lift(List("test2")))))
     baseEntityDeepCheck(actual1.head, e)
@@ -148,7 +148,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec with ZioSpec {
     val realEntity = quote {
       querySchema[RealEncodingTestEntity]("EncodingTestEntity")
     }
-    runSyncUnsafe(context.run(realEntity.insert(lift(insertValue))))
+    runSyncUnsafe(context.run(realEntity.insertValue(lift(insertValue))))
 
     case class EncodingTestEntity(v1: List[String])
     intercept[FiberFailure](runSyncUnsafe(context.run(query[EncodingTestEntity])))

--- a/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/PostgresAsyncEncodingSpec.scala
@@ -33,7 +33,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec with ZioSpec {
     val rez0 = runSyncUnsafe(testContext.run(q0))
 
     //insert new uuid
-    val rez1 = runSyncUnsafe(testContext.run(query[EncodingUUIDTestEntity].insert(lift(EncodingUUIDTestEntity(testUUID)))))
+    val rez1 = runSyncUnsafe(testContext.run(query[EncodingUUIDTestEntity].insertValue(lift(EncodingUUIDTestEntity(testUUID)))))
 
     //verify you can get the uuid back from the db
     val q2 = quote(query[EncodingUUIDTestEntity].map(p => p.v1))
@@ -67,7 +67,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec with ZioSpec {
     val fut =
       for {
         _ <- testContext.run(query[EncodingTestEntity].delete)
-        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
       } yield r
     verify(runSyncUnsafe(fut))
@@ -88,7 +88,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec with ZioSpec {
     val entity = DateEncodingTestEntity(JodaLocalDate.now, JodaLocalDateTime.now, JodaDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     runSyncUnsafe(r) mustBe Seq(entity)
@@ -99,7 +99,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec with ZioSpec {
     val entity = DateEncodingTestEntity(LocalDate.now, LocalDateTime.now, ZonedDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
-      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      _ <- testContext.run(query[DateEncodingTestEntity].insertValue(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     runSyncUnsafe(r) mustBe Seq(entity)
@@ -111,7 +111,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec with ZioSpec {
         import c._
         for {
           _ <- c.run(query[EncodingTestEntity].delete)
-          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- c.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insertValue(e)))
         } yield result
       }
     }

--- a/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/PostgresJAsyncContextSpec.scala
+++ b/quill-jasync-zio-postgres/src/test/scala/io/getquill/context/zio/jasync/postgres/PostgresJAsyncContextSpec.scala
@@ -19,7 +19,7 @@ class PostgresJAsyncContextSpec extends Spec with ZioSpec {
 
   "Insert with returning with single column table" in {
     val inserted: Long = runSyncUnsafe(testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
+      qr4.insertValue(lift(TestEntity4(0))).returningGenerated(_.i)
     })
     runSyncUnsafe(testContext.run(qr4.filter(_.i == lift(inserted))))
       .head.i mustBe inserted
@@ -27,7 +27,7 @@ class PostgresJAsyncContextSpec extends Spec with ZioSpec {
   "Insert with returning with multiple columns" in {
     runSyncUnsafe(testContext.run(qr1.delete))
     val inserted = runSyncUnsafe(testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
+      qr1.insertValue(lift(TestEntity("foo", 1, 18L, Some(123), true))).returning(r => (r.i, r.s, r.o))
     })
     (1, "foo", Some(123)) mustBe inserted
   }


### PR DESCRIPTION
Remove deprecated EntityQuery.update/insert APIs. Need to do this for the sake of upstream dotty changes in lampepfl/dotty#14043.

Completing the work started by zio/zio-quill/pull/2405 and zio/zio-quill/pull/2379.