### PR TITLE
Fix array encoding for PostgresJAsyncContext

### DIFF
--- a/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayEncoders.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayEncoders.scala
@@ -27,7 +27,12 @@ trait ArrayEncoders extends ArrayEncoding {
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayEncoder[LocalDate, Col](encodeLocalDate.f)
 
   def arrayEncoder[T, Col <: Seq[T]](mapper: T => Any): Encoder[Col] =
-    encoder[Col]((col: Col) => col.toIndexedSeq.map(mapper).mkString("{", ",", "}"), SqlTypes.ARRAY)
+    encoder[Col]((col: Col) =>
+      col
+        .toIndexedSeq
+        .map(mapper)
+        .map("\"" + _.toString.replace("\"", "\\\"") + "\"")
+        .mkString("{", ",", "}"), SqlTypes.ARRAY)
 
   def arrayRawEncoder[T, Col <: Seq[T]]: Encoder[Col] = arrayEncoder[T, Col](identity)
 


### PR DESCRIPTION
Array encoding respect empty values or values with double quotes for PostgresJAsyncContext

Fixes #2418 

### Problem

See #2418

### Solution

Put double quotes around any element value. Replace `"` with `\"` in the value.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
