### PR TITLE
move stuff

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
@@ -3,7 +3,7 @@ package io.getquill.context
 import com.typesafe.config.Config
 import io.getquill.JdbcContextConfig
 import io.getquill.util.{ ContextLogger, LoadConfig }
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import zio.{ Scope, ZEnvironment, ZIO, ZLayer }
 import zio.stream.ZStream
 import izumi.reflect.Tag

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -4,7 +4,7 @@ import io.getquill.context.ZioJdbc._
 import io.getquill.context.jdbc.JdbcContextTypes
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context._
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill.{ NamingStrategy, ReturnAction }
 import zio.Exit.{ Failure, Success }
 import zio.stream.ZStream

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
@@ -1,4 +1,4 @@
-package io.getquill.ziojdbc
+package io.getquill.jdbczio
 
 import com.typesafe.config.Config
 import io.getquill._

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
@@ -1,4 +1,4 @@
-package io.getquill.ziojdbc
+package io.getquill.jdbczio
 
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.getquill.context.{ ContextVerbStream, ExecutionInfo, ProtoContext }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/PeopleZioSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/PeopleZioSpec.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import io.getquill.context.sql.PeopleSpec
 import io.getquill.context.qzio.ZioJdbcContext
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 trait PeopleZioSpec extends PeopleSpec with ZioSpec {
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainApp.scala
@@ -1,6 +1,6 @@
 package io.getquill.examples
 
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill.{ Literal, PostgresZioJdbcContext }
 import zio.{ Runtime, Unsafe }
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppDataSource.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppDataSource.scala
@@ -2,7 +2,7 @@ package io.getquill.examples
 
 import com.zaxxer.hikari.HikariDataSource
 import io.getquill.util.LoadConfig
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill.{ JdbcContextConfig, Literal, PostgresZioJdbcContext }
 import zio.Console.printLine
 import zio.{ Runtime, Unsafe }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppQuillService.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/PlainAppQuillService.scala
@@ -1,6 +1,6 @@
 package io.getquill.examples
 
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill._
 import zio._
 import zio.Console.printLine

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ServiceExample.scala
@@ -1,6 +1,6 @@
 package io.getquill.examples
 
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill.{ Literal, PostgresZioJdbcContext }
 import zio.Console._
 import zio.{ ZIO, ZIOAppDefault, ZLayer }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
@@ -1,7 +1,7 @@
 package io.getquill.examples
 
 import io.getquill._
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import zio.Console.printLine
 import zio.ZIOAppDefault
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppExample.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppExample.scala
@@ -1,7 +1,7 @@
 package io.getquill.examples
 
 import io.getquill._
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import zio._
 
 import javax.sql.DataSource

--- a/quill-jdbc-zio/src/test/scala/io/getquill/h2/h2.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/h2/h2.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object h2 {
   val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testH2DB"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/ZioJdbcUnderlyingContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/ZioJdbcUnderlyingContextSpec.scala
@@ -7,7 +7,7 @@ import io.getquill.context.ZioJdbc._
 class ZioJdbcUnderlyingContextSpec extends ZioProxySpec {
 
   val context = testContext.underlying
-  import testContext._
+  import testContext.underlying._
 
   case class TestEntity(s: String, i: Int, l: Long, o: Option[Int], b: Boolean)
   val qr1 = quote {
@@ -15,7 +15,6 @@ class ZioJdbcUnderlyingContextSpec extends ZioProxySpec {
   }
 
   "provides transaction support" - {
-    import testContext.underlying._
     "success" in {
       (for {
         _ <- testContext.underlying.run(qr1.delete)
@@ -36,7 +35,6 @@ class ZioJdbcUnderlyingContextSpec extends ZioProxySpec {
       } yield r).onSomeDataSource.provideSomeLayer(ZLayer.succeed(io.getquill.postgres.pool) ++ ZLayer.succeed(33)).runSyncUnsafe().map(_.i) mustEqual List(33)
     }
     "success - stream" in {
-      import testContext.underlying._
       (for {
         _ <- testContext.underlying.run(qr1.delete)
         seq <- testContext.underlying.transaction {
@@ -49,7 +47,6 @@ class ZioJdbcUnderlyingContextSpec extends ZioProxySpec {
       } yield (seq.map(_.i), r.map(_.i))).onDataSource.runSyncUnsafe() mustEqual ((List(33), List(33)))
     }
     "failure - nested" in {
-      import testContext.underlying._
       (for {
         _ <- testContext.underlying.run(qr1.delete)
         e <- testContext.underlying.transaction {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mysql/mysql.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mysql/mysql.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object mysql {
   implicit val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testMysqlDB"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/oracle/oracle.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/oracle/oracle.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object oracle {
   implicit val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testOracleDB"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -6,7 +6,7 @@ import io.getquill.context.sql.ProductSpec
 import io.getquill.util.LoadConfig
 import io.getquill.context.ZioJdbc._
 import io.getquill.context.qzio.ImplicitSyntax.Implicit
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import zio.{ Runtime, Unsafe }
 
 import scala.util.Random

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.postgres
 
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 import io.getquill.{ testContext => _, _ }
 import zio.{ Unsafe, ZIO, ZLayer }
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object postgres {
   val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testPostgresDB"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/sqlite.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlite/sqlite.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object sqlite {
   val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testSqliteDB"))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/sqlserver.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/sqlserver/sqlserver.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.ZioSpec.runLayerUnsafe
-import io.getquill.ziojdbc.Quill
+import io.getquill.jdbczio.Quill
 
 package object sqlserver {
   val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testSqlServerDB"))


### PR DESCRIPTION
Fix package name. Future package of `Quill` objects will be the suffix of the module name.