### PR TITLE
Move qsql to `compat` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4101,6 +4101,7 @@ We can now construct a `DoobieContext` for our back-end database and import its 
 ```
 val dc = new DoobieContext.Postgres(Literal) // Literal naming scheme
 import dc.{ SqlInfixInterpolator => _, _ }   // Quill's `sql` interpolator conflicts with doobie so don't import it
+import dc.compat._                           // Import the qsql interpolator instead
 ```
 
 > Instead of using Quill's `sql"MyUDF(${something})"` interpolator, use `qsql"MyUDF(${something})"` since we have excluded it.

--- a/quill-doobie/src/test/scala/io/getquill/doobie/PostgresDoobieContextSuite.scala
+++ b/quill-doobie/src/test/scala/io/getquill/doobie/PostgresDoobieContextSuite.scala
@@ -32,6 +32,7 @@ class PostgresDoobieContextSuite extends AnyFreeSpec with Matchers {
   val dc = new DoobieContext.Postgres(Literal)
 
   import dc.{ SqlInfixInterpolator => _, _ }
+  import dc.compat._
 
   case class Country(code: String, name: String, population: Int)
 

--- a/quill-engine/src/main/scala/io/getquill/dsl/InfixDsl.scala
+++ b/quill-engine/src/main/scala/io/getquill/dsl/InfixDsl.scala
@@ -27,10 +27,12 @@ private[getquill] trait InfixDsl {
     def sql(args: Any*): InfixValue = NonQuotedException()
   }
 
-  // For compatibility with Slick/Doobie/etc... that already have an SQL interpolator
-  implicit class QsqlInfixInterpolator(val sc: StringContext) {
+  object compat {
+    // For compatibility with Slick/Doobie/etc... that already have an SQL interpolator
+    implicit class QsqlInfixInterpolator(val sc: StringContext) {
 
-    @compileTimeOnly(NonQuotedException.message)
-    def qsql(args: Any*): InfixValue = NonQuotedException()
+      @compileTimeOnly(NonQuotedException.message)
+      def qsql(args: Any*): InfixValue = NonQuotedException()
+    }
   }
 }


### PR DESCRIPTION
Don't want `qsql` to be imported by default. Only of absolutely needed.