### PR TITLE
Support Spark 3.2.x and Scala 2.13 in quill-spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,8 @@ lazy val scala213Modules = baseModules ++ jsModules ++ dbModules ++ codegenModul
   `quill-jasync-postgres`,
   `quill-jasync-mysql`,
   `quill-jasync-zio`,
-  `quill-jasync-zio-postgres`
+  `quill-jasync-zio-postgres`,
+  `quill-spark`
 )
 
 lazy val notScala211Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
@@ -511,8 +512,9 @@ lazy val `quill-spark` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "org.apache.spark" %% "spark-sql" % "2.4.4"
-      ),
+          if (isScala211) "org.apache.spark" %% "spark-sql" % "2.4.4"
+          else "org.apache.spark" %% "spark-sql" % "3.2.1"
+        ),
       excludeDependencies ++= Seq(
         "ch.qos.logback"  % "logback-classic"
       )

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -38,7 +38,7 @@ trait QuillSparkContext
 
   def close() = {}
 
-  def probe(statement: String): Try[_] = Success(Unit)
+  def probe(statement: String): Try[_] = Success(())
 
   val idiom = SparkDialect
   val naming = Literal
@@ -84,7 +84,7 @@ trait QuillSparkContext
       node.structField.dataType match {
         case st: StructType =>
           // Recursively convert all parent array columns to single null values if all their children are null
-          val preculatedColumn = struct(node.children.map(percolateNullArraysRecursive(_)): _*)
+          val preculatedColumn = struct(node.children.map(percolateNullArraysRecursive(_)).toIndexedSeq: _*)
           // Then express that column back out the schema
 
           val mapped =
@@ -101,7 +101,7 @@ trait QuillSparkContext
       }
 
     ds.select(
-      ds.schema.fields.map(f => percolateNullArraysRecursive(StructElement(col(f.name), f))): _*
+      ds.schema.fields.map(f => percolateNullArraysRecursive(StructElement(col(f.name), f))).toIndexedSeq: _*
     ).as[T]
   }
 

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -136,7 +136,7 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
 
   override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
     case Constant(v: String, _) => stmt"'${v.replaceAll("""[\\']""", """\\$0""").token}'"
-    case Tuple(values)          => stmt"struct(${values.zipWithIndex.map { case (value, index) => stmt"${value.token} AS _${(index + 1 + "").token}" }.token})"
+    case Tuple(values)          => stmt"struct(${values.zipWithIndex.map { case (value, index) => stmt"${value.token} AS _${(index + 1).toString.token}" }.token})"
     case CaseClass(values)      => stmt"struct(${values.map { case (name, value) => stmt"${value.token} AS ${name.token}" }.token})"
     case other                  => super.valueTokenizer.token(other)
   }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/QuillSparkContextSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/QuillSparkContextSpec.scala
@@ -20,7 +20,7 @@ class QuillSparkContextSpec extends Spec {
   }
 
   "probe is a no-op" in {
-    testContext.probe("stmt") mustEqual Success(Unit)
+    testContext.probe("stmt") mustEqual Success(())
   }
 
   "decoders aren't used and throw an exception" - {


### PR DESCRIPTION
Fixes #2459

### Problem

quill-spark doesn't support Spark 3.2.1 with Scala 2.13

### Solution

Update Spark to 3.2.1, enable Scala 2.13 for quill-spark and fix incompatibilities with Scala 2.13.

@getquill/maintainers
