### PR TITLE
WIP Clear out NoramlizeCache if size exceeds 100 entries

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/norm/NormalizeCaching.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/NormalizeCaching.scala
@@ -4,6 +4,7 @@ import io.getquill.ast.Ast
 import java.util.concurrent.ConcurrentHashMap
 
 object NormalizeCaching {
+  private val MAX_ENTRIES = 100
   private val cache = new ConcurrentHashMap[Ast, Ast]
 
   def apply(f: Ast => Ast): Ast => Ast = { ori =>
@@ -12,6 +13,7 @@ object NormalizeCaching {
     val normalized = if (cachedR != null) {
       cachedR
     } else {
+      if(cache.size > MAX_ENTRIES) cache.clear()
       val r = f(stablized)
       cache.put(stablized, r)
       r


### PR DESCRIPTION
Fixes #2484 

### Problem

NormalizeCache will grow forever if enough dynamic queries are compiled

### Solution

Blow away the cache if it exceeds 100 entries, ensuring it stays bounded.

### Notes

A nicer implementation would implement a real LRU cache. I don't anticipate this is a particularly hot loop and this two-line implementation solves the OOM so I think it's worth considering.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
