### PR TITLE
Fix LoadObject failing on nested objects

### DIFF
--- a/quill-core/src/main/scala/io/getquill/util/LoadObject.scala
+++ b/quill-core/src/main/scala/io/getquill/util/LoadObject.scala
@@ -7,7 +7,7 @@ object LoadObject {
 
   def apply[T](c: Context)(tpe: c.Type): Try[T] =
     Try {
-      val cls = Class.forName(tpe.typeSymbol.fullName + "$")
+      val cls = Class.forName(tpe.typeSymbol.fullName.replace('.', '$') + "$")
       val field = cls.getField("MODULE$")
       field.get(cls).asInstanceOf[T]
     }


### PR DESCRIPTION
Fixes #2589

`TypeSymbol.fullName` returns inner names separated by `.`. Those must be converted to `$` to match the class name.

@getquill/maintainers
