### PR TITLE
Sync Contexts with ProtoQuill and move out ProtoQuill conflicts

### DIFF
--- a/quill-cassandra-alpakka/src/main/scala/io/getquill/CassandraAlpakkaContext.scala
+++ b/quill-cassandra-alpakka/src/main/scala/io/getquill/CassandraAlpakkaContext.scala
@@ -6,7 +6,7 @@ import akka.{ Done, NotUsed }
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{ BoundStatement, PreparedStatement }
 import io.getquill.context.cassandra.{ CassandraSessionContext, CqlIdiom, PrepareStatementCache }
-import io.getquill.context.{ CassandraSession, ExecutionInfo, StreamingContext }
+import io.getquill.context.{ CassandraSession, ExecutionInfo, ContextVerbStream }
 import io.getquill.monad.ScalaFutureIOMonad
 import io.getquill.util.ContextLogger
 
@@ -20,7 +20,7 @@ class CassandraAlpakkaContext[N <: NamingStrategy](
   val preparedStatementCacheSize: Long
 ) extends CassandraSessionContext[N]
   with CassandraSession
-  with StreamingContext[CqlIdiom, N]
+  with ContextVerbStream[CqlIdiom, N]
   with ScalaFutureIOMonad {
 
   private val logger = ContextLogger(classOf[CassandraAlpakkaContext[_]])

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import com.datastax.oss.driver.api.core.cql.{ AsyncResultSet, BoundStatement, Row }
 import io.getquill.CassandraZioContext._
-import io.getquill.context.{ ExecutionInfo, StandardContext }
+import io.getquill.context.{ Context, ExecutionInfo }
 import io.getquill.context.cassandra.{ CassandraRowContext, CqlIdiom }
 import io.getquill.context.qzio.ZioContext
 import io.getquill.util.Messages.fail
@@ -51,7 +51,7 @@ trait CioOps {
 class CassandraZioContext[N <: NamingStrategy](val naming: N)
   extends CassandraRowContext[N]
   with ZioContext[CqlIdiom, N]
-  with StandardContext[CqlIdiom, N]
+  with Context[CqlIdiom, N]
   with CioOps {
 
   private val logger = ContextLogger(classOf[CassandraZioContext[_]])

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -2,7 +2,7 @@ package io.getquill.context.cassandra
 
 import com.datastax.oss.driver.api.core.cql.{ BoundStatement, Row }
 import io.getquill.NamingStrategy
-import io.getquill.context.{ CassandraSession, ExecutionInfo, StandardContext, UdtValueLookup }
+import io.getquill.context.{ CassandraSession, Context, ContextVerbPrepareLambda, ExecutionInfo, UdtValueLookup }
 import io.getquill.context.cassandra.encoding.{ CassandraTypes, Decoders, Encoders, UdtEncoding }
 import io.getquill.util.ContextLogger
 import io.getquill.util.Messages.fail
@@ -55,7 +55,7 @@ trait CassandraBaseContext[N <: NamingStrategy] extends CassandraRowContext[N] {
 
 trait CassandraRowContext[N <: NamingStrategy]
   extends CassandraContext[N]
-  with StandardContext[CqlIdiom, N]
+  with Context[CqlIdiom, N]
   with Encoders
   with Decoders
   with CassandraTypes

--- a/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
@@ -1,6 +1,6 @@
 package io.getquill
 
-import io.getquill.context.{ ExecutionInfo, RowContext, StandardContext, TranslateContext }
+import io.getquill.context.{ Context, ContextVerbTranslate, ExecutionInfo, RowContext }
 import io.getquill.context.mirror.{ MirrorDecoders, MirrorEncoders, MirrorSession, Row }
 
 import scala.concurrent.Future
@@ -14,9 +14,9 @@ import scala.util.Failure
 import scala.util.Success
 
 class AsyncMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
-  extends StandardContext[Idiom, Naming]
+  extends Context[Idiom, Naming]
   with RowContext
-  with TranslateContext
+  with ContextVerbTranslate
   with MirrorEncoders
   with MirrorDecoders
   with ScalaFutureIOMonad {

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.context.mirror.{ MirrorDecoders, MirrorEncoders, MirrorSession, Row }
-import io.getquill.context.{ ExecutionInfo, ProtoContext, StandardContext, TranslateContext }
+import io.getquill.context.{ Context, ContextVerbPrepareLambda, ContextVerbTranslate, ExecutionInfo, ProtoContext }
 import io.getquill.idiom.{ Idiom => BaseIdiom }
 import io.getquill.monad.SyncIOMonad
 
@@ -11,9 +11,10 @@ object mirrorContextWithQueryProbing
   extends MirrorContext(MirrorIdiom, Literal) with QueryProbing
 
 class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
-  extends StandardContext[Idiom, Naming]
+  extends Context[Idiom, Naming]
   with ProtoContext[Idiom, Naming]
-  with TranslateContext
+  with ContextVerbTranslate
+  with ContextVerbPrepareLambda
   with MirrorEncoders
   with MirrorDecoders
   with SyncIOMonad {

--- a/quill-core/src/main/scala/io/getquill/Quoted.scala
+++ b/quill-core/src/main/scala/io/getquill/Quoted.scala
@@ -1,0 +1,43 @@
+package io.getquill
+
+import io.getquill.ast.Ast
+
+/**
+ * Defines the primary interface by which information in Quill is composed. This includes not only
+ * queries but all code fragements.
+ * A quotation can be a simple value:
+ * {{
+ * val pi = quote(3.14159)
+ * }}
+ * And be used within another quotation:
+ * {{
+ * case class Circle(radius: Float)
+ *
+ * val areas = quote {
+ *   query[Circle].map(c => pi * c.radius * c.radius)
+ * }
+ * }}
+ * Quotations can also contain high-order functions and inline values:
+ * {{
+ * val area = quote {
+ *   (c: Circle) => {
+ *     val r2 = c.radius * c.radius
+ *     pi * r2
+ *   }
+ * }
+ * val areas = quote {
+ *   query[Circle].map(c => area(c))
+ * }
+ * }}
+ *
+ * Note that this class must not be in quill-engine since it cannot be shared with ProtoQuill and which
+ * has a different implementation of Quoted.
+ * @see <a href="https://youtrack.jetbrains.com/issue/SCL-20078/Scala-3.1.1-fails-to-compile-no-method-options#focus=Comments-27-6048464.0-0">Scala 3.1.1 fails to compile / no method options</a>
+ *      for more info.
+ *
+ */
+trait Quoted[+T] {
+  def ast: Ast
+  override def toString: String = ast.toString
+}
+

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -9,29 +9,6 @@ import java.io.Closeable
 import scala.util.Try
 import io.getquill.{ Action, ActionReturning, BatchAction, NamingStrategy, Query, Quoted }
 
-trait StagedPrepare extends PrepareContext {
-  type PrepareQueryResult = Session => Result[PrepareRow]
-  type PrepareActionResult = Session => Result[PrepareRow]
-  type PrepareBatchActionResult = Session => Result[List[PrepareRow]]
-}
-
-trait PrepareContext extends CoreDsl {
-  type Result[T]
-  type Session
-
-  type PrepareQueryResult //Usually: Session => Result[PrepareRow]
-  type PrepareActionResult //Usually: Session => Result[PrepareRow]
-  type PrepareBatchActionResult //Usually: Session => Result[List[PrepareRow]]
-
-  def prepare[T](quoted: Quoted[Query[T]]): PrepareQueryResult = macro QueryMacro.prepareQuery[T]
-  def prepare(quoted: Quoted[Action[_]]): PrepareActionResult = macro ActionMacro.prepareAction
-  def prepare(quoted: Quoted[BatchAction[Action[_]]]): PrepareBatchActionResult = macro ActionMacro.prepareBatchAction
-}
-
-trait StandardContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
-  extends Context[Idiom, Naming]
-  with StagedPrepare
-
 trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext
   with Closeable
   with CoreDsl {

--- a/quill-core/src/main/scala/io/getquill/context/ContextVerbPrepare.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextVerbPrepare.scala
@@ -1,0 +1,19 @@
+package io.getquill.context
+
+import io.getquill.{ Action, BatchAction, Query, Quoted }
+import io.getquill.dsl.CoreDsl
+import scala.language.experimental.macros
+import scala.language.higherKinds
+
+trait ContextVerbPrepare extends CoreDsl {
+  type Result[T]
+  type Session
+
+  type PrepareQueryResult //Usually: Session => Result[PrepareRow]
+  type PrepareActionResult //Usually: Session => Result[PrepareRow]
+  type PrepareBatchActionResult //Usually: Session => Result[List[PrepareRow]]
+
+  def prepare[T](quoted: Quoted[Query[T]]): PrepareQueryResult = macro QueryMacro.prepareQuery[T]
+  def prepare(quoted: Quoted[Action[_]]): PrepareActionResult = macro ActionMacro.prepareAction
+  def prepare(quoted: Quoted[BatchAction[Action[_]]]): PrepareBatchActionResult = macro ActionMacro.prepareBatchAction
+}

--- a/quill-core/src/main/scala/io/getquill/context/ContextVerbPrepareLambda.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextVerbPrepareLambda.scala
@@ -1,0 +1,7 @@
+package io.getquill.context
+
+trait ContextVerbPrepareLambda extends ContextVerbPrepare {
+  type PrepareQueryResult = Session => Result[PrepareRow]
+  type PrepareActionResult = Session => Result[PrepareRow]
+  type PrepareBatchActionResult = Session => Result[List[PrepareRow]]
+}

--- a/quill-core/src/main/scala/io/getquill/context/ContextVerbStream.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextVerbStream.scala
@@ -5,7 +5,7 @@ import io.getquill.{ NamingStrategy, Query, Quoted }
 import scala.language.higherKinds
 import scala.language.experimental.macros
 
-trait StreamingContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] {
+trait ContextVerbStream[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] {
   this: Context[Idiom, Naming] =>
 
   type StreamResult[T]

--- a/quill-core/src/main/scala/io/getquill/context/mirror/Row.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/Row.scala
@@ -4,6 +4,11 @@ import scala.reflect.ClassTag
 
 import io.getquill.util.Messages.fail
 
+/**
+ * Defines a artificial 'Row' used for the mirror context. Mostly used for testing.
+ * (Note that this must not be in quill-engine or it will conflict with the io.getquill.context.mirror.Row
+ * class in ProtoQuill.)
+ */
 case class Row(data: Any*) {
   def add(value: Any) = Row((data :+ value): _*)
   def apply[T](index: Int)(implicit t: ClassTag[T]) =

--- a/quill-engine/src/main/scala/io/getquill/Model.scala
+++ b/quill-engine/src/main/scala/io/getquill/Model.scala
@@ -5,11 +5,6 @@ import io.getquill.quotation.NonQuotedException
 
 import scala.annotation.compileTimeOnly
 
-trait Quoted[+T] {
-  def ast: Ast
-  override def toString: String = ast.toString
-}
-
 /**
  * A Quill-Action-Concept centrally defines Quill Query, Insert, Update, Delete, etc... actions.
  * This ZIO-inspired construct makes it easier to reason about Quoted actions

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -23,7 +23,7 @@ import io.getquill.context.sql.SqlContext
 import io.getquill.util.{ ContextLogger, LoadConfig }
 import io.getquill.util.Messages.fail
 import io.getquill.monad.TwitterFutureIOMonad
-import io.getquill.context.{ Context, ExecutionInfo, StreamingContext, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbStream, ContextVerbTranslate }
 
 sealed trait OperationType
 object OperationType {
@@ -38,9 +38,9 @@ class FinagleMysqlContext[N <: NamingStrategy](
   private[getquill] val extractionTimeZone: TimeZone
 )
   extends Context[MySQLDialect, N]
-  with TranslateContext
+  with ContextVerbTranslate
   with SqlContext[MySQLDialect, N]
-  with StreamingContext[MySQLDialect, N]
+  with ContextVerbStream[MySQLDialect, N]
   with FinagleMysqlDecoders
   with FinagleMysqlEncoders
   with TwitterFutureIOMonad {

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -9,12 +9,12 @@ import io.getquill.context.sql.SqlContext
 import io.getquill.util.{ ContextLogger, LoadConfig }
 
 import scala.util.Try
-import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbTranslate }
 import io.getquill.monad.TwitterFutureIOMonad
 
 class FinaglePostgresContext[N <: NamingStrategy](val naming: N, client: PostgresClient)
   extends Context[FinaglePostgresDialect, N]
-  with TranslateContext
+  with ContextVerbTranslate
   with SqlContext[FinaglePostgresDialect, N]
   with FinaglePostgresEncoders
   with FinaglePostgresDecoders

--- a/quill-jasync-zio/src/main/scala/io/getquill/context/zio/ZioJAsyncContext.scala
+++ b/quill-jasync-zio/src/main/scala/io/getquill/context/zio/ZioJAsyncContext.scala
@@ -3,7 +3,7 @@ package io.getquill.context.zio
 import com.github.jasync.sql.db.{ ConcreteConnection, QueryResult, RowData }
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbTranslate }
 import io.getquill.util.ContextLogger
 import io.getquill.{ NamingStrategy, ReturnAction }
 import kotlin.jvm.functions.Function1
@@ -15,7 +15,7 @@ import scala.util.Try
 
 abstract class ZioJAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N)
   extends Context[D, N]
-  with TranslateContext
+  with ContextVerbTranslate
   with SqlContext[D, N]
   with Decoders
   with Encoders

--- a/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
+++ b/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
@@ -15,7 +15,7 @@ import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.getquill.util.ContextLogger
 import io.getquill.monad.ScalaFutureIOMonad
-import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbTranslate }
 import kotlin.jvm.functions.Function1
 
 import scala.compat.java8.FutureConverters
@@ -23,7 +23,7 @@ import scala.jdk.CollectionConverters._
 
 abstract class JAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N, pool: ConnectionPool[C])
   extends Context[D, N]
-  with TranslateContext
+  with ContextVerbTranslate
   with SqlContext[D, N]
   with Decoders
   with Encoders

--- a/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
@@ -4,7 +4,7 @@ import java.io.Closeable
 import java.sql.{ Array => _, _ }
 import cats.effect.ExitCase
 import io.getquill.{ NamingStrategy, ReturnAction }
-import io.getquill.context.{ ExecutionInfo, ProtoContext, StreamingContext }
+import io.getquill.context.{ ExecutionInfo, ProtoContext, ContextVerbStream }
 import io.getquill.context.jdbc.JdbcContextBase
 import io.getquill.context.monix.MonixJdbcContext.EffectWrapper
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -28,7 +28,7 @@ abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
 ) extends MonixContext[Dialect, Naming]
   with ProtoContext[Dialect, Naming]
   with JdbcContextBase[Dialect, Naming]
-  with StreamingContext[Dialect, Naming]
+  with ContextVerbStream[Dialect, Naming]
   with MonixTranslateContext {
 
   override private[getquill] val logger = ContextLogger(classOf[MonixJdbcContext[_, _]])

--- a/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import com.typesafe.config.Config
-import io.getquill.context.jdbc.{ H2JdbcComposition, JdbcRunContext, MysqlJdbcComposition, OracleJdbcComposition, PostgresJdbcComposition, SqlServerExecuteOverride, SqlServerJdbcComposition, SqliteJdbcComposition }
+import io.getquill.context.jdbc.{ H2JdbcTypes, MysqlJdbcTypes, OracleJdbcTypes, PostgresJdbcTypes, SqlServerExecuteOverride, SqlServerJdbcTypes, SqliteJdbcTypes }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.qzio.{ ZioJdbcContext, ZioJdbcUnderlyingContext }
 import io.getquill.util.LoadConfig
@@ -10,20 +10,19 @@ import javax.sql.DataSource
 
 class PostgresZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[PostgresDialect, N]
-  with PostgresJdbcComposition[N] {
+  with PostgresJdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[PostgresDialect, N] = new PostgresZioJdbcContext.Underlying[N](naming)
 }
 object PostgresZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[PostgresDialect, N]
-    with PostgresJdbcComposition[N]
-    with JdbcRunContext[PostgresDialect, N]
+    with PostgresJdbcTypes[N]
 }
 
 class SqlServerZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[SQLServerDialect, N]
-  with SqlServerJdbcComposition[N] {
+  with SqlServerJdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[SQLServerDialect, N] = new SqlServerZioJdbcContext.Underlying[N](naming)
 }
@@ -31,61 +30,56 @@ class SqlServerZioJdbcContext[N <: NamingStrategy](val naming: N)
 object SqlServerZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[SQLServerDialect, N]
-    with SqlServerJdbcComposition[N]
-    with JdbcRunContext[SQLServerDialect, N]
+    with SqlServerJdbcTypes[N]
     with SqlServerExecuteOverride[N]
 }
 
 class H2ZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[H2Dialect, N]
-  with H2JdbcComposition[N] {
+  with H2JdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[H2Dialect, N] = new H2ZioJdbcContext.Underlying[N](naming)
 }
 object H2ZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[H2Dialect, N]
-    with H2JdbcComposition[N]
-    with JdbcRunContext[H2Dialect, N]
+    with H2JdbcTypes[N]
 }
 
 class MysqlZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[MySQLDialect, N]
-  with MysqlJdbcComposition[N] {
+  with MysqlJdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[MySQLDialect, N] = new MysqlZioJdbcContext.Underlying[N](naming)
 }
 object MysqlZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[MySQLDialect, N]
-    with MysqlJdbcComposition[N]
-    with JdbcRunContext[MySQLDialect, N]
+    with MysqlJdbcTypes[N]
 }
 
 class SqliteZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[SqliteDialect, N]
-  with SqliteJdbcComposition[N] {
+  with SqliteJdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[SqliteDialect, N] = new SqliteZioJdbcContext.Underlying[N](naming)
 }
 object SqliteZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[SqliteDialect, N]
-    with SqliteJdbcComposition[N]
-    with JdbcRunContext[SqliteDialect, N]
+    with SqliteJdbcTypes[N]
 }
 
 class OracleZioJdbcContext[N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[OracleDialect, N]
-  with OracleJdbcComposition[N] {
+  with OracleJdbcTypes[N] {
 
   val underlying: ZioJdbcUnderlyingContext[OracleDialect, N] = new OracleZioJdbcContext.Underlying[N](naming)
 }
 object OracleZioJdbcContext {
   class Underlying[N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[OracleDialect, N]
-    with OracleJdbcComposition[N]
-    with JdbcRunContext[OracleDialect, N]
+    with OracleJdbcTypes[N]
 }
 
 trait WithProbing[D <: SqlIdiom, N <: NamingStrategy] extends ZioJdbcUnderlyingContext[D, N] {

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
@@ -1,9 +1,9 @@
 package io.getquill.context.qzio
 
 import io.getquill.context.ZioJdbc._
-import io.getquill.context.jdbc.JdbcRunContext
+import io.getquill.context.jdbc.JdbcContextVerbExecute
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ ExecutionInfo, StreamingContext }
+import io.getquill.context.{ ContextVerbStream, ExecutionInfo }
 import io.getquill.util.ContextLogger
 import io.getquill.{ NamingStrategy, ReturnAction }
 import zio.Exit.{ Failure, Success }
@@ -16,8 +16,8 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 abstract class ZioJdbcUnderlyingContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
-  with JdbcRunContext[Dialect, Naming]
-  with StreamingContext[Dialect, Naming]
+  with JdbcContextVerbExecute[Dialect, Naming]
+  with ContextVerbStream[Dialect, Naming]
   with ZioPrepareContext[Dialect, Naming]
   with ZioTranslateContext {
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.qzio
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ ExecutionInfo, PrepareContext }
+import io.getquill.context.{ ExecutionInfo, ContextVerbPrepare }
 import io.getquill.context.ZioJdbc._
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.util.ContextLogger
@@ -10,7 +10,7 @@ import zio.{ Has, Task, ZIO }
 import java.sql.{ Connection, PreparedStatement, ResultSet, SQLException }
 
 trait ZioPrepareContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
-  with PrepareContext {
+  with ContextVerbPrepare {
 
   private[getquill] val logger = ContextLogger(classOf[ZioPrepareContext[_, _]])
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.h2
 
 import io.getquill.{ Prefix, ZioSpec }
 import zio.{ Task, ZIO }
-import io.getquill.context.ZioJdbc._
 
 class ZioJdbcContextSpec extends ZioSpec {
 
@@ -59,7 +58,7 @@ class ZioJdbcContextSpec extends ZioSpec {
     "prepare" in {
       testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.mysql
 
 import io.getquill.{ Prefix, ZioSpec }
 import zio.{ Task, ZIO, ZLayer }
-import io.getquill.context.ZioJdbc._
 
 import javax.sql.DataSource
 
@@ -73,7 +72,7 @@ class ZioJdbcContextSpec extends ZioSpec {
     "prepare" in {
       testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.postgres
 
 import io.getquill.{ Prefix, ZioSpec }
 import zio.{ Task, ZIO, ZLayer }
-import io.getquill.context.ZioJdbc._
 
 import javax.sql.DataSource
 
@@ -73,7 +72,7 @@ class ZioJdbcContextSpec extends ZioSpec {
     "prepare" in {
       testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PeopleZioJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PeopleZioJdbcSpec.scala
@@ -3,7 +3,6 @@ package io.getquill.sqlite
 import io.getquill.PeopleZioSpec
 import io.getquill.Prefix
 import org.scalatest.matchers.should.Matchers._
-import io.getquill.context.ZioJdbc._
 
 class PeopleZioJdbcSpec extends PeopleZioSpec {
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.sqlite
 
 import io.getquill.{ Prefix, ZioSpec }
 import zio.{ Task, ZIO, ZLayer }
-import io.getquill.context.ZioJdbc._
 import javax.sql.DataSource
 
 class ZioJdbcContextSpec extends ZioSpec {
@@ -72,7 +71,7 @@ class ZioJdbcContextSpec extends ZioSpec {
     "prepare" in {
       testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PeopleZioJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PeopleZioJdbcSpec.scala
@@ -3,7 +3,6 @@ package io.getquill.sqlserver
 import io.getquill.PeopleZioSpec
 import io.getquill.Prefix
 import org.scalatest.matchers.should.Matchers._
-import io.getquill.context.ZioJdbc._
 
 class PeopleZioJdbcSpec extends PeopleZioSpec {
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.sqlserver
 
 import io.getquill.{ Prefix, ZioSpec }
 import zio.{ Task, ZIO, ZLayer }
-import io.getquill.context.ZioJdbc._
 
 import javax.sql.DataSource
 
@@ -73,7 +72,7 @@ class ZioJdbcContextSpec extends ZioSpec {
     "prepare" in {
       testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
@@ -13,7 +13,7 @@ import scala.collection.compat._
 import scala.reflect.ClassTag
 
 trait ArrayDecoders extends ArrayEncoding {
-  self: JdbcComposition[_, _] =>
+  self: JdbcContextTypes[_, _] =>
 
   implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CBF[String, Col]): Decoder[Col] = arrayRawDecoder[String, Col]
   implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = arrayDecoder[JBigDecimal, BigDecimal, Col](BigDecimal.apply)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
@@ -9,7 +9,7 @@ import io.getquill.context.sql.encoding.ArrayEncoding
 import scala.collection.compat._
 
 trait ArrayEncoders extends ArrayEncoding {
-  self: JdbcComposition[_, _] =>
+  self: JdbcContextTypes[_, _] =>
 
   implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = arrayRawEncoder[String, Col](VARCHAR)
   implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] = arrayEncoder[BigDecimal, Col](parseJdbcType(NUMERIC), _.bigDecimal)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BaseContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BaseContexts.scala
@@ -2,14 +2,27 @@ package io.getquill.context.jdbc
 
 import io.getquill._
 
-trait PostgresJdbcContextBase[N <: NamingStrategy] extends PostgresJdbcContextSimplified[N] with JdbcContextBase[PostgresDialect, N]
+trait PostgresJdbcContextBase[N <: NamingStrategy]
+  extends PostgresJdbcTypes[N]
+  with JdbcContextBase[PostgresDialect, N]
 
-trait H2JdbcContextBase[N <: NamingStrategy] extends H2JdbcContextSimplified[N] with JdbcContextBase[H2Dialect, N]
+trait H2JdbcContextBase[N <: NamingStrategy]
+  extends H2JdbcTypes[N]
+  with JdbcContextBase[H2Dialect, N]
 
-trait MysqlJdbcContextBase[N <: NamingStrategy] extends MysqlJdbcContextSimplified[N] with JdbcContextBase[MySQLDialect, N]
+trait MysqlJdbcContextBase[N <: NamingStrategy]
+  extends MysqlJdbcTypes[N]
+  with JdbcContextBase[MySQLDialect, N]
 
-trait SqliteJdbcContextBase[N <: NamingStrategy] extends SqliteJdbcContextSimplified[N] with JdbcContextBase[SqliteDialect, N]
+trait SqliteJdbcContextBase[N <: NamingStrategy]
+  extends SqliteJdbcTypes[N]
+  with JdbcContextBase[SqliteDialect, N]
 
-trait SqlServerJdbcContextBase[N <: NamingStrategy] extends SqlServerJdbcContextSimplified[N] with JdbcContextBase[SQLServerDialect, N]
+trait SqlServerJdbcContextBase[N <: NamingStrategy]
+  extends SqlServerJdbcTypes[N]
+  with SqlServerExecuteOverride[N]
+  with JdbcContextBase[SQLServerDialect, N]
 
-trait OracleJdbcContextBase[N <: NamingStrategy] extends OracleJdbcContextSimplified[N] with JdbcContextBase[OracleDialect, N]
+trait OracleJdbcContextBase[N <: NamingStrategy]
+  extends OracleJdbcTypes[N]
+  with JdbcContextBase[OracleDialect, N]

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BooleanIntEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BooleanIntEncoding.scala
@@ -3,7 +3,7 @@ package io.getquill.context.jdbc
 import java.sql.Types
 
 trait BooleanIntEncoding {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
 
   implicit val booleanEncoder: Encoder[Boolean] = encoder(Types.TINYINT, (index, value, row) => row.setInt(index, if (value) 1 else 0))
   implicit val booleanDecoder: Decoder[Boolean] = decoder((index, row, session) => row.getInt(index) == 1)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BooleanObjectEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BooleanObjectEncoding.scala
@@ -3,7 +3,7 @@ package io.getquill.context.jdbc
 import java.sql.Types
 
 trait BooleanObjectEncoding {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
 
   implicit val booleanEncoder: Encoder[Boolean] = encoder(Types.BOOLEAN, _.setBoolean)
   implicit val booleanDecoder: Decoder[Boolean] = decoder(_.getBoolean)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -6,7 +6,7 @@ import java.util.Calendar
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
 trait Decoders {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
 
   type Decoder[T] = JdbcDecoder[T]
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -6,7 +6,7 @@ import java.util.Calendar
 import java.{ sql, util }
 
 trait Encoders {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
 
   type Encoder[T] = JdbcEncoder[T]
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -5,7 +5,7 @@ import java.sql.{ Connection, PreparedStatement }
 import javax.sql.DataSource
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
-import io.getquill.context.{ ExecutionInfo, ProtoContext, TranslateContext }
+import io.getquill.context.{ ExecutionInfo, ProtoContext, ContextVerbTranslate }
 
 import scala.util.{ DynamicVariable, Try }
 import scala.util.control.NonFatal
@@ -14,7 +14,7 @@ import io.getquill.monad.SyncIOMonad
 abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
   extends JdbcContextBase[Dialect, Naming]
   with ProtoContext[Dialect, Naming]
-  with TranslateContext
+  with ContextVerbTranslate
   with SyncIOMonad {
 
   // Need to override these with same values as JdbcRunContext because SyncIOMonad imports them. The imported values need to be overridden

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
@@ -1,13 +1,15 @@
 package io.getquill.context.jdbc
 
 import io.getquill._
+import io.getquill.context.ContextVerbPrepareLambda
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ ExecutionInfo, PrepareContext, StagedPrepare }
 
 import java.sql._
 
-trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends JdbcContextSimplified[Dialect, Naming]
-  with StagedPrepare {
+trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+  extends JdbcContextVerbExecute[Dialect, Naming]
+  with JdbcContextVerbPrepare[Dialect, Naming]
+  with ContextVerbPrepareLambda {
 
   // Need to re-define these here or they conflict with staged-prepare imported types
   override type PrepareQueryResult = Connection => Result[PreparedStatement]
@@ -17,46 +19,4 @@ trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends Jdb
   def constructPrepareQuery(f: Connection => Result[PreparedStatement]): Connection => Result[PreparedStatement] = f
   def constructPrepareAction(f: Connection => Result[PreparedStatement]): Connection => Result[PreparedStatement] = f
   def constructPrepareBatchAction(f: Connection => Result[List[PreparedStatement]]): Connection => Result[List[PreparedStatement]] = f
-}
-
-trait JdbcContextSimplified[Dialect <: SqlIdiom, Naming <: NamingStrategy]
-  extends JdbcRunContext[Dialect, Naming] with PrepareContext {
-
-  override type PrepareQueryResult = Connection => Result[PreparedStatement]
-  override type PrepareActionResult = Connection => Result[PreparedStatement]
-  override type PrepareBatchActionResult = Connection => Result[List[PreparedStatement]]
-
-  def constructPrepareQuery(f: Connection => Result[PreparedStatement]): PrepareQueryResult
-  def constructPrepareAction(f: Connection => Result[PreparedStatement]): PrepareActionResult
-  def constructPrepareBatchAction(f: Connection => Result[List[PreparedStatement]]): PrepareBatchActionResult
-
-  def prepareQuery(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): PrepareQueryResult =
-    constructPrepareQuery(prepareSingle(sql, prepare)(executionInfo, dc))
-
-  def prepareAction(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): PrepareActionResult =
-    constructPrepareAction(prepareSingle(sql, prepare)(executionInfo, dc))
-
-  def prepareSingle(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): Connection => Result[PreparedStatement] =
-    (conn: Connection) => wrap {
-      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
-      logger.logQuery(sql, params)
-      ps
-    }
-
-  def prepareBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: Runner): PrepareBatchActionResult =
-    constructPrepareBatchAction {
-      (session: Connection) =>
-        seq {
-          val batches = groups.flatMap {
-            case BatchGroup(sql, prepares) =>
-              prepares.map(sql -> _)
-          }
-          batches.map {
-            case (sql, prepare) =>
-              val prepareSql = prepareSingle(sql, prepare)(executionInfo, dc)
-              prepareSql(session)
-          }
-        }
-    }
-
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc
+
+import io.getquill.{ NamingStrategy, ReturnAction }
+import io.getquill.ReturnAction.{ ReturnColumns, ReturnNothing, ReturnRecord }
+import io.getquill.context.{ Context, ExecutionInfo }
+import io.getquill.context.sql.SqlContext
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.util.ContextLogger
+
+import java.sql.{ Connection, JDBCType, PreparedStatement, ResultSet, Statement }
+import java.util.TimeZone
+
+trait JdbcContextTypes[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends Context[Dialect, Naming]
+  with SqlContext[Dialect, Naming]
+  with Encoders
+  with Decoders {
+
+  type PrepareRow = PreparedStatement
+  type ResultRow = ResultSet
+  type Session = Connection
+  type Runner = Unit
+
+  protected val dateTimeZone = TimeZone.getDefault
+
+  /**
+   * Parses instances of java.sql.Types to string form so it can be used in creation of sql arrays.
+   * Some databases does not support each of generic types, hence it's welcome to override this method
+   * and provide alternatives to non-existent types.
+   *
+   * @param intType one of java.sql.Types
+   * @return JDBC type in string form
+   */
+  def parseJdbcType(intType: Int): String = JDBCType.valueOf(intType).getName
+}

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
@@ -1,0 +1,57 @@
+package io.getquill.context.jdbc
+
+import io.getquill._
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.context.{ ContextVerbPrepare, ExecutionInfo }
+import io.getquill.util.ContextLogger
+
+import java.sql._
+
+trait JdbcContextVerbPrepare[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+  extends ContextVerbPrepare
+  with JdbcContextTypes[Dialect, Naming] {
+
+  override type PrepareQueryResult = Connection => Result[PreparedStatement]
+  override type PrepareActionResult = Connection => Result[PreparedStatement]
+  override type PrepareBatchActionResult = Connection => Result[List[PreparedStatement]]
+
+  def constructPrepareQuery(f: Connection => Result[PreparedStatement]): PrepareQueryResult
+  def constructPrepareAction(f: Connection => Result[PreparedStatement]): PrepareActionResult
+  def constructPrepareBatchAction(f: Connection => Result[List[PreparedStatement]]): PrepareBatchActionResult
+
+  private[getquill] val logger = ContextLogger(classOf[JdbcContext[_, _]])
+
+  def wrap[T](t: => T): Result[T]
+  def push[A, B](result: Result[A])(f: A => B): Result[B]
+  def seq[A](list: List[Result[A]]): Result[List[A]]
+
+  def prepareQuery(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): PrepareQueryResult =
+    constructPrepareQuery(prepareSingle(sql, prepare)(executionInfo, dc))
+
+  def prepareAction(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): PrepareActionResult =
+    constructPrepareAction(prepareSingle(sql, prepare)(executionInfo, dc))
+
+  def prepareSingle(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: Runner): Connection => Result[PreparedStatement] =
+    (conn: Connection) => wrap {
+      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
+      logger.logQuery(sql, params)
+      ps
+    }
+
+  def prepareBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: Runner): PrepareBatchActionResult =
+    constructPrepareBatchAction {
+      (session: Connection) =>
+        seq {
+          val batches = groups.flatMap {
+            case BatchGroup(sql, prepares) =>
+              prepares.map(sql -> _)
+          }
+          batches.map {
+            case (sql, prepare) =>
+              val prepareSql = prepareSingle(sql, prepare)(executionInfo, dc)
+              prepareSql(session)
+          }
+        }
+    }
+
+}

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
@@ -3,11 +3,9 @@ package io.getquill.context.jdbc
 import java.sql.Types
 import io.getquill._
 import io.getquill.context.ExecutionInfo
+import io.getquill.util.ContextLogger
 
-trait PostgresJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[PostgresDialect, N]
-  with PostgresJdbcComposition[N] with JdbcRunContext[PostgresDialect, N]
-
-trait PostgresJdbcComposition[N <: NamingStrategy] extends JdbcComposition[PostgresDialect, N]
+trait PostgresJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[PostgresDialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding
   with ArrayDecoders
@@ -23,43 +21,30 @@ trait PostgresJdbcComposition[N <: NamingStrategy] extends JdbcComposition[Postg
   }
 }
 
-trait H2JdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[H2Dialect, N]
-  with H2JdbcComposition[N] with JdbcRunContext[H2Dialect, N]
-
-trait H2JdbcComposition[N <: NamingStrategy] extends JdbcComposition[H2Dialect, N]
+trait H2JdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[H2Dialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding {
 
   val idiom = H2Dialect
 }
 
-trait MysqlJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[MySQLDialect, N]
-  with MysqlJdbcComposition[N] with JdbcRunContext[MySQLDialect, N]
-
-trait MysqlJdbcComposition[N <: NamingStrategy] extends JdbcComposition[MySQLDialect, N]
+trait MysqlJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[MySQLDialect, N]
   with BooleanObjectEncoding
   with UUIDStringEncoding {
 
   val idiom = MySQLDialect
 }
 
-trait SqliteJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[SqliteDialect, N]
-  with SqliteJdbcComposition[N] with JdbcRunContext[SqliteDialect, N]
-
-trait SqliteJdbcComposition[N <: NamingStrategy] extends JdbcComposition[SqliteDialect, N]
+trait SqliteJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[SqliteDialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding {
 
   val idiom = SqliteDialect
 }
 
-trait SqlServerJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[SQLServerDialect, N]
-  with SqlServerJdbcComposition[N]
-  with JdbcRunContext[SQLServerDialect, N]
-  with SqlServerExecuteOverride[N]
+trait SqlServerExecuteOverride[N <: NamingStrategy] extends JdbcContextVerbExecute[SQLServerDialect, N] {
 
-trait SqlServerExecuteOverride[N <: NamingStrategy] {
-  this: JdbcRunContext[SQLServerDialect, N] =>
+  private val logger = ContextLogger(classOf[SqlServerExecuteOverride[_]])
 
   override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(executionInfo: ExecutionInfo, dc: Runner): Result[O] =
     withConnectionWrapped { conn =>
@@ -69,17 +54,14 @@ trait SqlServerExecuteOverride[N <: NamingStrategy] {
     }
 }
 
-trait SqlServerJdbcComposition[N <: NamingStrategy] extends JdbcComposition[SQLServerDialect, N]
+trait SqlServerJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[SQLServerDialect, N]
   with BooleanObjectEncoding
   with UUIDStringEncoding {
 
   val idiom = SQLServerDialect
 }
 
-trait OracleJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[OracleDialect, N]
-  with OracleJdbcComposition[N] with JdbcRunContext[OracleDialect, N]
-
-trait OracleJdbcComposition[N <: NamingStrategy] extends JdbcComposition[OracleDialect, N]
+trait OracleJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[OracleDialect, N]
   with BooleanIntEncoding
   with UUIDStringEncoding {
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
@@ -4,7 +4,7 @@ import java.sql.Types
 import java.util.UUID
 
 trait UUIDObjectEncoding {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
   implicit val uuidEncoder: Encoder[UUID] = encoder(Types.OTHER, (index, value, row) => row.setObject(index, value, Types.OTHER))
   implicit val uuidDecoder: Decoder[UUID] = decoder((index, row, conn) => UUID.fromString(row.getObject(index).toString))
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
@@ -4,7 +4,7 @@ import java.sql.Types
 import java.util.UUID
 
 trait UUIDStringEncoding {
-  this: JdbcComposition[_, _] =>
+  this: JdbcContextTypes[_, _] =>
   implicit val uuidEncoder: Encoder[UUID] = encoder(Types.VARCHAR, (index, value, row) => row.setString(index, value.toString))
   implicit val uuidDecoder: Decoder[UUID] = decoder((index, row, conn) => UUID.fromString(row.getString(index)))
 }

--- a/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.monix
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbStream }
 import io.getquill.mirrorContextWithQueryProbing.Runner
 import monix.eval.Task
 import monix.reactive.Observable
 
 trait MonixContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends Context[Idiom, Naming]
-  with StreamingContext[Idiom, Naming] {
+  with ContextVerbStream[Idiom, Naming] {
 
   override type StreamResult[T] = Observable[T]
   override type Result[T] = Task[T]

--- a/quill-monix/src/main/scala/io/getquill/context/monix/MonixTranslateContext.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/MonixTranslateContext.scala
@@ -1,11 +1,11 @@
 package io.getquill.context.monix
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, TranslateContextBase }
+import io.getquill.context.{ Context, ContextTranslateProto }
 import io.getquill.idiom.Idiom
 import monix.eval.Task
 
-trait MonixTranslateContext extends TranslateContextBase {
+trait MonixTranslateContext extends ContextTranslateProto {
   this: Context[_ <: Idiom, _ <: NamingStrategy] =>
 
   override type TranslateResult[T] = Task[T]

--- a/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
+++ b/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.monix
 
 import java.sql.{ Array => _ }
-import io.getquill.context.{ ExecutionInfo, StreamingContext }
+import io.getquill.context.{ ExecutionInfo, ContextVerbStream }
 import io.getquill.context.monix.MonixNdbcContext.Runner
 import io.getquill.context.ndbc.NdbcContextBase
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -79,7 +79,7 @@ abstract class MonixNdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy, P
   runner:     Runner
 ) extends MonixContext[Dialect, Naming]
   with NdbcContextBase[Dialect, Naming, P, R]
-  with StreamingContext[Dialect, Naming]
+  with ContextVerbStream[Dialect, Naming]
   with MonixTranslateContext {
 
   import runner._

--- a/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
+++ b/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.ndbc
 
-import io.getquill.context.{ ExecutionInfo, TranslateContextBase }
+import io.getquill.context.{ ExecutionInfo, ContextTranslateProto }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.trane.future.scala.{ Await, Future, Promise }
@@ -12,7 +12,7 @@ abstract class NdbcContext[I <: SqlIdiom, N <: NamingStrategy, P <: PreparedStat
   override val idiom: I, override val naming: N, val dataSource: DataSource[P, R]
 )
   extends NdbcContextBase[I, N, P, R]
-  with TranslateContextBase {
+  with ContextTranslateProto {
 
   override type Result[T] = Future[T]
   override type RunQueryResult[T] = List[T]

--- a/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
@@ -1,12 +1,12 @@
 package io.getquill.context.qzio
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
+import io.getquill.context.{ Context, ExecutionInfo, ContextVerbStream }
 import zio.ZIO
 import zio.stream.ZStream
 
 trait ZioContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends Context[Idiom, Naming]
-  with StreamingContext[Idiom, Naming] {
+  with ContextVerbStream[Idiom, Naming] {
 
   type Error
   type Environment

--- a/quill-zio/src/main/scala/io/getquill/context/qzio/ZioTranslateContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/qzio/ZioTranslateContext.scala
@@ -1,11 +1,11 @@
 package io.getquill.context.qzio
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, TranslateContextBase }
+import io.getquill.context.{ Context, ContextTranslateMacro }
 import io.getquill.idiom.Idiom
 import zio.ZIO
 
-trait ZioTranslateContext extends TranslateContextBase {
+trait ZioTranslateContext extends ContextTranslateMacro {
   this: Context[_ <: Idiom, _ <: NamingStrategy] =>
 
   type Error


### PR DESCRIPTION
Bring Context Refactorings up to ProtoQuill stage.
- Refactor quill-sql contexts. Remove StandardContext. Change TranslateContext -> ContextVerbTranslate. Also move separate out ContextVerbPrepare 
- In quill-jdbc Move needed parts of JdbcRunContext to JdbcContextVerbExecute. Change BaseContexts and SimplifiedContexts to make more sense.
- Move Row and Quoted into the quill-core module so they do not conflict with ProtoQuill