### PR TITLE
drop eclipse plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -877,11 +877,9 @@ lazy val basicSettings = Seq(
     .setPreference(IndentLocalDefs, false)
     .setPreference(SpacesWithinPatternBinders, true)
     .setPreference(SpacesAroundMultiImports, true),
-  EclipseKeys.createSrc := EclipseCreateSrc.Default,
   Test / unmanagedClasspath ++= Seq(
     baseDirectory.value / "src" / "test" / "resources"
   ),
-  EclipseKeys.eclipseOutput := Some("bin"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding", "UTF-8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ addDependencyTreePlugin
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
-
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
Fixes #2449 

### Problem

sbt eclipse plugin is not maintained.

### Solution
drop sbt eclipse plugin.

### Checklist

@getquill/maintainers
