### PR TITLE
Fall back to regular update for empty-values

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
@@ -156,30 +156,35 @@ trait PostgresDialect
           val (Update(Filter(table: Entity, tableAlias, replacedWhere), assignments), valuesColumns, valuesLifts) = {
             ReplaceLiftings.of(clause)(batchAlias, List())
           }
-
-          // The SET columns/values i.e. ([name, id], [STag(uid:1), STag(uid:2)]
-          val columnsAndValues = columnsAndValuesTogether(assignments)
-          // the `ps`
-          val colsId = batchAlias
-          // The columns that go in the SET clause i.e. `SET name = ps.name, id = ps.id`
-          val setColumns = columnsAndValues.map { case (column, value) => stmt"$column = ${value}" }.mkStmt(", ")
-          // The columns that go inside ps(name, id, id1) i.e. stmt"name, id, id1"
-          val asColumns = valuesColumns.toList.mkStmt(", ")
-          val output = stmt"UPDATE ${table.token} AS ${tableAlias.token} SET $setColumns FROM (VALUES ${ValuesClauseToken(stmt"(${valuesLifts.toList.map(v => v: External).mkStmt(", ")})")}) AS ${colsId.token}($asColumns) WHERE ${specialPropertyTokenizer.token(replacedWhere)}"
-          Some(output)
+          if (valuesLifts.nonEmpty) {
+            // The SET columns/values i.e. ([name, id], [STag(uid:1), STag(uid:2)]
+            val columnsAndValues = columnsAndValuesTogether(assignments)
+            // the `ps`
+            val colsId = batchAlias
+            // The columns that go in the SET clause i.e. `SET name = ps.name, id = ps.id`
+            val setColumns = columnsAndValues.map { case (column, value) => stmt"$column = ${value}" }.mkStmt(", ")
+            // The columns that go inside ps(name, id, id1) i.e. stmt"name, id, id1"
+            val asColumns = valuesColumns.toList.mkStmt(", ")
+            val output = stmt"UPDATE ${table.token} AS ${tableAlias.token} SET $setColumns FROM (VALUES ${ValuesClauseToken(stmt"(${valuesLifts.toList.map(v => v: External).mkStmt(", ")})")}) AS ${colsId.token}($asColumns) WHERE ${specialPropertyTokenizer.token(replacedWhere)}"
+            Some(output)
+          } else None
 
         case (clause @ Update(_: Entity, _), IdiomContext.QueryType.Batch(batchAlias)) =>
-          val (Update(table: Entity, assignments), valuesColumns, valuesLifts) =
+          val (Update(table: Entity, assignments), valuesColumns, valuesLifts) = {
             ReplaceLiftings.of(clause)(batchAlias, List())
+          }
+
           // Choose table alias based on how assignments clauses were realized. Batch-Alias should mean the same thing as when NormalizeFilteredActionAliases was run in Idiom should the
           // value should be the same thing as the cluases that were realiased.
-          val tableAlias = NormalizeFilteredActionAliases.chooseAlias(table.name, Some(batchAlias))
-          val colsId = batchAlias
-          val columnsAndValues = columnsAndValuesTogether(assignments)
-          val setColumns = columnsAndValues.map { case (column, value) => stmt"$column = ${value}" }.mkStmt(", ")
-          val asColumns = valuesColumns.toList.mkStmt(", ")
-          val output = stmt"UPDATE ${table.token} AS ${tableAlias.token} SET $setColumns FROM (VALUES ${ValuesClauseToken(stmt"(${valuesLifts.toList.map(v => v: External).mkStmt(", ")})")}) AS ${colsId.token}($asColumns)"
-          Some(output)
+          if (valuesLifts.nonEmpty) {
+            val tableAlias = NormalizeFilteredActionAliases.chooseAlias(table.name, Some(batchAlias))
+            val colsId = batchAlias
+            val columnsAndValues = columnsAndValuesTogether(assignments)
+            val setColumns = columnsAndValues.map { case (column, value) => stmt"$column = ${value}" }.mkStmt(", ")
+            val asColumns = valuesColumns.toList.mkStmt(", ")
+            val output = stmt"UPDATE ${table.token} AS ${tableAlias.token} SET $setColumns FROM (VALUES ${ValuesClauseToken(stmt"(${valuesLifts.toList.map(v => v: External).mkStmt(", ")})")}) AS ${colsId.token}($asColumns)"
+            Some(output)
+          } else None
 
         case _ =>
           None


### PR DESCRIPTION
In ProtoQuill Scalar lifts work a little differently and there are cases where `VALUES` clauses can be empty with update queries. Need to consider this case:
```scala
    case class Person(name: String, age: Int)
    val list = List("U%", "I%")
    inline def q = quote {
      liftQuery(list).foreach { pat =>
        query[Person].filter(_.name like pat).update(_.name -> "foo")
      }
    }
    run(q)
```
Should be:
```
UPDATE Person AS x14 SET name = 'foo' WHERE x14.name like ?
```
but it is:
```
UPDATE person AS x1 SET name = 'foo' FROM (VALUES ()) AS pat() WHERE x1.name = pat.value
```
So need to check if there are ScalarLiftTag elements inside of `VALUES` and fall back to the regular batching if there are not.