### PR TITLE
Update cassandra versions referenced in docker-compose to 3.11.13

### DIFF
--- a/build/Dockerfile-cassandra
+++ b/build/Dockerfile-cassandra
@@ -1,4 +1,4 @@
-FROM cassandra:3.11.11
+FROM cassandra:3.11.13
 MAINTAINER deusaquilus@gmail.com
 
 RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends default-jdk

--- a/build/m1/Dockerfile-setup
+++ b/build/m1/Dockerfile-setup
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.11
+ENV CASSANDRA_VERSION 3.11.13
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"
 RUN echo "Getting http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz"


### PR DESCRIPTION
No related issue from brief search

### Problem

Some parts of docker environment setup still references an old version of Cassandra, which is no longer downloadable, leading the setup to fail.

### Solution

Update Cassandra to a supported version

### Notes

None

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

Not applicable to this change

@getquill/maintainers
