### PR TITLE
Unwrap executeActionReturning to return multiple

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcRunContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcRunContext.scala
@@ -62,12 +62,12 @@ trait JdbcRunContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends Jdbc
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): Result[T] =
     handleSingleWrappedResult(executeQuery(sql, prepare, extractor)(info, dc))
 
-  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): Result[O] =
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): Result[List[O]] =
     withConnectionWrapped { conn =>
       val (params, ps) = prepare(prepareWithReturning(sql, conn, returningBehavior), conn)
       logger.logQuery(sql, params)
       ps.executeUpdate()
-      handleSingleResult(extractResult(ps.getGeneratedKeys, conn, extractor))
+      extractResult(ps.getGeneratedKeys, conn, extractor)
     }
 
   protected def prepareWithReturning(sql: String, conn: Connection, returningBehavior: ReturnAction) =


### PR DESCRIPTION
Fixes #2254

### Problem

.returning returns a single value instead of a list, failing on both zero and n > 1

### Solution

Return a list instead of a scalar from executeActionReturning

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
