### PR TITLE
Fixing VALUES-clause update query naming

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
@@ -228,7 +228,7 @@ case class ReplaceLiftings(foreachIdentName: String, existingColumnNames: List[S
       case lift @ ScalarTag(_, External.Source.UnparsedProperty(propNameRaw)) =>
         val id = Ident(foreachIdentName, lift.quat)
         val propName = freshIdent(propNameRaw)
-        (Property(id, propName), ReplaceLiftings(foreachIdentName, existingColumnNames, state + (propName -> lift)))
+        (Property.Opinionated(id, propName, Renameable.Fixed, Visibility.neutral), ReplaceLiftings(foreachIdentName, existingColumnNames, state + (propName -> lift)))
       case _ => super.apply(e)
     }
 }


### PR DESCRIPTION
Fixes #2593

Need to make properties synthesized for the new VALUES-clause query construct non-renameable (otherwise the snake-case schema will rename them).

@getquill/maintainers
