### PR TITLE
Implement ZIO-Idiomatic JDBC Context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val codegenModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
 )
 
 lazy val bigdataModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
-  `quill-cassandra`, `quill-cassandra-lagom`, `quill-cassandra-monix`, `quill-cassandra-zio`, `quill-cassandra-alpakka`,
+  `quill-cassandra`, `quill-cassandra-monix`, `quill-cassandra-zio`, `quill-cassandra-alpakka`,
   `quill-orientdb`, `quill-spark`
 )
 
@@ -73,7 +73,6 @@ lazy val scala213Modules = baseModules ++ jsModules ++ dbModules ++ codegenModul
   `quill-finagle-mysql`,
   `quill-cassandra`,
   `quill-cassandra-alpakka`,
-  `quill-cassandra-lagom`,
   `quill-cassandra-monix`,
   `quill-cassandra-zio`,
   `quill-orientdb`,
@@ -720,25 +719,25 @@ lazy val `quill-cassandra-alpakka` =
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
     .enablePlugins(MimaPlugin)
 
-lazy val `quill-cassandra-lagom` =
-   (project in file("quill-cassandra-lagom"))
-    .settings(commonSettings: _*)
-    .settings(mimaSettings: _*)
-    .settings(
-      Test / fork := true,
-      libraryDependencies ++= {
-        val lagomVersion = if (scalaVersion.value.startsWith("2.13")) "1.6.5" else "1.5.5"
-        val versionSpecificDependencies =  if (scalaVersion.value.startsWith("2.13")) Seq("com.typesafe.play" %% "play-akka-http-server" % "2.8.8") else Seq.empty
-        Seq(
-          "com.lightbend.lagom" %% "lagom-scaladsl-persistence-cassandra" % lagomVersion % Provided,
-          "com.lightbend.lagom" %% "lagom-scaladsl-testkit" % lagomVersion % Test,
-          "com.datastax.cassandra" %  "cassandra-driver-core" % "3.11.2",
-          // lagom uses datastax 3.x driver - not compatible with 4.x in API level
-          "io.getquill" %% "quill-cassandra" % "3.10.0" % "compile->compile"
-        ) ++ versionSpecificDependencies
-      }
-    )
-    .enablePlugins(MimaPlugin)
+//lazy val `quill-cassandra-lagom` =
+//   (project in file("quill-cassandra-lagom"))
+//    .settings(commonSettings: _*)
+//    .settings(mimaSettings: _*)
+//    .settings(
+//      Test / fork := true,
+//      libraryDependencies ++= {
+//        val lagomVersion = if (scalaVersion.value.startsWith("2.13")) "1.6.5" else "1.5.5"
+//        val versionSpecificDependencies =  if (scalaVersion.value.startsWith("2.13")) Seq("com.typesafe.play" %% "play-akka-http-server" % "2.8.8") else Seq.empty
+//        Seq(
+//          "com.lightbend.lagom" %% "lagom-scaladsl-persistence-cassandra" % lagomVersion % Provided,
+//          "com.lightbend.lagom" %% "lagom-scaladsl-testkit" % lagomVersion % Test,
+//          "com.datastax.cassandra" %  "cassandra-driver-core" % "3.11.2",
+//          // lagom uses datastax 3.x driver - not compatible with 4.x in API level
+//          "io.getquill" %% "quill-cassandra" % "3.10.0" % "compile->compile"
+//        ) ++ versionSpecificDependencies
+//      }
+//    )
+//    .enablePlugins(MimaPlugin)
 
 lazy val `quill-orientdb` =
   (project in file("quill-orientdb"))

--- a/quill-cassandra-alpakka/src/main/scala/io/getquill/CassandraAlpakkaContext.scala
+++ b/quill-cassandra-alpakka/src/main/scala/io/getquill/CassandraAlpakkaContext.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.Failure
 
