### PR TITLE
jasync zio current schema configuration, jasync version  update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -574,7 +574,7 @@ lazy val `quill-jasync` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-common" % "2.0.6",
+        "com.github.jasync-sql" % "jasync-common" % "2.0.8",
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
       )
     )
@@ -588,7 +588,7 @@ lazy val `quill-jasync-postgres` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.6"
+        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync` % "compile->compile;test->test")
@@ -601,7 +601,7 @@ lazy val `quill-jasync-mysql` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-mysql" % "2.0.6"
+        "com.github.jasync-sql" % "jasync-mysql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync` % "compile->compile;test->test")
@@ -614,7 +614,7 @@ lazy val `quill-jasync-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-common" % "2.0.6",
+        "com.github.jasync-sql" % "jasync-common" % "2.0.8",
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
         "dev.zio" %% "zio" % Version.zio,
         "dev.zio" %% "zio-streams" % Version.zio
@@ -631,7 +631,7 @@ lazy val `quill-jasync-zio-postgres` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.6"
+        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync-zio` % "compile->compile;test->test")

--- a/quill-jasync-zio/src/main/scala/io/getquill/context/zio/JAsyncContextConfig.scala
+++ b/quill-jasync-zio/src/main/scala/io/getquill/context/zio/JAsyncContextConfig.scala
@@ -59,6 +59,7 @@ abstract class JAsyncContextConfig[C <: ConcreteConnection](
     urlConfiguration.getAllocator,
     getString("applicationName").orElse(Option(urlConfiguration.getApplicationName)).orNull,
     urlConfiguration.getInterceptors,
-    getLong("maxConnectionTtl").map(JavaLong.valueOf).orElse(Option(default.getMaxConnectionTtl)).orNull
+    getLong("maxConnectionTtl").map(JavaLong.valueOf).orElse(Option(default.getMaxConnectionTtl)).orNull,
+    getString("currentSchema").orElse(Option(urlConfiguration.getCurrentSchema)).orNull
   )
 }


### PR DESCRIPTION

### Problem

`currentSchema` configuration in zio `JAsyncContextConfig` was missing

### Solution

added configuration

### Notes

jasync dep. updated (version 2.0.8)

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