-class CassandraAlpakkaContext[N <: NamingStrategy](
+class CassandraAlpakkaContext[+N <: NamingStrategy](
   val naming:                     N,
   val alpakkaSession:             CassandraAlpakkaSession,
   val preparedStatementCacheSize: Long

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
@@ -8,7 +8,7 @@ import io.getquill.util.ContextLogger
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class CassandraLagomAsyncContext[N <: NamingStrategy](
+class CassandraLagomAsyncContext[+N <: NamingStrategy](
   naming:  N,
   session: CassandraSession
 )

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomSessionContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomSessionContext.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 case class CassandraLagomSession(cs: CassandraSession) extends UdtValueLookup
 
-abstract class CassandraLagomSessionContext[N <: NamingStrategy](
+abstract class CassandraLagomSessionContext[+N <: NamingStrategy](
   val naming:  N,
   val session: CassandraSession
 )

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomStreamContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomStreamContext.scala
@@ -8,7 +8,7 @@ import io.getquill.util.ContextLogger
 
 import scala.concurrent.ExecutionContext
 
-class CassandraLagomStreamContext[N <: NamingStrategy](
+class CassandraLagomStreamContext[+N <: NamingStrategy](
   naming:  N,
   session: CassandraSession
 ) extends CassandraLagomSessionContext[N](naming, session) {

--- a/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
+++ b/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
@@ -15,7 +15,7 @@ import scala.compat.java8.FutureConverters._
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success }
 
-class CassandraMonixContext[N <: NamingStrategy](
+class CassandraMonixContext[+N <: NamingStrategy](
   naming:                     N,
   session:                    CqlSession,
   preparedStatementCacheSize: Long

--- a/quill-cassandra-monix/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra-monix/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -15,7 +15,7 @@ import scala.compat.java8.FutureConverters._
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success }
 
-class CassandraStreamContext[N <: NamingStrategy](
+class CassandraStreamContext[+N <: NamingStrategy](
   naming:                     N,
   session:                    CqlSession,
   preparedStatementCacheSize: Long

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -39,7 +39,7 @@ object CassandraZioContext {
  *   Runtime.default.unsafeRun(MyZioContext.run(query[Person]).provideCustomLayer(zioSession))
  * }}
  */
-class CassandraZioContext[N <: NamingStrategy](val naming: N)
+class CassandraZioContext[+N <: NamingStrategy](val naming: N)
   extends CassandraRowContext[N]
   with ZioContext[CqlIdiom, N]
   with Context[CqlIdiom, N] {

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -12,7 +12,7 @@ import scala.compat.java8.FutureConverters._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class CassandraAsyncContext[N <: NamingStrategy](
+class CassandraAsyncContext[+N <: NamingStrategy](
   naming:                     N,
   session:                    CqlSession,
   preparedStatementCacheSize: Long

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraCqlSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraCqlSessionContext.scala
@@ -4,7 +4,7 @@ import com.datastax.oss.driver.api.core.CqlSession
 import io.getquill.context.{ AsyncFutureCache, CassandraSession, SyncCache }
 import io.getquill.context.cassandra.CassandraSessionContext
 
-abstract class CassandraCqlSessionContext[N <: NamingStrategy](
+abstract class CassandraCqlSessionContext[+N <: NamingStrategy](
   val naming:                     N,
   val session:                    CqlSession,
   val preparedStatementCacheSize: Long

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 
 class CassandraMirrorContextWithQueryProbing extends CassandraMirrorContext(Literal) with QueryProbing
 
-class CassandraMirrorContext[Naming <: NamingStrategy](naming: Naming)
+class CassandraMirrorContext[+Naming <: NamingStrategy](naming: Naming)
   extends MirrorContext[CqlIdiom, Naming](CqlIdiom, naming) with CassandraContext[Naming] {
 
   implicit val timestampDecoder: Decoder[Instant] = decoder[Instant]

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -8,7 +8,7 @@ import io.getquill.util.{ ContextLogger, LoadConfig }
 
 import scala.jdk.CollectionConverters._
 
-class CassandraSyncContext[N <: NamingStrategy](
+class CassandraSyncContext[+N <: NamingStrategy](
   naming:                     N,
   session:                    CqlSession,
   preparedStatementCacheSize: Long

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
@@ -8,7 +8,7 @@ import io.getquill.context.cassandra.encoding.{ CassandraMapper, Encodings }
 import java.time.{ Instant, LocalDate }
 import scala.reflect.ClassTag
 
-trait CassandraContext[N <: NamingStrategy]
+trait CassandraContext[+N <: NamingStrategy]
   extends Context[CqlIdiom, N]
   with Encodings
   with UdtMetaDsl

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.util.Try
 
-abstract class CassandraSessionContext[N <: NamingStrategy]
+abstract class CassandraSessionContext[+N <: NamingStrategy]
   extends CassandraPrepareContext[N]
   with CassandraBaseContext[N]
 
@@ -19,10 +19,10 @@ abstract class CassandraSessionContext[N <: NamingStrategy]
  * When using this context, we cannot encode UDTs since does not have a proper CassandraSession trait mixed in with udtValueOf.
  * Certain contexts e.g. the CassandraLagomContext does not currently have this ability.
  */
-abstract class CassandraSessionlessContext[N <: NamingStrategy]
+abstract class CassandraSessionlessContext[+N <: NamingStrategy]
   extends CassandraPrepareContext[N]
 
-trait CassandraPrepareContext[N <: NamingStrategy] extends CassandraRowContext[N] with CassandraContext[N] {
+trait CassandraPrepareContext[+N <: NamingStrategy] extends CassandraRowContext[N] with CassandraContext[N] {
   protected def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement]
 
   def probe(cql: String): Try[_] = {
@@ -49,11 +49,11 @@ trait CassandraPrepareContext[N <: NamingStrategy] extends CassandraRowContext[N
     fail("Cassandra doesn't support `returning`.")
 }
 
-trait CassandraBaseContext[N <: NamingStrategy] extends CassandraRowContext[N] {
+trait CassandraBaseContext[+N <: NamingStrategy] extends CassandraRowContext[N] {
   override type Session = CassandraSession
 }
 
-trait CassandraRowContext[N <: NamingStrategy]
+trait CassandraRowContext[+N <: NamingStrategy]
   extends CassandraContext[N]
   with Context[CqlIdiom, N]
   with Encoders

--- a/quill-codegen-jdbc/src/main/scala/io/getquill/codegen/jdbc/ComposeableTraitsJdbcCodegen.scala
+++ b/quill-codegen-jdbc/src/main/scala/io/getquill/codegen/jdbc/ComposeableTraitsJdbcCodegen.scala
@@ -22,7 +22,7 @@ import javax.sql.DataSource
  * case class Person(firstName:String, lastName:String, age:Int)
  * case class Address(...)
  *
- * trait PublicExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait PublicExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   object PersonDao { def query = querySchema[Person](...) }
@@ -54,7 +54,7 @@ import javax.sql.DataSource
  *
  * The following schema should result:
  * <pre>
- * trait CommonExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait CommonExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   object PersonDao {
@@ -64,7 +64,7 @@ import javax.sql.DataSource
  *   }
  * }
  *
- * trait PublicExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait PublicExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   object AddressDao {
@@ -76,13 +76,13 @@ import javax.sql.DataSource
  * <h2>When DAO Objects Collide</h2>
  * Now when you are trying to generate schemas which are not being stereotyped but have equivalent table names for example:
  * <pre>
- * trait AlphaExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait AlphaExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   object PersonDao { def query = querySchema[Person](...) }
  * }
  *
- * trait BravoExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait BravoExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   object PersonDao { def query = querySchema[Person](...) }
@@ -97,7 +97,7 @@ import javax.sql.DataSource
  * will collide inside of MyCustomContext. Use the parameter <code>nestedTrait=true</code> in order to get around this.
  *
  * <pre>
- * trait AlphaExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait AlphaExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   trait AlphaSchema {
@@ -105,7 +105,7 @@ import javax.sql.DataSource
  *   }
  * }
  *
- * trait BravoExtensions[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+ * trait BravoExtensions[+Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
  *   this:io.getquill.context.Context[Idiom, Naming] =>
  *
  *   trait BravoSchema {
@@ -178,7 +178,7 @@ class ComposeableTraitsJdbcCodegen(
     def traitName: String = packageName.getOrElse(defaultNamespace).capitalize + "Extensions"
 
     override def tableSchemasCode: String = super.tableSchemasCode.notEmpty.map(tsCode => s"""
-      |trait ${traitName}[Idiom <: io.getquill.idiom.Idiom, Naming <: io.getquill.NamingStrategy] {
+      |trait ${traitName}[+Idiom <: io.getquill.idiom.Idiom, +Naming <: io.getquill.NamingStrategy] {
       |  this:io.getquill.context.Context[Idiom, Naming] =>
       |
       |  ${indent(possibleTraitNesting(indent(tsCode)))}

--- a/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
 
-class AsyncMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
+class AsyncMirrorContext[+Idiom <: BaseIdiom, +Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
   extends Context[Idiom, Naming]
   with RowContext
   with ContextVerbTranslate

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -19,7 +19,7 @@ object mirrorContextWithQueryProbing
  * Similarly, when doing `ResultSet(foo:null /*Expecting an int*/, etc).getInt(1)` the result will be 0 as opposed to throwing
  * a NPE as would be the scala expectation. So we need to do `Row(foo:null /*Expecting an int*/, etc).apply(1)` do the same thing.
  */
-class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
+class MirrorContext[+Idiom <: BaseIdiom, +Naming <: NamingStrategy](val idiom: Idiom, val naming: Naming, session: MirrorSession = MirrorSession("DefaultMirrorContextSession"))
   extends Context[Idiom, Naming]
   with ProtoContext[Idiom, Naming]
   with ContextVerbTranslate

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -12,7 +12,7 @@ import java.io.Closeable
 import scala.util.Try
 import io.getquill.{ Action, ActionReturning, BatchAction, NamingStrategy, Query, Quoted }
 
-trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext
+trait Context[+Idiom <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] extends RowContext
   with Closeable
   with CoreDsl {
 

--- a/quill-core/src/main/scala/io/getquill/context/ContextVerbStream.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextVerbStream.scala
@@ -5,7 +5,7 @@ import io.getquill.{ NamingStrategy, Query, Quoted }
 import scala.language.higherKinds
 import scala.language.experimental.macros
 
-trait ContextVerbStream[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] {
+trait ContextVerbStream[+Idiom <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] {
   this: Context[Idiom, Naming] =>
 
   type StreamResult[T]

--- a/quill-core/src/test/scala/io/getquill/MirrorIdiomExt.scala
+++ b/quill-core/src/test/scala/io/getquill/MirrorIdiomExt.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import io.getquill.context.{ CanReturnField, CanReturnMultiField, CannotReturn }
 
-class TestMirrorContextTemplate[Dialect <: MirrorIdiomBase, Naming <: NamingStrategy](dialect: Dialect, naming: Naming)
+class TestMirrorContextTemplate[Dialect <: MirrorIdiomBase, +Naming <: NamingStrategy](dialect: Dialect, naming: Naming)
   extends MirrorContext[Dialect, Naming](dialect, naming) with TestEntities {
 
   def withDialect[I <: MirrorIdiomBase](dialect: I)(f: TestMirrorContextTemplate[I, Naming] => Any): Unit = {

--- a/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContext.scala
+++ b/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContext.scala
@@ -5,27 +5,27 @@ import io.getquill.context.jdbc._
 
 object DoobieContext {
 
-  class H2[N <: NamingStrategy](val naming: N)
+  class H2[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[H2Dialect, N]
     with H2JdbcContextBase[N]
 
-  class MySQL[N <: NamingStrategy](val naming: N)
+  class MySQL[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[MySQLDialect, N]
     with MysqlJdbcContextBase[N]
 
-  class Oracle[N <: NamingStrategy](val naming: N)
+  class Oracle[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[OracleDialect, N]
     with OracleJdbcContextBase[N]
 
-  class Postgres[N <: NamingStrategy](val naming: N)
+  class Postgres[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[PostgresDialect, N]
     with PostgresJdbcContextBase[N]
 
-  class SQLite[N <: NamingStrategy](val naming: N)
+  class SQLite[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[SqliteDialect, N]
     with SqliteJdbcContextBase[N]
 
-  class SQLServer[N <: NamingStrategy](val naming: N)
+  class SQLServer[+N <: NamingStrategy](val naming: N)
     extends DoobieContextBase[SQLServerDialect, N]
     with SqlServerJdbcContextBase[N]
 

--- a/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
+++ b/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
@@ -25,7 +25,7 @@ import io.getquill.util.ContextLogger
 import scala.language.implicitConversions
 
 /** Base trait from which vendor-specific variants are derived. */
-trait DoobieContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   extends JdbcContextBase[Dialect, Naming]
     with ContextVerbStream[Dialect, Naming] {
 

--- a/quill-engine/src/main/scala/io/getquill/context/ProtoContext.scala
+++ b/quill-engine/src/main/scala/io/getquill/context/ProtoContext.scala
@@ -17,7 +17,7 @@ import scala.language.higherKinds
  * as a guard-rail against API drift i.e. so that the Scala2-Quill and ProtoQuill internal-context
  * APIs remain largely the same.
  */
-trait ProtoContext[Dialect <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext {
+trait ProtoContext[+Dialect <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] extends RowContext {
   type PrepareRow
   type ResultRow
 
@@ -69,7 +69,7 @@ object ExecutionType {
   case object Unknown extends ExecutionType
 }
 
-trait ProtoStreamContext[Dialect <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext {
+trait ProtoStreamContext[Dialect <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] extends RowContext {
   type PrepareRow
   type ResultRow
 

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -23,7 +23,7 @@ object OperationType {
   case object Write extends OperationType
 }
 
-class FinagleMysqlContext[N <: NamingStrategy](
+class FinagleMysqlContext[+N <: NamingStrategy](
   val naming:                               N,
   client:                                   OperationType => Client with Transactions,
   private[getquill] val injectionTimeZone:  TimeZone,

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 import io.getquill.context.{ Context, ExecutionInfo, ContextVerbTranslate }
 import io.getquill.monad.TwitterFutureIOMonad
 
-class FinaglePostgresContext[N <: NamingStrategy](val naming: N, client: PostgresClient)
+class FinaglePostgresContext[+N <: NamingStrategy](val naming: N, client: PostgresClient)
   extends Context[FinaglePostgresDialect, N]
   with ContextVerbTranslate
   with SqlContext[FinaglePostgresDialect, N]

--- a/quill-jasync-mysql/src/main/scala/io/getquill/MysqlJAsyncContext.scala
+++ b/quill-jasync-mysql/src/main/scala/io/getquill/MysqlJAsyncContext.scala
@@ -13,7 +13,7 @@ import io.getquill.util.Messages.fail
 import com.github.jasync.sql.db.general.ArrayRowData
 import scala.jdk.CollectionConverters._
 
-class MysqlJAsyncContext[N <: NamingStrategy](naming: N, pool: ConnectionPool[MySQLConnection])
+class MysqlJAsyncContext[+N <: NamingStrategy](naming: N, pool: ConnectionPool[MySQLConnection])
   extends JAsyncContext[MySQLDialect, N, MySQLConnection](MySQLDialect, naming, pool) with UUIDStringEncoding {
 
   def this(naming: N, config: MysqlJAsyncContextConfig) = this(naming, config.pool)

--- a/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
@@ -10,7 +10,7 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 import scala.jdk.CollectionConverters._
 
-class PostgresJAsyncContext[N <: NamingStrategy](naming: N, pool: ConnectionPool[PostgreSQLConnection])
+class PostgresJAsyncContext[+N <: NamingStrategy](naming: N, pool: ConnectionPool[PostgreSQLConnection])
   extends JAsyncContext[PostgresDialect, N, PostgreSQLConnection](PostgresDialect, naming, pool)
   with ArrayEncoders
   with ArrayDecoders

--- a/quill-jasync-zio-postgres/src/main/scala/io/getquill/context/zio/PostgresZioJAsyncContext.scala
+++ b/quill-jasync-zio-postgres/src/main/scala/io/getquill/context/zio/PostgresZioJAsyncContext.scala
@@ -9,7 +9,7 @@ import io.getquill.{ NamingStrategy, PostgresDialect, ReturnAction }
 
 import scala.jdk.CollectionConverters._
 
-class PostgresZioJAsyncContext[N <: NamingStrategy](naming: N)
+class PostgresZioJAsyncContext[+N <: NamingStrategy](naming: N)
   extends ZioJAsyncContext[PostgresDialect, N, PostgreSQLConnection](PostgresDialect, naming)
   with ArrayEncoders
   with ArrayDecoders

--- a/quill-jasync-zio/src/main/scala/io/getquill/context/zio/ZioJAsyncContext.scala
+++ b/quill-jasync-zio/src/main/scala/io/getquill/context/zio/ZioJAsyncContext.scala
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 import scala.util.Try
 
-abstract class ZioJAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N)
+abstract class ZioJAsyncContext[D <: SqlIdiom, +N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N)
   extends Context[D, N]
   with ContextVerbTranslate
   with SqlContext[D, N]

--- a/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
+++ b/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
@@ -23,7 +23,7 @@ import java.util.TimeZone
 import scala.compat.java8.FutureConverters
 import scala.jdk.CollectionConverters._
 
-abstract class JAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N, pool: ConnectionPool[C])
+abstract class JAsyncContext[D <: SqlIdiom, +N <: NamingStrategy, C <: ConcreteConnection](val idiom: D, val naming: N, pool: ConnectionPool[C])
   extends Context[D, N]
   with ContextVerbTranslate
   with SqlContext[D, N]

--- a/quill-jdbc-monix/src/main/scala/io/getquill/H2MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/H2MonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.monix.MonixJdbcContext.EffectWrapper
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class H2MonixJdbcContext[N <: NamingStrategy](
+class H2MonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/MysqlMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/MysqlMonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.monix.MonixJdbcContext.EffectWrapper
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class MysqlMonixJdbcContext[N <: NamingStrategy](
+class MysqlMonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/OracleMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/OracleMonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.monix.MonixJdbcContext
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class OracleMonixJdbcContext[N <: NamingStrategy](
+class OracleMonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/PostgresMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/PostgresMonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.util.LoadConfig
 
 import javax.sql.DataSource
 
-class PostgresMonixJdbcContext[N <: NamingStrategy](
+class PostgresMonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/SqlServerMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/SqlServerMonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.monix.MonixJdbcContext.EffectWrapper
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class SqlServerMonixJdbcContext[N <: NamingStrategy](
+class SqlServerMonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/SqliteMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/SqliteMonixJdbcContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.monix.MonixJdbcContext
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class SqliteMonixJdbcContext[N <: NamingStrategy](
+class SqliteMonixJdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource with Closeable,
   runner:         EffectWrapper

--- a/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
@@ -22,7 +22,7 @@ import scala.util.Try
  * Quill context that wraps all JDBC calls in `monix.eval.Task`.
  *
  */
-abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
+abstract class MonixJdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy](
   dataSource: DataSource with Closeable,
   wrapper:    EffectWrapper
 ) extends MonixContext[Dialect, Naming]

--- a/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
@@ -8,86 +8,86 @@ import io.getquill.util.LoadConfig
 
 import javax.sql.DataSource
 
-class PostgresZioJdbcContext[N <: NamingStrategy](val naming: N)
+class PostgresZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[PostgresDialect, N]
   with PostgresJdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[PostgresDialect, N] = new PostgresZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[PostgresDialect, N] = new PostgresZioJdbcContext.Underlying[N](naming)
 }
 object PostgresZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[PostgresDialect, N]
     with PostgresJdbcTypes[N]
 }
 
-class SqlServerZioJdbcContext[N <: NamingStrategy](val naming: N)
+class SqlServerZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[SQLServerDialect, N]
   with SqlServerJdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[SQLServerDialect, N] = new SqlServerZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[SQLServerDialect, N] = new SqlServerZioJdbcContext.Underlying[N](naming)
 }
 
 object SqlServerZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[SQLServerDialect, N]
     with SqlServerJdbcTypes[N]
     with SqlServerExecuteOverride[N]
 }
 
-class H2ZioJdbcContext[N <: NamingStrategy](val naming: N)
+class H2ZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[H2Dialect, N]
   with H2JdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[H2Dialect, N] = new H2ZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[H2Dialect, N] = new H2ZioJdbcContext.Underlying[N](naming)
 }
 object H2ZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[H2Dialect, N]
     with H2JdbcTypes[N]
 }
 
-class MysqlZioJdbcContext[N <: NamingStrategy](val naming: N)
+class MysqlZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[MySQLDialect, N]
   with MysqlJdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[MySQLDialect, N] = new MysqlZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[MySQLDialect, N] = new MysqlZioJdbcContext.Underlying[N](naming)
 }
 object MysqlZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[MySQLDialect, N]
     with MysqlJdbcTypes[N]
 }
 
-class SqliteZioJdbcContext[N <: NamingStrategy](val naming: N)
+class SqliteZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[SqliteDialect, N]
   with SqliteJdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[SqliteDialect, N] = new SqliteZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[SqliteDialect, N] = new SqliteZioJdbcContext.Underlying[N](naming)
 }
 object SqliteZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[SqliteDialect, N]
     with SqliteJdbcTypes[N]
 }
 
-class OracleZioJdbcContext[N <: NamingStrategy](val naming: N)
+class OracleZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[OracleDialect, N]
   with OracleJdbcTypes[N] {
 
-  val underlying: ZioJdbcUnderlyingContext[OracleDialect, N] = new OracleZioJdbcContext.Underlying[N](naming)
+  val connDelegate: ZioJdbcUnderlyingContext[OracleDialect, N] = new OracleZioJdbcContext.Underlying[N](naming)
 }
 object OracleZioJdbcContext {
-  class Underlying[N <: NamingStrategy](val naming: N)
+  class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[OracleDialect, N]
     with OracleJdbcTypes[N]
 }
 
-trait WithProbing[D <: SqlIdiom, N <: NamingStrategy] extends ZioJdbcUnderlyingContext[D, N] {
+trait WithProbing[D <: SqlIdiom, +N <: NamingStrategy] extends ZioJdbcUnderlyingContext[D, N] {
   def probingConfig: Config;
   override def probingDataSource: Option[DataSource] = Some(JdbcContextConfig(probingConfig).dataSource)
 }
 
-trait WithProbingPrefix[D <: SqlIdiom, N <: NamingStrategy] extends WithProbing[D, N] {
+trait WithProbingPrefix[D <: SqlIdiom, +N <: NamingStrategy] extends WithProbing[D, N] {
   def configPrefix: String;
   def probingConfig: Config = LoadConfig(configPrefix)
 }

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
@@ -3,6 +3,7 @@ package io.getquill.context
 import com.typesafe.config.Config
 import io.getquill.JdbcContextConfig
 import io.getquill.util.{ ContextLogger, LoadConfig }
+import io.getquill.ziojdbc.Quill
 import zio.{ Scope, ZEnvironment, ZIO, ZLayer }
 import zio.stream.ZStream
 import izumi.reflect.Tag
@@ -27,6 +28,7 @@ object ZioJdbc {
   }
 
   object DataSourceLayer {
+    @deprecated("Use Quill.DataSource.live instead", "3.3.0")
     val live: ZLayer[DataSource, SQLException, Connection] =
       ZLayer.scoped {
         for {
@@ -36,24 +38,31 @@ object ZioJdbc {
         } yield r
       }
 
+    @deprecated("Use ZLayer.succeed(dataSource:DataSource) instead", "3.3.0")
     def fromDataSource(ds: => DataSource): ZLayer[Any, Throwable, DataSource] =
       ZLayer.fromZIO(ZIO.attempt(ds))
 
+    @deprecated("Use Quill.fromConfig instead", "3.3.0")
     def fromConfig(config: => Config): ZLayer[Any, Throwable, DataSource] =
       fromConfigClosable(config)
 
+    @deprecated("Use Quill.fromPrefix instead", "3.3.0")
     def fromPrefix(prefix: String): ZLayer[Any, Throwable, DataSource] =
       fromPrefixClosable(prefix)
 
+    @deprecated("Use Quill.fromJdbcConfig instead", "3.3.0")
     def fromJdbcConfig(jdbcContextConfig: => JdbcContextConfig): ZLayer[Any, Throwable, DataSource] =
       fromJdbcConfigClosable(jdbcContextConfig)
 
+    @deprecated("Use Quill.fromConfigClosable instead", "3.3.0")
     def fromConfigClosable(config: => Config): ZLayer[Any, Throwable, DataSource with Closeable] =
       fromJdbcConfigClosable(JdbcContextConfig(config))
 
+    @deprecated("Use Quill.fromPrefixClosable instead", "3.3.0")
     def fromPrefixClosable(prefix: String): ZLayer[Any, Throwable, DataSource with Closeable] =
       fromJdbcConfigClosable(JdbcContextConfig(LoadConfig(prefix)))
 
+    @deprecated("Use Quill.fromJdbcConfigClosable instead", "3.3.0")
     def fromJdbcConfigClosable(jdbcContextConfig: => JdbcContextConfig): ZLayer[Any, Throwable, DataSource with Closeable] =
       ZLayer.scoped {
         for {
@@ -88,20 +97,20 @@ object ZioJdbc {
 
     def onDataSource: ZIO[DataSource, SQLException, T] =
       (for {
-        q <- qzio.provideSomeLayer(DataSourceLayer.live)
+        q <- qzio.provideSomeLayer(Quill.DataSource.live)
       } yield q).refineToOrDie[SQLException]
 
     def implicitDS(implicit implicitEnv: Implicit[DataSource]): ZIO[Any, SQLException, T] =
       (for {
         q <- qzio
-          .provideSomeLayer(DataSourceLayer.live)
+          .provideSomeLayer(Quill.DataSource.live)
           .provideEnvironment(ZEnvironment(implicitEnv.env))
       } yield q).refineToOrDie[SQLException]
   }
 
   implicit class QuillZioExt[T, R](qzio: ZIO[Connection with R, Throwable, T])(implicit tag: Tag[R]) {
     /**
-     * Change `Connection` of a QIO to `DataSource with Closeable` by providing a `DataSourceLayer.live` instance
+     * Change `Connection` of a QIO to `DataSource with Closeable` by providing a `Quill.DataSource.live` instance
      * which will grab a connection from the data-source, perform the QIO operation, and the immediately release the connection.
      * This is used for data-sources that have pooled connections e.g. Hikari.
      * {{{
@@ -114,7 +123,7 @@ object ZioJdbc {
         r <- ZIO.environment[R]
         q <- qzio
           .provideSomeLayer[Connection](ZLayer.succeedEnvironment(r))
-          .provideSomeLayer(DataSourceLayer.live)
+          .provideSomeLayer(Quill.DataSource.live)
       } yield q).refineToOrDie[SQLException]
   }
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
@@ -16,7 +16,7 @@ import javax.sql.DataSource
 import scala.reflect.ClassTag
 import scala.util.Try
 
-abstract class ZioJdbcUnderlyingContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
+abstract class ZioJdbcUnderlyingContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
   with JdbcContextVerbExecute[Dialect, Naming]
   with ContextVerbStream[Dialect, Naming]
   with ZioPrepareContext[Dialect, Naming]

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
@@ -9,7 +9,7 @@ import zio.ZIO
 
 import java.sql.{ Connection, PreparedStatement, ResultSet, SQLException }
 
-trait ZioPrepareContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
+trait ZioPrepareContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
   with ContextVerbPrepare {
 
   private[getquill] val logger = ContextLogger(classOf[ZioPrepareContext[_, _]])

--- a/quill-jdbc-zio/src/main/scala/io/getquill/ziojdbc/Quill.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/ziojdbc/Quill.scala
@@ -1,0 +1,112 @@
+package io.getquill.ziojdbc
+
+import com.typesafe.config.Config
+import io.getquill._
+import io.getquill.context.ZioJdbc
+import io.getquill.context.ZioJdbc.scopedBestEffort
+import io.getquill.context.jdbc._
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.util.LoadConfig
+import zio.{ Tag, ZIO, ZLayer }
+
+import java.io.Closeable
+import java.sql.{ Connection, SQLException }
+import javax.sql.DataSource
+
+object Quill {
+  case class PostgresService[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[PostgresDialect, N] with PostgresJdbcTypes[N] {
+    val dsDelegate = new PostgresZioJdbcContext[N](naming)
+  }
+
+  object PostgresService {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, PostgresService[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new PostgresService[N](naming, ds)))
+  }
+
+  case class SqlServerService[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[SQLServerDialect, N] with SqlServerJdbcTypes[N] {
+    val dsDelegate = new SqlServerZioJdbcContext[N](naming)
+  }
+  object SqlServerService {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, SqlServerService[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new SqlServerService[N](naming, ds)))
+  }
+
+  case class H2Service[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[H2Dialect, N] with H2JdbcTypes[N] {
+    val dsDelegate = new H2ZioJdbcContext[N](naming)
+  }
+  object H2Service {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, H2Service[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new H2Service[N](naming, ds)))
+  }
+
+  case class MysqlService[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[MySQLDialect, N] with MysqlJdbcTypes[N] {
+    val dsDelegate = new MysqlZioJdbcContext[N](naming)
+  }
+  object MysqlService {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, MysqlService[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new MysqlService[N](naming, ds)))
+  }
+
+  case class SqliteService[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[SqliteDialect, N] with SqliteJdbcTypes[N] {
+    val dsDelegate = new SqliteZioJdbcContext[N](naming)
+  }
+  object SqliteService {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, SqliteService[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new SqliteService[N](naming, ds)))
+  }
+
+  case class OracleService[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+    extends Quill[OracleDialect, N] with OracleJdbcTypes[N] {
+    val dsDelegate = new OracleZioJdbcContext[N](naming)
+  }
+  object OracleService {
+    def apply[N <: NamingStrategy: Tag](naming: N): LayerConstructor[ZLayer[javax.sql.DataSource, Nothing, OracleService[N]]] =
+      new LayerConstructor(ZLayer.fromFunction((ds: javax.sql.DataSource) => new OracleService[N](naming, ds)))
+  }
+
+  object DataSource {
+    val live: ZLayer[DataSource, SQLException, Connection] =
+      ZLayer.scoped {
+        for {
+          blockingExecutor <- ZIO.blockingExecutor
+          ds <- ZIO.service[DataSource]
+          r <- ZioJdbc.scopedBestEffort(ZIO.attempt(ds.getConnection)).refineToOrDie[SQLException].onExecutor(blockingExecutor)
+        } yield r
+      }
+
+    def fromDataSource(ds: => DataSource): ZLayer[Any, Throwable, DataSource] =
+      ZLayer.fromZIO(ZIO.attempt(ds))
+
+    def fromConfig(config: => Config): ZLayer[Any, Throwable, DataSource] =
+      fromConfigClosable(config)
+
+    def fromPrefix(prefix: String): ZLayer[Any, Throwable, DataSource] =
+      fromPrefixClosable(prefix)
+
+    def fromJdbcConfig(jdbcContextConfig: => JdbcContextConfig): ZLayer[Any, Throwable, DataSource] =
+      fromJdbcConfigClosable(jdbcContextConfig)
+
+    def fromConfigClosable(config: => Config): ZLayer[Any, Throwable, DataSource with Closeable] =
+      fromJdbcConfigClosable(JdbcContextConfig(config))
+
+    def fromPrefixClosable(prefix: String): ZLayer[Any, Throwable, DataSource with Closeable] =
+      fromJdbcConfigClosable(JdbcContextConfig(LoadConfig(prefix)))
+
+    def fromJdbcConfigClosable(jdbcContextConfig: => JdbcContextConfig): ZLayer[Any, Throwable, DataSource with Closeable] =
+      ZLayer.scoped {
+        for {
+          conf <- ZIO.attempt(jdbcContextConfig)
+          ds <- scopedBestEffort(ZIO.attempt(conf.dataSource))
+        } yield ds
+      }
+  }
+
+  private[getquill] class LayerConstructor[Layer](val live: Layer)
+}
+
+trait Quill[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends QuillBaseContext[Dialect, Naming]

--- a/quill-jdbc-zio/src/main/scala/io/getquill/ziojdbc/QuillBaseContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/ziojdbc/QuillBaseContext.scala
@@ -1,0 +1,98 @@
+package io.getquill.ziojdbc
+
+import io.getquill.{ NamingStrategy, ReturnAction }
+import io.getquill.context.{ ContextVerbStream, ExecutionInfo, ProtoContext }
+import io.getquill.context.jdbc.JdbcContextTypes
+import io.getquill.context.qzio.{ ZioContext, ZioJdbcContext, ZioTranslateContext }
+import io.getquill.context.sql.idiom.SqlIdiom
+import zio.{ ZEnvironment, ZIO }
+import zio.stream.ZStream
+
+import java.sql.{ Connection, PreparedStatement, ResultSet, SQLException }
+import javax.sql.DataSource
+import scala.util.Try
+
+trait QuillBaseContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends ZioContext[Dialect, Naming]
+  with JdbcContextTypes[Dialect, Naming]
+  with ProtoContext[Dialect, Naming]
+  with ContextVerbStream[Dialect, Naming]
+  with ZioTranslateContext {
+
+  def ds: DataSource
+
+  override type StreamResult[T] = ZStream[Environment, Error, T]
+  override type Result[T] = ZIO[Environment, Error, T]
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Long
+  override type RunActionReturningResult[T] = T
+  override type RunBatchActionResult = List[Long]
+  override type RunBatchActionReturningResult[T] = List[T]
+
+  override type Error = SQLException
+  override type Environment = Any
+  override type PrepareRow = PreparedStatement
+  override type ResultRow = ResultSet
+
+  override type TranslateResult[T] = ZIO[Environment, Error, T]
+  override type Session = Connection
+
+  lazy val underlying: ZioJdbcContext[Dialect, Naming] = dsDelegate
+  private[getquill] val dsDelegate: ZioJdbcContext[Dialect, Naming]
+
+  override def close() = ()
+
+  override def probe(sql: String): Try[_] = dsDelegate.probe(sql)
+
+  def executeAction(sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, Long] =
+    onDS(dsDelegate.executeAction(sql, prepare)(info, dc))
+
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, List[T]] =
+    onDS(dsDelegate.executeQuery[T](sql, prepare, extractor)(info, dc))
+
+  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, T] =
+    onDS(dsDelegate.executeQuerySingle[T](sql, prepare, extractor)(info, dc))
+
+  override def translateQuery[T](statement: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor, prettyPrint: Boolean = false)(executionInfo: ExecutionInfo, dc: Runner): TranslateResult[String] =
+    onDS(dsDelegate.translateQuery[T](statement, prepare, extractor, prettyPrint)(executionInfo, dc))
+
+  override def translateBatchQuery(groups: List[BatchGroup], prettyPrint: Boolean = false)(executionInfo: ExecutionInfo, dc: Runner): TranslateResult[List[String]] =
+    onDS(dsDelegate.translateBatchQuery(groups.asInstanceOf[List[QuillBaseContext.this.dsDelegate.BatchGroup]], prettyPrint)(executionInfo, dc))
+
+  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): ZStream[Any, SQLException, T] =
+    onDSStream(dsDelegate.streamQuery[T](fetchSize, sql, prepare, extractor)(info, dc))
+
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, O] =
+    onDS(dsDelegate.executeActionReturning[O](sql, prepare, extractor, returningBehavior)(info, dc))
+
+  def executeActionReturningMany[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, List[O]] =
+    onDS(dsDelegate.executeActionReturningMany[O](sql, prepare, extractor, returningBehavior)(info, dc))
+
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, List[Long]] =
+    onDS(dsDelegate.executeBatchAction(groups.asInstanceOf[List[QuillBaseContext.this.dsDelegate.BatchGroup]])(info, dc))
+
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: Runner): ZIO[Any, SQLException, List[T]] =
+    onDS(dsDelegate.executeBatchActionReturning[T](groups.asInstanceOf[List[QuillBaseContext.this.dsDelegate.BatchGroupReturning]], extractor)(info, dc))
+
+  // Used in translation functions
+  private[getquill] def prepareParams(statement: String, prepare: Prepare): ZIO[Any, SQLException, Seq[String]] =
+    onDS(dsDelegate.prepareParams(statement, prepare))
+
+  /**
+   * Execute instructions in a transaction. For example, to add a Person row to the database and return
+   * the contents of the Person table immediately after that:
+   * {{{
+   *   val a = run(query[Person].insert(Person(...)): ZIO[Has[DataSource], SQLException, Long]
+   *   val b = run(query[Person]): ZIO[Has[DataSource], SQLException, Person]
+   *   transaction(a *> b): ZIO[Has[DataSource], SQLException, Person]
+   * }}}
+   */
+  def transaction[R, A](op: ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
+    dsDelegate.transaction(op).provideSomeEnvironment[R]((env: ZEnvironment[R]) => env.add[DataSource](ds: DataSource))
+
+  private def onDS[T](qio: ZIO[DataSource, SQLException, T]): ZIO[Any, SQLException, T] =
+    qio.provideEnvironment(ZEnvironment(ds))
+
+  private def onDSStream[T](qstream: ZStream[DataSource, SQLException, T]): ZStream[Any, SQLException, T] =
+    qstream.provideEnvironment(ZEnvironment(ds))
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/PeopleZioSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/PeopleZioSpec.scala
@@ -2,8 +2,18 @@ package io.getquill
 
 import io.getquill.context.sql.PeopleSpec
 import io.getquill.context.qzio.ZioJdbcContext
+import io.getquill.ziojdbc.Quill
 
 trait PeopleZioSpec extends PeopleSpec with ZioSpec {
+
+  val context: Quill[_, _]
+  import context._
+
+  val `Ex 11 query` = quote(query[Person])
+  val `Ex 11 expected` = peopleEntries
+}
+
+trait PeopleZioProxySpec extends PeopleSpec with ZioProxySpec {
 
   val context: ZioJdbcContext[_, _]
   import context._

--- a/quill-jdbc-zio/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
@@ -1,14 +1,15 @@
 package io.getquill
 
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import io.getquill.context.qzio.ResultSetIterator
 import zio.ZIO
-import io.getquill.postgres._
 
 import javax.sql.DataSource
 import scala.collection.mutable.ArrayBuffer
 
-class ResultSetIteratorSpec extends ZioSpec {
+class ResultSetIteratorSpec extends ZioProxySpec {
 
+  implicit val pool = Implicit(io.getquill.postgres.pool)
   val ctx = new PostgresZioJdbcContext(Literal)
   import ctx._
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
@@ -3,12 +3,43 @@ package io.getquill
 import io.getquill.context.qzio.ImplicitSyntax._
 import org.scalatest.BeforeAndAfterAll
 import zio.stream.{ ZSink, ZStream }
-import zio.{ Runtime, Unsafe, ZIO }
+import zio.{ Runtime, Tag, Unsafe, ZEnvironment, ZIO, ZLayer }
 
 import java.sql.Connection
 import javax.sql.DataSource
 
+object ZioSpec {
+  def runLayerUnsafe[T: Tag](layer: ZLayer[Any, Throwable, T]): T =
+    zio.Unsafe.unsafe { implicit u =>
+      zio.Runtime.default.unsafe.run(zio.Scope.global.extend(layer.build)).getOrThrow()
+    }.get
+}
+
 trait ZioSpec extends Spec with BeforeAndAfterAll {
+
+  def accumulate[T](stream: ZStream[Any, Throwable, T]): ZIO[Any, Throwable, List[T]] =
+    stream.run(ZSink.collectAll).map(_.toList)
+
+  def collect[T](stream: ZStream[Any, Throwable, T]): List[T] =
+    Unsafe.unsafe { implicit u =>
+      zio.Runtime.default.unsafe.run(stream.run(ZSink.collectAll).map(_.toList)).getOrThrow()
+    }
+
+  def collect[T](qzio: ZIO[Any, Throwable, T]): T =
+    Unsafe.unsafe { implicit u =>
+      zio.Runtime.default.unsafe.run(qzio).getOrThrow()
+    }
+
+  implicit class ZStreamTestExt[T](stream: ZStream[Any, Throwable, T]) {
+    def runSyncUnsafe() = collect[T](stream)
+  }
+
+  implicit class ZioTestExt[T](qzio: ZIO[Any, Throwable, T]) {
+    def runSyncUnsafe() = collect[T](qzio)
+  }
+}
+
+trait ZioProxySpec extends Spec with BeforeAndAfterAll {
 
   def accumulateDS[T](stream: ZStream[DataSource, Throwable, T]): ZIO[DataSource, Throwable, List[T]] =
     stream.run(ZSink.collectAll).map(_.toList)
@@ -16,17 +47,16 @@ trait ZioSpec extends Spec with BeforeAndAfterAll {
   def accumulate[T](stream: ZStream[Connection, Throwable, T]): ZIO[Connection, Throwable, List[T]] =
     stream.run(ZSink.collectAll).map(_.toList)
 
-  def collect[T](stream: ZStream[DataSource, Throwable, T])(implicit runtime: Implicit[Runtime.Scoped[DataSource]]): List[T] =
+  def collect[T](stream: ZStream[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]): List[T] =
     Unsafe.unsafe { implicit u =>
-      runtime.env.unsafe.run(stream.run(ZSink.collectAll).map(_.toList)).getOrThrow()
+      zio.Runtime.default.unsafe.run(stream.run(ZSink.collectAll).map(_.toList).provideEnvironment(ZEnvironment(runtime.env))).getOrThrow()
     }
 
-  def collect[T](qzio: ZIO[DataSource, Throwable, T])(implicit runtime: Implicit[Runtime.Scoped[DataSource]]): T =
+  def collect[T](qzio: ZIO[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]): T =
     Unsafe.unsafe { implicit u =>
-      runtime.env.unsafe.run(qzio).getOrThrow()
+      zio.Runtime.default.unsafe.run(qzio.provideEnvironment(ZEnvironment(runtime.env))).getOrThrow()
     }
 
-  // TODO Change to runUnsafe
   implicit class ZioAnyOps[T](qzio: ZIO[Any, Throwable, T]) {
     def runSyncUnsafe() =
       Unsafe.unsafe { implicit u =>
@@ -34,11 +64,11 @@ trait ZioSpec extends Spec with BeforeAndAfterAll {
       }
   }
 
-  implicit class ZStreamTestExt[T](stream: ZStream[DataSource, Throwable, T])(implicit runtime: Implicit[Runtime.Scoped[DataSource]]) {
+  implicit class ZStreamTestExt[T](stream: ZStream[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]) {
     def runSyncUnsafe() = collect[T](stream)
   }
 
-  implicit class ZioTestExt[T](qzio: ZIO[DataSource, Throwable, T])(implicit runtime: Implicit[Runtime.Scoped[DataSource]]) {
+  implicit class ZioTestExt[T](qzio: ZIO[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]) {
     def runSyncUnsafe() = collect[T](qzio)
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainApp.scala
@@ -1,7 +1,7 @@
 package io.getquill.examples
 
+import io.getquill.ziojdbc.Quill
 import io.getquill.{ Literal, PostgresZioJdbcContext }
-import io.getquill.context.ZioJdbc._
 import zio.{ Runtime, Unsafe }
 
 object PlainApp {
@@ -11,7 +11,7 @@ object PlainApp {
 
   case class Person(name: String, age: Int)
 
-  val zioDS = DataSourceLayer.fromPrefix("testPostgresDB")
+  val zioDS = Quill.DataSource.fromPrefix("testPostgresDB")
 
   def main(args: Array[String]): Unit = {
     val people = quote {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppDataSource.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppDataSource.scala
@@ -1,8 +1,8 @@
 package io.getquill.examples
 
 import com.zaxxer.hikari.HikariDataSource
-import io.getquill.context.ZioJdbc._
 import io.getquill.util.LoadConfig
+import io.getquill.ziojdbc.Quill
 import io.getquill.{ JdbcContextConfig, Literal, PostgresZioJdbcContext }
 import zio.Console.printLine
 import zio.{ Runtime, Unsafe }
@@ -16,7 +16,7 @@ object PlainAppDataSource {
 
   def config = JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource
 
-  val zioDS = DataSourceLayer.fromDataSource(new HikariDataSource(config))
+  val zioDS = Quill.DataSource.fromDataSource(new HikariDataSource(config))
 
   def main(args: Array[String]): Unit = {
     val people = quote {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppQuillService.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppQuillService.scala
@@ -1,0 +1,48 @@
+package io.getquill.examples
+
+import io.getquill.ziojdbc.Quill
+import io.getquill._
+import zio._
+import zio.Console.printLine
+
+import java.sql.SQLException
+
+object PlainAppQuillService {
+
+  case class DataService(quill: Quill[PostgresDialect, Literal]) {
+    import quill._
+    val people = quote { query[Person] }
+    def peopleByName = quote { (name: String) => people.filter(p => p.name == name) }
+  }
+  case class ApplicationLive(dataService: DataService) {
+    import dataService.quill._
+    def getPeopleByName(name: String): ZIO[Any, SQLException, List[Person]] = run(dataService.peopleByName(lift(name)))
+    def getAllPeople(): ZIO[Any, SQLException, List[Person]] = run(dataService.people)
+  }
+  object Application {
+    def getPeopleByName(name: String) =
+      ZIO.serviceWithZIO[ApplicationLive](_.getPeopleByName(name))
+    def getAllPeople() =
+      ZIO.serviceWithZIO[ApplicationLive](_.getAllPeople())
+  }
+  case class Person(name: String, age: Int)
+
+  def main(args: Array[String]): Unit = {
+    val dataServiceLive = ZLayer.fromFunction(DataService.apply _)
+    val applicationLive = ZLayer.fromFunction(ApplicationLive.apply _)
+    val dataSourceLive = Quill.DataSource.fromPrefix("testPostgresDB")
+    val postgresServiceLive = Quill.PostgresService(Literal).live
+
+    Unsafe.unsafe { implicit u =>
+      Runtime.default.unsafe.run(
+        (for {
+          joes <- Application.getPeopleByName("Joe")
+          _ <- printLine(joes)
+          allPeople <- Application.getAllPeople()
+          _ <- printLine(allPeople)
+        } yield ()).provide(applicationLive, dataServiceLive, dataSourceLive, postgresServiceLive)
+      ).getOrThrow()
+    }
+    ()
+  }
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
@@ -1,9 +1,9 @@
 package io.getquill.examples
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
+import io.getquill.ziojdbc.Quill
 import io.getquill.{ Literal, PostgresZioJdbcContext }
-import zio.{ ZIOAppDefault, ZIO, ZLayer }
 import zio.Console._
+import zio.{ ZIO, ZIOAppDefault, ZLayer }
 
 import java.sql.SQLException
 import javax.sql.DataSource
@@ -33,7 +33,7 @@ object DBManager {
 
   val ctx = new PostgresZioJdbcContext(Literal)
   import ctx._
-  val zioDS: ZLayer[Any, Throwable, DataSource] = DataSourceLayer.fromPrefix("testPostgresDB")
+  val zioDS: ZLayer[Any, Throwable, DataSource] = Quill.DataSource.fromPrefix("testPostgresDB")
 
   trait Service {
     def persist(person: Person): ZIO[DataSource, SQLException, Long]

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
@@ -1,7 +1,7 @@
 package io.getquill.examples
 
 import io.getquill._
-import io.getquill.context.ZioJdbc._
+import io.getquill.ziojdbc.Quill
 import zio.Console.printLine
 import zio.ZIOAppDefault
 
@@ -12,7 +12,7 @@ object ZioApp extends ZIOAppDefault {
 
   case class Person(name: String, age: Int)
 
-  val zioDS = DataSourceLayer.fromPrefix("testPostgresDB")
+  val zioDS = Quill.DataSource.fromPrefix("testPostgresDB")
 
   override def run = {
     val people = quote {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppExample.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppExample.scala
@@ -1,14 +1,15 @@
 package io.getquill.examples
 
 import io.getquill._
-import io.getquill.context.ZioJdbc._
+import io.getquill.ziojdbc.Quill
 import zio._
+
 import javax.sql.DataSource
 
 case class Person(name: String, age: Int)
 
 object QuillContext extends PostgresZioJdbcContext(SnakeCase) {
-  val dataSourceLayer = DataSourceLayer.fromPrefix("testPostgresDB").orDie
+  val dataSourceLayer = Quill.DataSource.fromPrefix("testPostgresDB").orDie
 }
 
 object DataService {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
@@ -2,13 +2,14 @@ package io.getquill.h2
 
 import java.sql.{ Connection, ResultSet }
 import io.getquill.PrepareZioJdbcSpecBase
-
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import org.scalatest.BeforeAndAfter
 
 class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
 
-  val context = testContext
+  val context = testContext.underlying
   import context._
+  implicit val implicitPool = Implicit(pool)
 
   before {
     testContext.run(query[Product].delete).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/ZioJdbcContextSpec.scala
@@ -22,7 +22,7 @@ class ZioJdbcContextSpec extends ZioSpec {
         seq <- testContext.transaction {
           for {
             _ <- testContext.run(qr1.insert(_.i -> 33))
-            s <- accumulateDS(testContext.stream(qr1))
+            s <- accumulate(testContext.stream(qr1))
           } yield s
         }
         r <- testContext.run(qr1)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/h2.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/h2.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object h2 {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testH2DB"))) }
-  object testContext extends H2ZioJdbcContext(Literal) with TestEntities
+  val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testH2DB"))
+  object testContext extends Quill.H2Service(Literal, pool) with TestEntities
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
@@ -3,9 +3,8 @@ package io.getquill.integration
 import java.sql.{ Connection, ResultSet }
 import org.scalatest.matchers.should.Matchers._
 import io.getquill._
-
 import io.getquill.context.ZioJdbc._
-import io.getquill.postgres._ // Implicitly use the postgres connection pool
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 
 /**
  * This is a long-running test that will cause a OutOfMemory exception if
@@ -17,7 +16,8 @@ import io.getquill.postgres._ // Implicitly use the postgres connection pool
  *
  * As a default, this test will run as part of the suite without blowing up.
  */
-class StreamResultsOrBlowUpSpec extends ZioSpec {
+class StreamResultsOrBlowUpSpec extends ZioProxySpec {
+  implicit val pool = Implicit(io.getquill.postgres.pool)
 
   case class Person(name: String, age: Int)
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/OnDataSourceSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/OnDataSourceSpec.scala
@@ -1,14 +1,12 @@
-package io.getquill.postgres
+package io.getquill.misc
 
-import io.getquill.PeopleZioSpec
-
-import org.scalatest.matchers.should.Matchers._
-import zio.{ ZIO, ZLayer }
+import io.getquill.PeopleZioProxySpec
 import io.getquill.context.ZioJdbc._
+import zio.{ ZIO, ZLayer }
 
 import javax.sql.DataSource
 
-class OnDataSourceSpec extends PeopleZioSpec {
+class OnDataSourceSpec extends PeopleZioProxySpec {
 
   val context = testContext
 
@@ -45,7 +43,7 @@ class OnDataSourceSpec extends PeopleZioSpec {
     "should work" in {
       // This is how you import the encoders/decoders of `underlying` context without importing things that will conflict
       // i.e. the quote and run methods
-      import testContext.underlying.{ quote => _, run => _, prepare => _, _ }
+      import testContext.underlying.{ prepare => _, quote => _, run => _, _ }
       val people =
         (for {
           out <- testContext.underlying.run(query[Person].filter(p => p.name == "Alex"))
@@ -58,13 +56,13 @@ class OnDataSourceSpec extends PeopleZioSpec {
   }
 
   "implicitDS on underlying context" - {
-    import io.getquill.context.qzio.ImplicitSyntax._
 
     "should work with additional dependency" in {
       // This is how you import the decoders of `underlying` context without importing things that will conflict
       // i.e. the quote and run methods
       case class Service(ds: DataSource) {
-        implicit val dsi = Implicit(ds)
+        // Note that implicit Implicit(dataSource) is given by the package-level `pool` object
+        //implicit val dsi = Implicit(ds)
         val people =
           (for {
             n <- ZIO.service[String]
@@ -84,7 +82,8 @@ class OnDataSourceSpec extends PeopleZioSpec {
       // This is how you import the decoders of `underlying` context without importing things that will conflict
       // i.e. the quote and run methods
       case class Service(ds: DataSource) {
-        implicit val dsi = Implicit(ds)
+        // Note that implicit Implicit(dataSource) is given by the package-level `pool` object
+        //implicit val dsi = Implicit(ds)
         val people =
           (for {
             out <- testContext.run(query[Person].filter(p => p.name == "Alex"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/PeopleZioOuterJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/PeopleZioOuterJdbcSpec.scala
@@ -1,15 +1,14 @@
-package io.getquill.postgres
+package io.getquill.misc
 
-import io.getquill.util.LoadConfig
-import io.getquill.{ JdbcContextConfig, Literal, PostgresZioJdbcContext, Spec }
-import zio.{ Unsafe, ZEnvironment, Runtime }
+import io.getquill.{ Literal, PostgresZioJdbcContext, Spec }
+import zio.{ Runtime, Unsafe, ZEnvironment }
 
 class PeopleZioOuterJdbcSpec extends Spec {
   val testContext = new PostgresZioJdbcContext(Literal)
   import testContext._
   case class Person(name: String, age: Int)
 
-  def ds = JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource
+  def ds = io.getquill.postgres.pool
 
   "test query" in {
     val q = quote {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/PrepareJdbcSpec.scala
@@ -1,11 +1,11 @@
-package io.getquill.postgres
+package io.getquill.misc
 
-import io.getquill.{ PrepareZioJdbcSpecBase, ZioSpec }
+import io.getquill.{ PrepareZioJdbcSpecBase, ZioProxySpec }
 import org.scalatest.BeforeAndAfter
 
 import java.sql.{ Connection, ResultSet }
 
-class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with ZioSpec with BeforeAndAfter {
+class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with ZioProxySpec with BeforeAndAfter {
 
   val context = testContext
   import context._

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/StreamingWithFetchSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/StreamingWithFetchSpec.scala
@@ -1,11 +1,11 @@
-package io.getquill.postgres
+package io.getquill.misc
 
-import io.getquill.ZioSpec
+import io.getquill.ZioProxySpec
 import io.getquill.context.ZioJdbc._
 import org.scalatest.BeforeAndAfter
-import zio.Unsafe
+import zio.ZEnvironment
 
-class StreamingWithFetchSpec extends ZioSpec with BeforeAndAfter {
+class StreamingWithFetchSpec extends ZioProxySpec with BeforeAndAfter {
 
   val context = testContext
   import testContext._
@@ -16,9 +16,7 @@ class StreamingWithFetchSpec extends ZioSpec with BeforeAndAfter {
   val insert = quote { (p: Person) => query[Person].insertValue(p) }
 
   def result[T](qzio: QIO[T]): T =
-    Unsafe.unsafe { implicit u =>
-      pool.env.unsafe.run(qzio).getOrThrow()
-    }
+    qzio.provideEnvironment(ZEnvironment(io.getquill.postgres.pool)).runSyncUnsafe()
 
   before {
     testContext.run(quote(query[Person].delete)).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/package.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/package.scala
@@ -1,0 +1,8 @@
+package io.getquill
+
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
+
+package object misc {
+  implicit val pool = Implicit(io.getquill.postgres.pool)
+  object testContext extends PostgresZioJdbcContext(Literal) with TestEntities
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
@@ -2,13 +2,14 @@ package io.getquill.mysql
 
 import java.sql.{ Connection, ResultSet }
 import io.getquill.PrepareZioJdbcSpecBase
-
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import org.scalatest.BeforeAndAfter
 
 class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
 
-  val context = testContext
+  val context = testContext.underlying
   import context._
+  implicit val implicitPool = Implicit(pool)
 
   before {
     testContext.run(query[Product].delete).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/ZioJdbcContextSpec.scala
@@ -3,8 +3,6 @@ package io.getquill.mysql
 import io.getquill.ZioSpec
 import zio.{ ZIO, ZLayer }
 
-import javax.sql.DataSource
-
 class ZioJdbcContextSpec extends ZioSpec {
 
   val context = testContext
@@ -28,7 +26,7 @@ class ZioJdbcContextSpec extends ZioSpec {
           } yield qry
         }
         r <- testContext.run(qr1)
-      } yield r).provideSomeLayer(ZLayer.service[DataSource] >>> ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
+      } yield r).provideSomeLayer(ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
     }
     "success - stream" in {
       (for {
@@ -36,7 +34,7 @@ class ZioJdbcContextSpec extends ZioSpec {
         seq <- testContext.transaction {
           for {
             _ <- testContext.run(qr1.insert(_.i -> 33))
-            s <- accumulateDS(testContext.stream(qr1))
+            s <- accumulate(testContext.stream(qr1))
           } yield s
         }
         r <- testContext.run(qr1)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/mysql.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/mysql.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object mysql {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testMysqlDB"))) }
-  object testContext extends MysqlZioJdbcContext(Literal) with TestEntities
+  implicit val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testMysqlDB"))
+  object testContext extends Quill.MysqlService(Literal, pool) with TestEntities
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PeopleZioJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PeopleZioJdbcSpec.scala
@@ -1,9 +1,7 @@
 package io.getquill.oracle
 
 import io.getquill.PeopleZioSpec
-
 import org.scalatest.matchers.should.Matchers._
-import io.getquill.context.ZioJdbc._
 
 class PeopleZioJdbcSpec extends PeopleZioSpec {
 
@@ -12,15 +10,14 @@ class PeopleZioJdbcSpec extends PeopleZioSpec {
 
   override def beforeAll = {
     super.beforeAll()
-    testContext.underlying.transaction {
-      import testContext.underlying._
+    testContext.transaction {
       for {
-        _ <- testContext.underlying.run(query[Couple].delete)
-        _ <- testContext.underlying.run(query[Person].delete)
-        _ <- testContext.underlying.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
-        _ <- testContext.underlying.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+        _ <- testContext.run(query[Couple].delete)
+        _ <- testContext.run(query[Person].delete)
+        _ <- testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+        _ <- testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
       } yield ()
-    }.onDataSource.runSyncUnsafe()
+    }.runSyncUnsafe()
   }
 
   "Example 1 - differences" in {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
@@ -2,13 +2,14 @@ package io.getquill.oracle
 
 import java.sql.{ Connection, ResultSet }
 import io.getquill.PrepareZioJdbcSpecBase
-
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import org.scalatest.BeforeAndAfter
 
 class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
 
-  val context = testContext
+  val context = testContext.underlying
   import context._
+  implicit val implicitPool = Implicit(pool)
 
   before {
     testContext.run(query[Product].delete).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.oracle
 
 import io.getquill.ZioSpec
 import zio.ZIO
-import io.getquill.context.ZioJdbc._
 
 class ZioJdbcContextSpec extends ZioSpec {
 
@@ -25,7 +24,7 @@ class ZioJdbcContextSpec extends ZioSpec {
         seq <- testContext.transaction {
           for {
             _ <- testContext.run(qr1.insert(_.i -> 33))
-            s <- accumulateDS(testContext.stream(qr1))
+            s <- accumulate(testContext.stream(qr1))
           } yield s
         }
         r <- testContext.run(qr1)
@@ -34,36 +33,34 @@ class ZioJdbcContextSpec extends ZioSpec {
     "failure" in {
       (for {
         _ <- testContext.run(qr1.delete)
-        e <- testContext.underlying.transaction {
-          import testContext.underlying._
+        e <- testContext.transaction {
           ZIO.collectAll(Seq(
-            testContext.underlying.run(qr1.insert(_.i -> 18)),
+            testContext.run(qr1.insert(_.i -> 18)),
             ZIO.attempt {
               throw new IllegalStateException
             }
           ))
         }.catchSome {
           case e: Exception => ZIO.attempt(e.getClass.getSimpleName)
-        }.onDataSource
+        }
         r <- testContext.run(qr1)
       } yield (e, r.isEmpty)).runSyncUnsafe() mustEqual (("IllegalStateException", true))
     }
     "nested" in {
       (for {
         _ <- testContext.run(qr1.delete)
-        _ <- testContext.underlying.transaction {
-          import testContext.underlying._
-          testContext.underlying.transaction {
-            testContext.underlying.run(qr1.insert(_.i -> 33))
+        _ <- testContext.transaction {
+          testContext.transaction {
+            testContext.run(qr1.insert(_.i -> 33))
           }
-        }.onDataSource
+        }
         r <- testContext.run(qr1)
       } yield r).runSyncUnsafe().map(_.i) mustEqual List(33)
     }
     "prepare" in {
-      testContext.underlying.prepareParams(
+      testContext.prepareParams(
         "select * from Person where name=? and age > ?", (ps, _) => (List("Sarah", 127), ps)
-      ).onDataSource.runSyncUnsafe() mustEqual List("127", "'Sarah'")
+      ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
   }
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/oracle.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/oracle.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object oracle {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testOracleDB"))) }
-  object testContext extends OracleZioJdbcContext(Literal) with TestEntities
+  implicit val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testOracleDB"))
+  object testContext extends Quill.OracleService(Literal, pool) with TestEntities
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -1,18 +1,19 @@
 package io.getquill.postgres
 
 import java.util.UUID
-import io.getquill.{ JdbcContextConfig, Literal, PostgresZioJdbcContext, ZioSpec }
+import io.getquill.{ JdbcContextConfig, Literal, PostgresZioJdbcContext, ZioProxySpec }
 import io.getquill.context.sql.ProductSpec
 import io.getquill.util.LoadConfig
 import io.getquill.context.ZioJdbc._
 import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ziojdbc.Quill
 import zio.{ Runtime, Unsafe }
 
 import scala.util.Random
 
-class ConnectionLeakTest extends ProductSpec with ZioSpec {
+class ConnectionLeakTest extends ProductSpec with ZioProxySpec {
 
-  implicit val pool = Implicit(DataSourceLayer.fromPrefix("testPostgresDB"))
+  implicit val pool = Implicit(Quill.DataSource.fromPrefix("testPostgresDB"))
 
   val dataSource = JdbcContextConfig(LoadConfig("testPostgresLeakDB")).dataSource
   val context = new PostgresZioJdbcContext(Literal)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
@@ -1,0 +1,81 @@
+package io.getquill.postgres
+
+import io.getquill.ziojdbc.Quill
+import io.getquill.{ testContext => _, _ }
+import zio.{ Unsafe, ZIO, ZLayer }
+
+import java.sql.SQLException
+import javax.sql.DataSource
+
+class MultiLevelServiceSpec extends PeopleZioSpec with ZioSpec {
+
+  val context = testContext
+  import testContext._
+  val entries = List(Person("Joe", 1), Person("Jack", 2))
+
+  override def beforeAll = {
+    super.beforeAll()
+    testContext.transaction {
+      for {
+        _ <- testContext.run(query[Person].delete)
+        _ <- testContext.run(liftQuery(entries).foreach(p => peopleInsert(p)))
+      } yield ()
+    }.runSyncUnsafe()
+  }
+
+  case class DataService(quill: Quill[PostgresDialect, Literal]) {
+    import quill.{ run => qrun, _ }
+    val people = quote { query[Person] }
+    def somePeopleByName = quote { (ps: Query[Person], name: String) => ps.filter(p => p.name == name) }
+    def peopleByName = quote { (name: String) => people.filter(p => p.name == name) }
+    def getAllPeople(): ZIO[Any, SQLException, List[Person]] = qrun(people)
+    def getPeopleByName(name: String): ZIO[Any, SQLException, List[Person]] = qrun(peopleByName(lift(name)))
+  }
+  case class ApplicationLive(dataService: DataService) {
+    import dataService._
+    import dataService.quill.{ run => qrun, _ }
+
+    val joes = quote { peopleByName("Joe") }
+    def getJoes: ZIO[Any, SQLException, List[Person]] = qrun(joes)
+    def getPeopleByName3(name: String): ZIO[Any, SQLException, List[Person]] = qrun(somePeopleByName(query[Person], lift(name)))
+    def getPeopleByName2(name: String): ZIO[Any, SQLException, List[Person]] = qrun(peopleByName(lift(name)))
+    def getPeopleByName(name: String): ZIO[Any, SQLException, List[Person]] = dataService.getPeopleByName(name)
+    def getAllPeople(): ZIO[Any, SQLException, List[Person]] = dataService.getAllPeople()
+  }
+  val dataServiceLive = ZLayer.fromFunction(DataService.apply _)
+  val applicationLive = ZLayer.fromFunction(ApplicationLive.apply _)
+
+  object Application {
+    def getJoes() = ZIO.serviceWithZIO[ApplicationLive](_.getJoes)
+    def getPeopleByName3(name: String) = ZIO.serviceWithZIO[ApplicationLive](_.getPeopleByName3(name))
+    def getPeopleByName2(name: String) = ZIO.serviceWithZIO[ApplicationLive](_.getPeopleByName2(name))
+    def getPeopleByName(name: String) = ZIO.serviceWithZIO[ApplicationLive](_.getPeopleByName(name))
+    def getAllPeople() = ZIO.serviceWithZIO[ApplicationLive](_.getAllPeople())
+  }
+
+  "All Composition variations must work" in {
+
+    val dataSourceLive = ZLayer.succeed(io.getquill.postgres.pool)
+    val postgresServiceLive = ZLayer.fromFunction(Quill.PostgresService(Literal, _: DataSource))
+
+    val (a, b, c, d, e) =
+      Unsafe.unsafe { implicit u =>
+        zio.Runtime.default.unsafe.run(
+          (for {
+            a <- Application.getJoes()
+            b <- Application.getPeopleByName("Joe")
+            c <- Application.getPeopleByName2("Joe")
+            d <- Application.getPeopleByName3("Joe")
+            e <- Application.getAllPeople()
+          } yield (a, b, c, d, e)).provide(applicationLive, dataServiceLive, dataSourceLive, postgresServiceLive)
+        ).getOrThrow()
+      }
+
+    val joes = entries.filter(_.name == "Joe")
+    a mustEqual joes
+    b mustEqual joes
+    c mustEqual joes
+    d mustEqual joes
+    e.toSet mustEqual entries.toSet
+  }
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PeopleZioJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PeopleZioJdbcSpec.scala
@@ -1,10 +1,9 @@
 package io.getquill.postgres
 
-import io.getquill.PeopleZioSpec
-
+import io.getquill.{ PeopleZioSpec, ZioSpec }
 import org.scalatest.matchers.should.Matchers._
 
-class PeopleZioJdbcSpec extends PeopleZioSpec {
+class PeopleZioJdbcSpec extends PeopleZioSpec with ZioSpec {
 
   val context = testContext
   import testContext._

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/QuillServiceSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/QuillServiceSpec.scala
@@ -3,7 +3,7 @@ package io.getquill.postgres
 import io.getquill.ZioSpec
 import zio.{ ZIO, ZLayer }
 
-class ZioJdbcContextSpec extends ZioSpec {
+class QuillServiceSpec extends ZioSpec {
 
   val context = testContext
   import testContext._

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object postgres {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testPostgresDB"))) }
-  object testContext extends PostgresZioJdbcContext(Literal) with TestEntities
+  val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testPostgresDB"))
+  object testContext extends Quill.PostgresService(Literal, pool) with TestEntities
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
@@ -2,13 +2,14 @@ package io.getquill.sqlite
 
 import java.sql.{ Connection, ResultSet }
 import io.getquill.PrepareZioJdbcSpecBase
-
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import org.scalatest.BeforeAndAfter
 
 class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
 
-  val context = testContext
+  val context = testContext.underlying
   import context._
+  implicit val implicitPool = Implicit(pool)
 
   before {
     testContext.run(query[Product].delete).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/ZioJdbcContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.sqlite
 
 import io.getquill.ZioSpec
 import zio.{ ZIO, ZLayer }
-import javax.sql.DataSource
 
 class ZioJdbcContextSpec extends ZioSpec {
 
@@ -27,7 +26,7 @@ class ZioJdbcContextSpec extends ZioSpec {
           } yield qry
         }
         r <- testContext.run(qr1)
-      } yield r).provideSomeLayer(ZLayer.service[DataSource] >>> ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
+      } yield r).provideSomeLayer(ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
     }
     "success - stream" in {
       (for {
@@ -35,7 +34,7 @@ class ZioJdbcContextSpec extends ZioSpec {
         seq <- testContext.transaction {
           for {
             _ <- testContext.run(qr1.insert(_.i -> 33))
-            s <- accumulateDS(testContext.stream(qr1))
+            s <- accumulate(testContext.stream(qr1))
           } yield s
         }
         r <- testContext.run(qr1)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/sqlite.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/sqlite.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object sqlite {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testSqliteDB"))) }
-  object testContext extends SqliteZioJdbcContext(Literal) with TestEntities
+  val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testSqliteDB"))
+  object testContext extends Quill.SqliteService(Literal, pool) with TestEntities
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
@@ -2,13 +2,14 @@ package io.getquill.sqlserver
 
 import java.sql.{ Connection, ResultSet }
 import io.getquill.PrepareZioJdbcSpecBase
-
+import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import org.scalatest.BeforeAndAfter
 
 class PrepareJdbcSpec extends PrepareZioJdbcSpecBase with BeforeAndAfter {
 
-  val context = testContext
+  val context = testContext.underlying
   import context._
+  implicit val implicitPool = Implicit(pool)
 
   before {
     testContext.run(query[Product].delete).runSyncUnsafe()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/ZioJdbcContextSpec.scala
@@ -3,8 +3,6 @@ package io.getquill.sqlserver
 import io.getquill.ZioSpec
 import zio.{ ZIO, ZLayer }
 
-import javax.sql.DataSource
-
 class ZioJdbcContextSpec extends ZioSpec {
 
   val context = testContext
@@ -28,7 +26,7 @@ class ZioJdbcContextSpec extends ZioSpec {
           } yield qry
         }
         r <- testContext.run(qr1)
-      } yield r).provideSomeLayer(ZLayer.service[DataSource] >>> ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
+      } yield r).provideSomeLayer(ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
     }
     "success - stream" in {
       (for {
@@ -36,7 +34,7 @@ class ZioJdbcContextSpec extends ZioSpec {
         seq <- testContext.transaction {
           for {
             _ <- testContext.run(qr1.insert(_.i -> 33))
-            s <- accumulateDS(testContext.stream(qr1))
+            s <- accumulate(testContext.stream(qr1))
           } yield s
         }
         r <- testContext.run(qr1)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/sqlserver.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/sqlserver.scala
@@ -1,9 +1,9 @@
 package io.getquill
 
-import io.getquill.context.ZioJdbc.DataSourceLayer
-import io.getquill.context.qzio.ImplicitSyntax.Implicit
+import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.ziojdbc.Quill
 
 package object sqlserver {
-  implicit val pool = zio.Unsafe.unsafe { implicit u => Implicit(zio.Runtime.unsafe.fromLayer(DataSourceLayer.fromPrefix("testSqlServerDB"))) }
-  object testContext extends SqlServerZioJdbcContext(Literal) with TestEntities
+  val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testSqlServerDB"))
+  object testContext extends Quill.SqlServerService(Literal, pool) with TestEntities
 }

--- a/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, H2JdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class H2JdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[H2Dialect, N]
   with H2JdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, MysqlJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class MysqlJdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[MySQLDialect, N]
   with MysqlJdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
@@ -7,7 +7,7 @@ import io.getquill.context.jdbc.{ JdbcContext, OracleJdbcContextBase }
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class OracleJdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[OracleDialect, N]
   with OracleJdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, PostgresJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class PostgresJdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[PostgresDialect, N]
   with PostgresJdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqlServerJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqlServerJdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[SQLServerDialect, N]
   with SqlServerJdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqliteJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqliteJdbcContext[N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
   extends JdbcContext[SqliteDialect, N]
   with SqliteJdbcContextBase[N] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BaseContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/BaseContexts.scala
@@ -2,27 +2,27 @@ package io.getquill.context.jdbc
 
 import io.getquill._
 
-trait PostgresJdbcContextBase[N <: NamingStrategy]
+trait PostgresJdbcContextBase[+N <: NamingStrategy]
   extends PostgresJdbcTypes[N]
   with JdbcContextBase[PostgresDialect, N]
 
-trait H2JdbcContextBase[N <: NamingStrategy]
+trait H2JdbcContextBase[+N <: NamingStrategy]
   extends H2JdbcTypes[N]
   with JdbcContextBase[H2Dialect, N]
 
-trait MysqlJdbcContextBase[N <: NamingStrategy]
+trait MysqlJdbcContextBase[+N <: NamingStrategy]
   extends MysqlJdbcTypes[N]
   with JdbcContextBase[MySQLDialect, N]
 
-trait SqliteJdbcContextBase[N <: NamingStrategy]
+trait SqliteJdbcContextBase[+N <: NamingStrategy]
   extends SqliteJdbcTypes[N]
   with JdbcContextBase[SqliteDialect, N]
 
-trait SqlServerJdbcContextBase[N <: NamingStrategy]
+trait SqlServerJdbcContextBase[+N <: NamingStrategy]
   extends SqlServerJdbcTypes[N]
   with SqlServerExecuteOverride[N]
   with JdbcContextBase[SQLServerDialect, N]
 
-trait OracleJdbcContextBase[N <: NamingStrategy]
+trait OracleJdbcContextBase[+N <: NamingStrategy]
   extends OracleJdbcTypes[N]
   with JdbcContextBase[OracleDialect, N]

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -11,7 +11,7 @@ import scala.util.{ DynamicVariable, Try }
 import scala.util.control.NonFatal
 import io.getquill.monad.SyncIOMonad
 
-abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+abstract class JdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   extends JdbcContextBase[Dialect, Naming]
   with ProtoContext[Dialect, Naming]
   with ContextVerbTranslate

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
@@ -6,7 +6,7 @@ import io.getquill.context.sql.idiom.SqlIdiom
 
 import java.sql._
 
-trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+trait JdbcContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   extends JdbcContextVerbExecute[Dialect, Naming]
   with JdbcContextVerbPrepare[Dialect, Naming]
   with ContextVerbPrepareLambda {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
@@ -10,7 +10,7 @@ import io.getquill.util.ContextLogger
 import java.sql.{ Connection, JDBCType, PreparedStatement, ResultSet, Statement }
 import java.util.TimeZone
 
-trait JdbcContextTypes[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends Context[Dialect, Naming]
+trait JdbcContextTypes[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends Context[Dialect, Naming]
   with SqlContext[Dialect, Naming]
   with Encoders
   with Decoders {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbExecute.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbExecute.scala
@@ -8,7 +8,7 @@ import io.getquill.{ NamingStrategy, ReturnAction }
 
 import java.sql.{ Connection, ResultSet, Statement }
 
-trait JdbcContextVerbExecute[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends JdbcContextTypes[Dialect, Naming] {
+trait JdbcContextVerbExecute[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends JdbcContextTypes[Dialect, Naming] {
 
   // These type overrides are not required for JdbcRunContext in Scala2-Quill but it's a typing error. It only works
   // because executeQuery is not actually defined in Context.scala therefore typing doesn't have

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
@@ -7,7 +7,7 @@ import io.getquill.util.ContextLogger
 
 import java.sql._
 
-trait JdbcContextVerbPrepare[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+trait JdbcContextVerbPrepare[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   extends ContextVerbPrepare
   with JdbcContextTypes[Dialect, Naming] {
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
@@ -5,7 +5,7 @@ import io.getquill._
 import io.getquill.context.ExecutionInfo
 import io.getquill.util.ContextLogger
 
-trait PostgresJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[PostgresDialect, N]
+trait PostgresJdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[PostgresDialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding
   with ArrayDecoders
@@ -21,28 +21,28 @@ trait PostgresJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[PostgresDi
   }
 }
 
-trait H2JdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[H2Dialect, N]
+trait H2JdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[H2Dialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding {
 
   val idiom = H2Dialect
 }
 
-trait MysqlJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[MySQLDialect, N]
+trait MysqlJdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[MySQLDialect, N]
   with BooleanObjectEncoding
   with UUIDStringEncoding {
 
   val idiom = MySQLDialect
 }
 
-trait SqliteJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[SqliteDialect, N]
+trait SqliteJdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[SqliteDialect, N]
   with BooleanObjectEncoding
   with UUIDObjectEncoding {
 
   val idiom = SqliteDialect
 }
 
-trait SqlServerExecuteOverride[N <: NamingStrategy] extends JdbcContextVerbExecute[SQLServerDialect, N] {
+trait SqlServerExecuteOverride[+N <: NamingStrategy] extends JdbcContextVerbExecute[SQLServerDialect, N] {
 
   private val logger = ContextLogger(classOf[SqlServerExecuteOverride[_]])
 
@@ -54,14 +54,14 @@ trait SqlServerExecuteOverride[N <: NamingStrategy] extends JdbcContextVerbExecu
     }
 }
 
-trait SqlServerJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[SQLServerDialect, N]
+trait SqlServerJdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[SQLServerDialect, N]
   with BooleanObjectEncoding
   with UUIDStringEncoding {
 
   val idiom = SQLServerDialect
 }
 
-trait OracleJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[OracleDialect, N]
+trait OracleJdbcTypes[+N <: NamingStrategy] extends JdbcContextTypes[OracleDialect, N]
   with BooleanIntEncoding
   with UUIDStringEncoding {
 

--- a/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
@@ -6,7 +6,7 @@ import io.getquill.mirrorContextWithQueryProbing.Runner
 import monix.eval.Task
 import monix.reactive.Observable
 
-trait MonixContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends Context[Idiom, Naming]
+trait MonixContext[+Idiom <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] extends Context[Idiom, Naming]
   with ContextVerbStream[Idiom, Naming] {
 
   override type StreamResult[T] = Observable[T]

--- a/quill-ndbc-monix/src/main/scala/io/getquill/PostgresMonixNdbcContext.scala
+++ b/quill-ndbc-monix/src/main/scala/io/getquill/PostgresMonixNdbcContext.scala
@@ -7,7 +7,7 @@ import io.getquill.context.ndbc.{ NdbcContextConfig, PostgresNdbcContextBase }
 import io.getquill.util.LoadConfig
 import io.trane.ndbc.{ DataSource, PostgresDataSource, PostgresPreparedStatement, PostgresRow }
 
-class PostgresMonixNdbcContext[N <: NamingStrategy](
+class PostgresMonixNdbcContext[+N <: NamingStrategy](
   val naming:     N,
   val dataSource: DataSource[PostgresPreparedStatement, PostgresRow],
   runner:         Runner

--- a/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
+++ b/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
@@ -74,7 +74,7 @@ object MonixNdbcContext {
  * Quill context that wraps all NDBC calls in `monix.eval.Task`.
  *
  */
-abstract class MonixNdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy, P <: PreparedStatement, R <: Row](
+abstract class MonixNdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy, P <: PreparedStatement, R <: Row](
   dataSource: DataSource[P, R],
   runner:     Runner
 ) extends MonixContext[Dialect, Naming]

--- a/quill-ndbc-postgres/src/main/scala/io/getquill/PostgresNdbcContext.scala
+++ b/quill-ndbc-postgres/src/main/scala/io/getquill/PostgresNdbcContext.scala
@@ -5,7 +5,7 @@ import io.getquill.context.ndbc._
 import io.getquill.util.LoadConfig
 import io.trane.ndbc._
 
-class PostgresNdbcContext[N <: NamingStrategy](naming: N, dataSource: DataSource[PostgresPreparedStatement, PostgresRow])
+class PostgresNdbcContext[+N <: NamingStrategy](naming: N, dataSource: DataSource[PostgresPreparedStatement, PostgresRow])
   extends NdbcContext[PostgresDialect, N, PostgresPreparedStatement, PostgresRow](PostgresDialect, naming, dataSource)
   with PostgresNdbcContextBase[N] {
 

--- a/quill-ndbc-postgres/src/main/scala/io/getquill/context/ndbc/PostgresNdbcContextBase.scala
+++ b/quill-ndbc-postgres/src/main/scala/io/getquill/context/ndbc/PostgresNdbcContextBase.scala
@@ -6,7 +6,7 @@ import io.getquill.context.sql.encoding.ArrayEncoding
 import io.getquill.{ NamingStrategy, PostgresDialect }
 import io.trane.ndbc.{ PostgresPreparedStatement, PostgresRow }
 
-trait PostgresNdbcContextBase[N <: NamingStrategy] extends NdbcContextBase[PostgresDialect, N, PostgresPreparedStatement, PostgresRow]
+trait PostgresNdbcContextBase[+N <: NamingStrategy] extends NdbcContextBase[PostgresDialect, N, PostgresPreparedStatement, PostgresRow]
   with ArrayEncoding
   with PostgresEncoders
   with PostgresDecoders {

--- a/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
+++ b/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
@@ -8,7 +8,7 @@ import io.trane.ndbc.{ DataSource, PreparedStatement, Row }
 
 import scala.concurrent.duration.Duration
 
-abstract class NdbcContext[I <: SqlIdiom, N <: NamingStrategy, P <: PreparedStatement, R <: Row](
+abstract class NdbcContext[I <: SqlIdiom, +N <: NamingStrategy, P <: PreparedStatement, R <: Row](
   override val idiom: I, override val naming: N, val dataSource: DataSource[P, R]
 )
   extends NdbcContextBase[I, N, P, R]

--- a/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContextBase.scala
+++ b/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContextBase.scala
@@ -45,7 +45,7 @@ object NdbcContextBase {
   }
 }
 
-trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: PreparedStatement, R <: Row]
+trait NdbcContextBase[+Idiom <: SqlIdiom, +Naming <: NamingStrategy, P <: PreparedStatement, R <: Row]
   extends SqlContext[Idiom, Naming] {
 
   private[getquill] val logger = ContextLogger(classOf[NdbcContext[_, _, _, _]])

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBMirrorContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBMirrorContext.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import io.getquill.context.orientdb.{ OrientDBContext, OrientDBIdiom }
 
-class OrientDBMirrorContext[Naming <: NamingStrategy](naming: Naming)
+class OrientDBMirrorContext[+Naming <: NamingStrategy](naming: Naming)
   extends MirrorContext[OrientDBIdiom, Naming](OrientDBIdiom, naming) with OrientDBContext[Naming] {
 
   implicit def listDecoder[T]: Decoder[List[T]] = decoderUnsafe[List[T]]

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
@@ -10,7 +10,7 @@ import io.getquill.util.{ ContextLogger, LoadConfig }
 import scala.jdk.CollectionConverters._
 import io.getquill.monad.SyncIOMonad
 
-class OrientDBSyncContext[N <: NamingStrategy](
+class OrientDBSyncContext[+N <: NamingStrategy](
   naming:   N,
   dbUrl:    String,
   username: String,

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBContext.scala
@@ -6,7 +6,7 @@ import io.getquill.NamingStrategy
 import io.getquill.context.Context
 import io.getquill.context.orientdb.dsl.OrientDBDsl
 
-trait OrientDBContext[Naming <: NamingStrategy]
+trait OrientDBContext[+Naming <: NamingStrategy]
   extends Context[OrientDBIdiom, Naming]
   with OrientDBDsl {
 

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import io.getquill.context.Context
 
-abstract class OrientDBSessionContext[N <: NamingStrategy](
+abstract class OrientDBSessionContext[+N <: NamingStrategy](
   val naming: N,
   dbUrl:      String,
   username:   String,

--- a/quill-sql/src/main/scala/io/getquill/SqlMirrorContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqlMirrorContext.scala
@@ -4,7 +4,7 @@ import io.getquill.idiom.{ Idiom => BaseIdiom }
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.encoding.mirror.ArrayMirrorEncoding
 
-class SqlMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](idiom: Idiom, naming: Naming)
+class SqlMirrorContext[+Idiom <: BaseIdiom, +Naming <: NamingStrategy](idiom: Idiom, naming: Naming)
   extends MirrorContext(idiom, naming)
   with SqlContext[Idiom, Naming]
   with ArrayMirrorEncoding

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.Context
 import io.getquill.context.sql.dsl.SqlDsl
 import io.getquill.NamingStrategy
 
-trait SqlContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
+trait SqlContext[+Idiom <: BaseIdiom, +Naming <: NamingStrategy]
   extends Context[Idiom, Naming]
   with SqlDsl {
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
@@ -6,7 +6,7 @@ import io.getquill.norm.EqualityBehavior
 import io.getquill.norm.EqualityBehavior.NonAnsiEquality
 import io.getquill._
 
-class TestContextTemplate[Dialect <: SqlIdiom, Naming <: NamingStrategy](dialect: Dialect, naming: Naming)
+class TestContextTemplate[+Dialect <: SqlIdiom, +Naming <: NamingStrategy](dialect: Dialect, naming: Naming)
   extends SqlMirrorContext(dialect, naming)
   with TestEntities
   with TestEncoders
@@ -47,7 +47,7 @@ object NonAnsiMirrorSqlDialect extends NonAnsiMirrorSqlDialect {
   override def prepareForProbing(string: String) = string
 }
 
-class NonAnsiTestContextTemplate[Naming <: NamingStrategy](naming: Naming)
+class NonAnsiTestContextTemplate[+Naming <: NamingStrategy](naming: Naming)
   extends SqlMirrorContext(NonAnsiMirrorSqlDialect, naming)
   with TestEntities
   with TestEncoders

--- a/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
@@ -5,7 +5,7 @@ import io.getquill.context.{ Context, ExecutionInfo, ContextVerbStream }
 import zio.ZIO
 import zio.stream.ZStream
 
-trait ZioContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends Context[Idiom, Naming]
+trait ZioContext[+Idiom <: io.getquill.idiom.Idiom, +Naming <: NamingStrategy] extends Context[Idiom, Naming]
   with ContextVerbStream[Idiom, Naming] {
 
   type Error


### PR DESCRIPTION
- Implement ZIO-Idiomatic context that wraps a DataSource and can be passed as a parameter.
- This was enabled by https://github.com/zio/zio-quill/pull/1877 and https://github.com/zio/zio-quill/pull/2295 (the latter released in 3.11.0) which removed a very well know limitation of Quill that was even documented in the README.md:

    > The context instance provides all methods and types to interact with quotations and the database. Depending on how the context import happens, Scala won't be able to infer that the types are compatible.
    > 
    > For instance, this example **will not** compile:
    > 
    > ```
    > class MyContext extends SqlMirrorContext(MirrorSqlDialect, Literal)
    > 
    > case class MySchema(c: MyContext) {
    > 
    >   import c._
    >   val people = quote {
    >     querySchema[Person]("people")
    >   }
    > }
    > 
    > case class MyDao(c: MyContext, schema: MySchema) {
    > 
    >   def allPeople =
    >     c.run(schema.people)
    > // ERROR: [T](quoted: MyDao.this.c.Quoted[MyDao.this.c.Query[T]])MyDao.this.c.QueryResult[T]
    >  cannot be applied to (MyDao.this.schema.c.Quoted[MyDao.this.schema.c.EntityQuery[Person]]{def quoted: io.getquill.ast.ConfiguredEntity; def ast: io.getquill.ast.ConfiguredEntity; def id1854281249(): Unit; val bindings: Object})
    > }
 

- The new context is io.getquill.jdbczio.Quill which will be a newly required import (TODO Still need to document this).
- In order for contexts like `Quill.PostgresContext(Literal)` which type as `Quill.PostgresContext[Literal.type]` to be injectable into a layer requiring `Quill.PostgresContext[Literal]` the `Naming` parameter had to be changed to be covariant. I decided to change the Dialect parameter as well due to a similar potential issue.
- This latter change also required me to remove the `quill-cassandra-lagom` context from the build since it's context cannot be changed to make Naming and Dialect covariant since this context depends on earlier quill versions. This was necessary since as of https://github.com/zio/zio-quill/pull/2315 the cassandra modules we moved to the DataStax V4 drivers but `quill-cassandra-lagom` could not be moved (The akka-persistence-cassandra project itself was was eventually bumped to V4 in https://github.com/akka/akka-persistence-cassandra/pull/596 but as of this writing lagom still depends on akka-persistence-cassandra 0.106, see [here](https://github.com/lagom/lagom/blob/6cdd99f07d5b5e40a8ef2a8d3be5ac688c771bd3/project/Dependencies.scala#L31)).
- It would be nice for someone to migrate the quill-cassandra-lagom module to akka-persitence-cassandra but it is not necessary since Quill already supports the akka + cassandra stack via `quill-cassandra-alpakka` which does have V4 driver support.