### PR TITLE
Remove the need to make things embedded, happens automatically

### DIFF
--- a/quill-cassandra-lagom/src/test/scala/io/getquill/TestEntities.scala
+++ b/quill-cassandra-lagom/src/test/scala/io/getquill/TestEntities.scala
@@ -7,13 +7,13 @@ trait TestEntities {
   this: Context[_, _] =>
 
   case class TestEntity(s: String, i: Int, l: Long, o: Option[Int], b: Boolean)
-  case class Emb(s: String, i: Int) extends Embedded
+  case class Emb(s: String, i: Int)
   case class TestEntityEmb(emb: Emb, l: Long, o: Option[Int])
   case class TestEntity2(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity3(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity4(i: Long)
   case class TestEntity5(i: Long, s: String)
-  case class EmbSingle(i: Long) extends Embedded
+  case class EmbSingle(i: Long)
   case class TestEntity4Emb(emb: EmbSingle)
   case class TestEntityRegular(s: String, i: Long)
 

--- a/quill-core/src/main/scala/io/getquill/dsl/ValueComputation.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/ValueComputation.scala
@@ -51,16 +51,16 @@ trait ValueComputation {
 
           def value(tpe: Type) =
             tpe match {
-              case tpe if !is[Embedded](tpe) && nested =>
+              case tpe if is[Product](tpe) =>
+                nest(tpe, term)
+
+              case _ =>
                 c.fail(
                   s"""Can't find implicit `$encoding[$tpe]`. Please, do one of the following things:
                      |1. ensure that implicit `$encoding[$tpe]` is provided and there are no other conflicting implicits;
                      |2. make `$tpe` `Embedded` case class or `AnyVal`.
                    """.stripMargin
                 )
-
-              case tpe =>
-                nest(tpe, term)
             }
 
           if (isNone(tpe)) {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -589,12 +589,7 @@ trait Parsing extends ValueComputation with QuatMaking with MacroUtilBase {
       if (caseAccessors.nonEmpty && !caseAccessors.contains(property))
         c.fail(s"Can't find case class property: ${property.decodedName.toString}")
 
-      val visibility = {
-        val tpe = c.typecheck(q"$e.$property")
-        val innerParam = innerOptionParam(q"$tpe".tpe, None)
-        if (is[Embedded](q"$innerParam")) Hidden
-        else Visible
-      }
+      val visibility = Visible
 
       Property.Opinionated(astParser(e), property.decodedName.toString,
         Renameable.neutral, //Renameability of the property is determined later in the RenameProperties normalization phase

--- a/quill-core/src/test/scala/io/getquill/OptionalProductEncodingSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/OptionalProductEncodingSpec.scala
@@ -9,7 +9,7 @@ class OptionalProductEncodingSpec extends Spec {
   import ctx._
 
   "optional product with optional embedded row" in {
-    case class Name(first: String, last: Int) extends Embedded
+    case class Name(first: String, last: Int)
     case class Person(id: Int, name: Option[Name], age: Int)
     case class Address(owner: Int, street: String)
 
@@ -45,8 +45,8 @@ class OptionalProductEncodingSpec extends Spec {
   }
 
   "optional product with multiple nested optional embeds" in {
-    case class InnerName(title: Int, last: String) extends Embedded
-    case class Name(first: String, last: Option[InnerName]) extends Embedded
+    case class InnerName(title: Int, last: String)
+    case class Name(first: String, last: Option[InnerName])
     case class Address(owner: Int, street: String)
     case class Person(id: Int, name: Option[Name])
 
@@ -69,7 +69,7 @@ class OptionalProductEncodingSpec extends Spec {
   }
 
   "optional product with nested optional with optional leaf" in {
-    case class Name(first: String, last: Option[Int]) extends Embedded
+    case class Name(first: String, last: Option[Int])
     case class Address(owner: Int, street: String)
     case class Person(id: Int, name: Option[Name], age: Int)
 

--- a/quill-core/src/test/scala/io/getquill/TestEntities.scala
+++ b/quill-core/src/test/scala/io/getquill/TestEntities.scala
@@ -7,13 +7,13 @@ trait TestEntities {
   this: Context[_, _] =>
 
   case class TestEntity(s: String, i: Int, l: Long, o: Option[Int], b: Boolean)
-  case class Emb(s: String, i: Int) extends Embedded
+  case class Emb(s: String, i: Int)
   case class TestEntityEmb(emb: Emb, l: Long, o: Option[Int])
   case class TestEntity2(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity3(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity4(i: Long)
   case class TestEntity5(i: Long, s: String)
-  case class EmbSingle(i: Long) extends Embedded
+  case class EmbSingle(i: Long)
   case class TestEntity4Emb(emb: EmbSingle)
   case class TestEntityRegular(s: String, i: Long)
 

--- a/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
@@ -12,9 +12,9 @@ class UnlimitedOptionalEmbeddedSpec extends Spec {
 
   import ctx._
 
-  case class Emb3(value: String) extends Embedded
-  case class Emb2(e1: Emb3, e2: Option[Emb3]) extends Embedded
-  case class Emb1(e1: Emb2, e2: Option[Emb2]) extends Embedded
+  case class Emb3(value: String)
+  case class Emb2(e1: Emb3, e2: Option[Emb3])
+  case class Emb1(e1: Emb2, e2: Option[Emb2])
   case class OptEmd(e1: Emb1, e2: Option[Emb1])
 
   lazy val optEmdEnt = OptEmd(

--- a/quill-core/src/test/scala/io/getquill/context/encoding/OptionalNestedSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/encoding/OptionalNestedSpec.scala
@@ -15,7 +15,7 @@ trait OptionalNestedSpec extends Spec with BeforeAndAfterEach {
   }
 
   object `1.Optional Inner Product` {
-    case class LastNameAge(lastName: String, age: Int) extends Embedded
+    case class LastNameAge(lastName: String, age: Int)
     case class Contact(firstName: String, opt: Option[LastNameAge], addressFk: Int)
 
     val data = quote { query[Contact] }
@@ -34,8 +34,8 @@ trait OptionalNestedSpec extends Spec with BeforeAndAfterEach {
   }
 
   object `2.Optional Inner Product with Optional Leaf` {
-    case class Age(age: Option[Int]) extends Embedded
-    case class LastNameAge(lastName: String, age: Age) extends Embedded
+    case class Age(age: Option[Int])
+    case class LastNameAge(lastName: String, age: Age)
     case class Contact(firstName: String, opt: Option[LastNameAge], addressFk: Int)
 
     val data = quote { query[Contact] }
@@ -60,8 +60,8 @@ trait OptionalNestedSpec extends Spec with BeforeAndAfterEach {
   }
 
   object `3.Optional Nested Inner Product` {
-    case class Age(age: Int) extends Embedded
-    case class LastNameAge(lastName: String, age: Option[Age]) extends Embedded
+    case class Age(age: Int)
+    case class LastNameAge(lastName: String, age: Option[Age])
     case class Contact(firstName: String, opt: Option[LastNameAge], addressFk: Int)
 
     val data = quote { query[Contact] }

--- a/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
@@ -569,10 +569,10 @@ class MirrorIdiomSpec extends Spec {
       }
       "row" in {
         val q = quote {
-          (o: Option[Row]) => o.forall(v => v.id == 1)
+          (o: Option[Row]) => o.exists(v => v.id == 1)
         }
         stmt"${(q.ast: Ast).token}" mustEqual
-          stmt"(o) => o.forall((v) => v.id == 1)"
+          stmt"(o) => o.exists((v) => v.id == 1)"
       }
     }
     "exists" - {

--- a/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
@@ -14,7 +14,7 @@ class MetaDslSpec extends Spec {
     y0: Int, y1: Int, y2: Int, y3: Int, y4: Int, y5: Int, y6: Int, y7: Int, y8: Int, y9: Int
   )
 
-  case class EmbValue(i: Int) extends Embedded
+  case class EmbValue(i: Int)
 
   "schema meta" - {
     "materialized" in {
@@ -45,7 +45,7 @@ class MetaDslSpec extends Spec {
         meta.extract(Row("1", 2), MirrorSession.default) mustEqual Entity("1", 2)
       }
       "with embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeQueryMeta[Entity]
         meta.extract(Row("1", 2, 3L), MirrorSession.default) mustEqual Entity("1", Nested(2, 3L))
@@ -55,12 +55,12 @@ class MetaDslSpec extends Spec {
         meta.extract(Row("1", 2), MirrorSession.default) mustEqual (("1", 2))
       }
       "tuple + embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         val meta = materializeQueryMeta[(String, Nested)]
         meta.extract(Row("1", 2, 3L), MirrorSession.default) mustEqual (("1", Nested(2, 3L)))
       }
       "tuple + nested embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeQueryMeta[(String, Entity)]
         meta.extract(Row("a", "1", 2, 3L), MirrorSession.default) mustEqual (("a", Entity("1", Nested(2, 3L))))
@@ -142,7 +142,7 @@ class MetaDslSpec extends Spec {
         meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a, v => v.b -> value.b)"
       }
       "with embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeUpdateMeta[Entity]
         meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a, v => v.b.i -> value.b.i, v => v.b.l -> value.b.l)"
@@ -152,12 +152,12 @@ class MetaDslSpec extends Spec {
         meta.expand.toString mustEqual "(q, value) => q.update(v => v._1 -> value._1, v => v._2 -> value._2)"
       }
       "tuple + embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         val meta = materializeUpdateMeta[(String, Nested)]
         meta.expand.toString mustEqual "(q, value) => q.update(v => v._1 -> value._1, v => v._2.i -> value._2.i, v => v._2.l -> value._2.l)"
       }
       "tuple + nested embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeUpdateMeta[(String, Entity)]
         meta.expand.toString mustEqual "(q, value) => q.update(v => v._1 -> value._1, v => v._2.a -> value._2.a, v => v._2.b.i -> value._2.b.i, v => v._2.b.l -> value._2.b.l)"
@@ -173,7 +173,7 @@ class MetaDslSpec extends Spec {
       }
     }
     "custom" - {
-      case class Nested(i: Int, l: Long) extends Embedded
+      case class Nested(i: Int, l: Long)
       case class Entity(a: String, b: Nested, c: Option[Nested])
 
       "exclude column" in {
@@ -212,7 +212,7 @@ class MetaDslSpec extends Spec {
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a, v => v.b -> value.b)"
       }
       "with embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeInsertMeta[Entity]
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a, v => v.b.i -> value.b.i, v => v.b.l -> value.b.l)"
@@ -222,12 +222,12 @@ class MetaDslSpec extends Spec {
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v._1 -> value._1, v => v._2 -> value._2)"
       }
       "tuple + embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         val meta = materializeInsertMeta[(String, Nested)]
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v._1 -> value._1, v => v._2.i -> value._2.i, v => v._2.l -> value._2.l)"
       }
       "tuple + nested embedded" in {
-        case class Nested(i: Int, l: Long) extends Embedded
+        case class Nested(i: Int, l: Long)
         case class Entity(a: String, b: Nested)
         val meta = materializeInsertMeta[(String, Entity)]
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v._1 -> value._1, v => v._2.a -> value._2.a, v => v._2.b.i -> value._2.b.i, v => v._2.b.l -> value._2.b.l)"
@@ -243,7 +243,7 @@ class MetaDslSpec extends Spec {
       }
     }
     "custom" - {
-      case class Nested(i: Int, l: Long) extends Embedded
+      case class Nested(i: Int, l: Long)
       case class Entity(a: String, b: Nested, c: Option[Nested])
 
       "exclude column" in {

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
@@ -11,7 +11,7 @@ class NormalizeReturningSpec extends Spec {
 
   "do not remove assignment if embedded has columns with the same name" - {
 
-    case class EmbEntity(id: Int) extends Embedded
+    case class EmbEntity(id: Int)
     case class Entity(id: Int, emb: EmbEntity)
 
     val e = Entity(1, EmbEntity(2))

--- a/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
@@ -155,12 +155,12 @@ class AvoidAliasConflictSpec extends Spec {
       "multiple" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
-            .leftJoin(qr1).on((a, b) => a._2.forall(v => v.i == b.i))
+            .leftJoin(qr1).on((a, b) => a._2.exists(v => v.i == b.i)) //
             .map(t => 1)
         }
         val n = quote {
           qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
-            .leftJoin(qr1).on((a1, b1) => a1._2.forall(v => v.i == b1.i))
+            .leftJoin(qr1).on((a1, b1) => a1._2.exists(v => v.i == b1.i))
             .map(t => 1)
         }
         AvoidAliasConflict(q.ast) mustEqual n.ast

--- a/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -29,8 +29,8 @@ class QuatSpec extends Spec {
   }
 
   "should support embedded" in {
-    case class MyName(first: String, last: String) extends Embedded
-    case class MyPerson(name: MyName, age: Int) extends Embedded
+    case class MyName(first: String, last: String)
+    case class MyPerson(name: MyName, age: Int)
     val MyPersonQuat = Quat.Product("name" -> Quat.LeafProduct("first", "last"), "age" -> Quat.Value)
 
     quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
@@ -85,8 +85,8 @@ class QuatSpec extends Spec {
   }
 
   "should support multi-level embedded" in {
-    case class MyName(first: String, last: String) extends Embedded
-    case class MyId(name: MyName, memberNum: Int) extends Embedded
+    case class MyName(first: String, last: String)
+    case class MyId(name: MyName, memberNum: Int)
     case class MyPerson(name: MyId, age: Int)
     val MyPersonQuat = Quat.Product("name" -> Quat.Product("name" -> Quat.LeafProduct("first", "last"), "memberNum" -> Quat.Value), "age" -> Quat.Value)
 

--- a/quill-core/src/test/scala/io/getquill/quotation/CompatibleDynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/CompatibleDynamicQuerySpec.scala
@@ -63,7 +63,7 @@ class CompatibleDynamicQuerySpec extends Spec {
   }
 
   // Need to put here so an summon TypeTag for these
-  case class S(v: String) extends Embedded
+  case class S(v: String)
   case class E(s: S)
 
   "query" - {

--- a/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
@@ -65,7 +65,7 @@ class DynamicQuerySpec extends Spec {
   }
 
   // Need to put here so an summon TypeTag for these
-  case class S(v: String) extends Embedded
+  case class S(v: String)
   case class E(s: S)
   case class Person2(firstName: String, lastName: String)
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -16,7 +16,7 @@ import io.getquill.base.Spec
 import scala.math.BigDecimal.{ double2bigDecimal, int2bigDecimal, javaBigDecimal2bigDecimal, long2bigDecimal }
 
 case class CustomAnyValue(i: Int) extends AnyVal
-case class EmbeddedValue(s: String, i: Int) extends Embedded
+case class EmbeddedValue(s: String, i: Int)
 
 class QuotationSpec extends Spec {
 
@@ -1348,7 +1348,7 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast.body mustEqual OptionForall(Ident("o"), Ident("v"), Ident("v"))
         }
         "embedded" in {
-          case class EmbeddedEntity(id: Int) extends Embedded
+          case class EmbeddedEntity(id: Int)
           "quote((o: Option[EmbeddedEntity]) => o.forall(v => v.id == 1))" mustNot compile
         }
       }
@@ -1360,7 +1360,7 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast.body mustEqual FilterIfDefined(Ident("o"), Ident("v"), Ident("v"))
         }
         "embedded" in {
-          case class EmbeddedEntity(id: Int) extends Embedded
+          case class EmbeddedEntity(id: Int)
           "quote((o: Option[EmbeddedEntity]) => o.filterIfDefined(v => v.id == 1))" mustNot compile
         }
       }
@@ -1379,7 +1379,7 @@ class QuotationSpec extends Spec {
             Property(Ident("v"), "id") +==+ Constant.auto(4))
         }
         "embedded" in {
-          case class EmbeddedEntity(id: Int) extends Embedded
+          case class EmbeddedEntity(id: Int)
           val q = quote {
             (o: Option[EmbeddedEntity]) => o.exists(v => v.id == 1)
           }
@@ -1672,7 +1672,7 @@ class QuotationSpec extends Spec {
         }
       }
       "embedded" in {
-        case class EmbeddedTestEntity(id: String) extends Embedded
+        case class EmbeddedTestEntity(id: String)
         case class TestEntity(embedded: EmbeddedTestEntity)
         val t = TestEntity(EmbeddedTestEntity("test"))
         val q = quote {

--- a/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
@@ -334,8 +334,8 @@ final class Ident private (val name: String)(theQuat: => Quat)(val visibility: V
  * Invisible identities are a rare case where a user returns an embedded table from a map clause:
  *
  * <pre><code>
- *     case class Emb(id: Int, name: String) extends Embedded
- *     case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+ *     case class Emb(id: Int, name: String)
+ *     case class Parent(id: Int, name: String, emb: Emb)
  *     case class GrandParent(id: Int, par: Parent)
  *
  *     query[GrandParent]

--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -43,10 +43,11 @@ trait SqlIdiom extends Idiom {
 
   // See HideTopLevelFilterAlias for more detail on how this works
   def querifyAction(ast: Action, batchAlias: Option[String]) = {
-    val norm = new NormalizeFilteredActionAliases(batchAlias)(ast)
+    val norm1 = new NormalizeFilteredActionAliases(batchAlias)(ast)
+    val norm2 = io.getquill.sql.norm.HideInnerProperties(norm1)
     useActionTableAliasAs match {
-      case ActionTableAliasBehavior.Hide => HideTopLevelFilterAlias(norm)
-      case _                             => norm
+      case ActionTableAliasBehavior.Hide => HideTopLevelFilterAlias(norm2)
+      case _                             => norm2
     }
   }
 

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
@@ -147,8 +147,8 @@ object ExpandNestedQueries extends StatelessQueryTransformer {
          * In sub-queries, need to make sure that the same field/alias pair is not selected twice
          * which is possible when aliases are used. For example, something like this:
          *
-         * case class Emb(id: Int, name: String) extends Embedded
-         * case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+         * case class Emb(id: Int, name: String)
+         * case class Parent(id: Int, name: String, emb: Emb)
          * case class GrandParent(id: Int, par: Parent)
          * val q = quote { query[GrandParent].map(g => g.par).distinct.map(p => (p.name, p.emb, p.id, p.emb.id)).distinct.map(tup => (tup._1, tup._2, tup._3, tup._4)).distinct }
          * Will cause double-select inside the innermost subselect:

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/NormalizeActionAliases.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/NormalizeActionAliases.scala
@@ -21,6 +21,22 @@ object NormalizeFilteredActionAliases {
   }
 }
 
+/** In actions inner properties typically result from embedded classes, hide them */
+object HideInnerProperties extends StatelessTransformer {
+  override def apply(e: Property): Property =
+    e.copyAll(ast = recurseHide(e.ast))
+
+  // Note should also transformation for properties where queries are in the Returning(...) slot of actions.
+  // Their inner properties should be hidden by select expansion anyway.
+  private def recurseHide(ast: Ast): Ast =
+    ast match {
+      case p @ Property(inner, _) =>
+        val innerNew = recurseHide(inner)
+        p.copyAll(ast = innerNew, visibility = Visibility.Hidden)
+      case _ => ast
+    }
+}
+
 case class NormalizeFilteredActionAliases(batchAlias: Option[String]) extends StatelessTransformer {
 
   override def apply(e: Action): Action =

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
@@ -175,7 +175,7 @@ case class ProtractQuat(refersToEntity: Boolean) {
             /* If the property represents a property of a Entity (i.e. we're selecting from an actual table,
              * then the entire projection of the Quat should be visible (since subsequent aliases will
              * be using the entire path.
-             * Take: Bim(bid:Int, mam:Mam), Mam(mid:Int, mood:Int) extends Embedded
+             * Take: Bim(bid:Int, mam:Mam), Mam(mid:Int, mood:Int)
              * Here is an example:
              * SELECT g.mam FROM
              *    SELECT gim.bim: CC(bid:Int,mam:CC(mid:Int,mood:Int)) FROM g

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
@@ -11,7 +11,7 @@ class EmbeddedSpec extends Spec {
   "queries with embedded entities should" - {
     "function property inside of nested distinct queries" in {
       case class Parent(id: Int, emb1: Emb)
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Emb(a: Int, b: Int)
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct
       }
@@ -20,7 +20,7 @@ class EmbeddedSpec extends Spec {
 
     "function property inside of nested distinct queries - tuple" in {
       case class Parent(id: Int, emb1: Emb)
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Emb(a: Int, b: Int)
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => (2, p)).distinct
       }
@@ -29,7 +29,7 @@ class EmbeddedSpec extends Spec {
 
     "function property inside of nested distinct queries through tuples" in {
       case class Parent(id: Int, emb1: Emb)
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Emb(a: Int, b: Int)
       val q = quote {
         query[Emb].map(e => (1, e)).distinct.map(t => Parent(t._1, t._2)).distinct
       }
@@ -38,8 +38,8 @@ class EmbeddedSpec extends Spec {
 
     "function property inside of nested distinct queries - twice" in {
       case class Grandparent(idG: Int, par: Parent)
-      case class Parent(idP: Int, emb1: Emb) extends Embedded
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Parent(idP: Int, emb1: Emb)
+      case class Emb(a: Int, b: Int)
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct
       }
@@ -48,8 +48,8 @@ class EmbeddedSpec extends Spec {
 
     "function property inside of nested distinct queries - twice - into tuple" in {
       case class Grandparent(idG: Int, par: Parent)
-      case class Parent(idP: Int, emb1: Emb) extends Embedded
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Parent(idP: Int, emb1: Emb)
+      case class Emb(a: Int, b: Int)
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct.map(g => (3, g)).distinct
       }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -54,10 +54,16 @@ trait EncodingSpec extends Spec {
   }
 
   object TimeEntity {
-    def make(zoneIdRaw: ZoneId) = {
+    case class TimeEntityInput(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, nano: Int) {
+      def toLocalDate = LocalDateTime.of(year, month, day, hour, minute, second, nano)
+    }
+    object TimeEntityInput {
+      def default = new TimeEntityInput(2022, 1, 2, 3, 4, 6, 0)
+    }
+    def make(zoneIdRaw: ZoneId, timeEntity: TimeEntityInput = TimeEntityInput.default) = {
       val zoneId = zoneIdRaw.normalized()
       // Millisecond precisions in SQL Server and many contexts are wrong so not using them
-      val nowInstant = LocalDateTime.of(2022, 1, 2, 3, 4, 6, 0).atZone(zoneId).toInstant
+      val nowInstant = timeEntity.toLocalDate.atZone(zoneId).toInstant
       val nowDateTime = LocalDateTime.ofInstant(nowInstant, zoneId)
       val nowDate = nowDateTime.toLocalDate
       val nowTime = nowDateTime.toLocalTime

--- a/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
@@ -71,7 +71,7 @@ class GroupBySpec extends Spec {
   }
 
   "Embedded entity expansion" - {
-    case class Language(name: String, dialect: String) extends Embedded
+    case class Language(name: String, dialect: String)
     case class Country(countryCode: String, language: Language)
     case class City(countryCode: String, name: String)
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
@@ -216,7 +216,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct.map(tup => (tup._1, tup._2)).distinct
         }
-        ctx.run(q).string mustEqual "SELECT DISTINCT e.theName AS _1, e.id AS _2 FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
+        ctx.run(q).string mustEqual "SELECT DISTINCT p._1theName AS _1, p._1id AS _2 FROM (SELECT DISTINCT p.id AS _1id, p.theName AS _1theName FROM Parent p) AS p"
       }
 
       "can be propogated across query with naming intact and then used further - nested" in {
@@ -230,7 +230,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => p.emb).distinct.map(e => (e.name))
         }
-        ctx.run(q).string mustEqual "SELECT e.theName FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
+        ctx.run(q).string mustEqual "SELECT p._1theName AS theName FROM (SELECT DISTINCT p.id AS _1id, p.theName AS _1theName FROM Parent p) AS p"
       }
 
       "can be propogated across query with naming intact - and the immediately returned" in {
@@ -251,7 +251,7 @@ class NestedDistinctSpec extends Spec {
         val q = quote {
           query[Parent].map(p => p.emb).distinct.map(e => Parent(1, e))
         }
-        ctx.run(q).string mustEqual "SELECT 1 AS idP, e.id, e.theName FROM (SELECT DISTINCT p.id, p.theName FROM Parent p) AS e"
+        ctx.run(q).string mustEqual "SELECT 1 AS idP, p._1id AS id, p._1theName AS theName FROM (SELECT DISTINCT p.id AS _1id, p.theName AS _1theName FROM Parent p) AS p"
       }
 
       "can be propogated across query with naming intact and then re-wrapped in tuple" in {
@@ -274,7 +274,7 @@ class NestedDistinctSpec extends Spec {
             .map(g => g.par).distinct
             .map(p => p.emb).map(p => p.name).distinct
         }
-        ctx.run(q).string mustEqual "SELECT DISTINCT p.embtheName AS theName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
+        ctx.run(q).string mustEqual "SELECT DISTINCT g._1embtheName AS theName FROM (SELECT DISTINCT g.id AS _1id, g.theParentName AS _1theParentName, g.id AS _1embid, g.theName AS _1embtheName FROM GrandParent g) AS g"
       }
 
       "fully unwrapped name propagates with side property" in {
@@ -285,7 +285,7 @@ class NestedDistinctSpec extends Spec {
             .map(tup => (tup._1, tup._2)).distinct
         }
         ctx.run(q).string mustEqual
-          "SELECT DISTINCT p.theParentName AS _1, p.embid AS id, p.embtheName AS theName FROM (SELECT DISTINCT g.id, g.theParentName, g.id AS embid, g.theName AS embtheName FROM GrandParent g) AS p"
+          "SELECT DISTINCT g._1theParentName AS _1, g._1embid AS id, g._1embtheName AS theName FROM (SELECT DISTINCT g.id AS _1id, g.theParentName AS _1theParentName, g.id AS _1embid, g.theName AS _1embtheName FROM GrandParent g) AS g"
       }
 
       "fully unwrapped name propagates with side property - nested" in {
@@ -335,24 +335,24 @@ class NestedDistinctSpec extends Spec {
             .map(p => (p.name, p.emb, p.id, p.emb.id)).distinct
             .map(tup => (tup._1, tup._2, tup._3, tup._4)).distinct
         }
-        ctx.run(q).string(true).collapseSpace mustEqual
+        ctx.run(q).string(true).collapseSpace mustEqual //
           """
             |SELECT
-            |  DISTINCT p.theParentName AS _1,
-            |  p.embid AS id,
-            |  p.embtheName AS theName,
-            |  p.id AS _3,
-            |  p.embid AS _4
+            |  DISTINCT g._1theParentName AS _1,
+            |  g._1embid AS id,
+            |  g._1embtheName AS theName,
+            |  g._1id AS _3,
+            |  g._1embid AS _4
             |FROM
             |  (
             |    SELECT
-            |      DISTINCT g.id,
-            |      g.theParentName,
-            |      g.id AS embid,
-            |      g.theName AS embtheName
+            |      DISTINCT g.id AS _1id,
+            |      g.theParentName AS _1theParentName,
+            |      g.id AS _1embid,
+            |      g.theName AS _1embtheName
             |    FROM
             |      GrandParent g
-            |  ) AS p
+            |  ) AS g
             |""".collapseSpace
       }
 
@@ -367,21 +367,21 @@ class NestedDistinctSpec extends Spec {
         ctx.run(q).string(true).collapseSpace mustEqual
           """
             |SELECT
-            |  DISTINCT p.theParentName AS _1,
-            |  p.embid AS id,
-            |  p.embtheName AS theName,
-            |  p.id AS _3,
-            |  p.embid AS _4
+            |  DISTINCT g._1theParentName AS _1,
+            |  g._1embid AS id,
+            |  g._1embtheName AS theName,
+            |  g._1id AS _3,
+            |  g._1embid AS _4
             |FROM
             |  (
             |    SELECT
-            |      DISTINCT g.id,
-            |      g.theParentName,
-            |      g.id AS embid,
-            |      g.theName AS embtheName
+            |      DISTINCT g.id AS _1id,
+            |      g.theParentName AS _1theParentName,
+            |      g.id AS _1embid,
+            |      g.theName AS _1embtheName
             |    FROM
             |      GrandParent g
-            |  ) AS p
+            |  ) AS g
             |""".collapseSpace
       }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
@@ -13,7 +13,7 @@ class NestedDistinctSpec extends Spec {
     import ctx._
 
     "first operation" - {
-      case class MyEmb(name: String) extends Embedded
+      case class MyEmb(name: String)
       case class MyParent(myEmb: MyEmb)
 
       "first operation nesting with filter" in {
@@ -49,7 +49,7 @@ class NestedDistinctSpec extends Spec {
       }
 
       "first operation nesting with filter before and after - groupBy" in { //hello
-        case class MyEmb(name: Int) extends Embedded
+        case class MyEmb(name: Int)
         case class MyParent(myEmb: MyEmb)
 
         val q = quote {
@@ -176,7 +176,7 @@ class NestedDistinctSpec extends Spec {
     }
 
     "embedded entity from parent" - {
-      case class Emb(id: Int, name: String) extends Embedded
+      case class Emb(id: Int, name: String)
       case class Parent(idP: Int, emb: Emb)
       implicit val parentMeta = schemaMeta[Parent]("Parent", _.emb.name -> "theName")
 
@@ -263,8 +263,8 @@ class NestedDistinctSpec extends Spec {
     }
 
     "double embedded entity from parent" - {
-      case class Emb(id: Int, name: String) extends Embedded
-      case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+      case class Emb(id: Int, name: String)
+      case class Parent(id: Int, name: String, emb: Emb)
       case class GrandParent(id: Int, par: Parent)
       implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.par.emb.name -> "theName", _.par.name -> "theParentName")
 
@@ -619,7 +619,7 @@ class NestedDistinctSpec extends Spec {
 
     "adversarial tests" - {
       "should correctly rename the right property when multiple nesting layers have the same one" in {
-        case class Emb(name: String, id: Int) extends Embedded
+        case class Emb(name: String, id: Int)
         case class Parent(name: String, emb1: Emb, emb2: Emb)
         case class GrandParent(name: String, par: Parent)
 
@@ -745,7 +745,7 @@ class NestedDistinctSpec extends Spec {
     }
 
     "query with single embedded element" - {
-      case class Emb(a: Int, b: Int) extends Embedded
+      case class Emb(a: Int, b: Int)
       case class Parent(id: Int, emb1: Emb)
       case class Parent2(emb1: Emb, id: Int)
 
@@ -801,12 +801,12 @@ class NestedDistinctSpec extends Spec {
     }
 
     "query with multiple embedded elements with same names" - {
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
       case class Parent(name: String, emb1: Emb, emb2: Emb)
       case class GrandParent(name: String, par: Parent)
 
-      case class One(name: String, id: Int) extends Embedded
-      case class Two(name: String, id: Int) extends Embedded
+      case class One(name: String, id: Int)
+      case class Two(name: String, id: Int)
       case class Dual(one: One, two: Two)
 
       // Try parent and embedded children with same name, schema on parent

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -173,7 +173,7 @@ class SqlActionMacroSpec extends Spec {
       "returning clause - embedded" - {
         case class Dummy(i: Int)
 
-        "embedded property" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+        "embedded property" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx => //
           import ctx._
           val q = quote {
             qr1Emb.insertValue(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returningGenerated(_.emb.i)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/base/BatchUpdateValuesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/base/BatchUpdateValuesSpec.scala
@@ -110,7 +110,7 @@ trait BatchUpdateValuesSpec extends Spec with BeforeAndAfterEach {
   }
 
   object `Ex 2 - Optional Embedded with Renames` extends Adaptable {
-    case class Name(first: String, last: String) extends Embedded
+    case class Name(first: String, last: String)
     case class ContactTable(name: Option[Name], age: Int)
     type Row = ContactTable
     override def makeData(c: ContactBase): ContactTable = ContactTable(Some(Name(c.firstName, c.lastName)), c.age)
@@ -132,9 +132,9 @@ trait BatchUpdateValuesSpec extends Spec with BeforeAndAfterEach {
   }
 
   object `Ex 3 - Deep Embedded Optional` extends Adaptable {
-    case class FirstName(firstName: Option[String]) extends Embedded
-    case class LastName(lastName: Option[String]) extends Embedded
-    case class Name(first: FirstName, last: LastName) extends Embedded
+    case class FirstName(firstName: Option[String])
+    case class LastName(lastName: Option[String])
+    case class Name(first: FirstName, last: LastName)
     case class Contact(name: Option[Name], age: Int)
     type Row = Contact
     override def makeData(c: ContactBase): Contact = Contact(Some(Name(FirstName(Option(c.firstName)), LastName(Option(c.lastName)))), c.age)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/BooleanLiteralSupportSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/BooleanLiteralSupportSpec.scala
@@ -243,19 +243,19 @@ class BooleanLiteralSupportSpec extends Spec {
     "join + map (with conditional comparison)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
       import ctx._
       val q = quote {
-        qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.forall(_.i > 20)) false else true))
+        qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.exists(_.i > 20)) false else true))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i AS _1, CASE WHEN b IS NULL OR b.i > 20 THEN 0 ELSE 1 END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, CASE WHEN b.i > 20 THEN 0 ELSE 1 END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map (with conditional comparison lifted)" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>
       import ctx._
       val q = quote {
-        qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.forall(_.i > 20)) lift(false) else lift(true)))
+        qr1.leftJoin(qr2).on((a, b) => true).map(t => (t._1.i, if (t._2.exists(_.i > 20)) lift(false) else lift(true)))
       }
       ctx.run(q).string mustEqual
-        "SELECT a.i AS _1, CASE WHEN b IS NULL OR b.i > 20 THEN ? ELSE ? END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
+        "SELECT a.i AS _1, CASE WHEN b.i > 20 THEN ? ELSE ? END AS _2 FROM TestEntity a LEFT JOIN TestEntity2 b ON 1 = 1"
     }
 
     "join + map + filter" in testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { ctx =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomOptionCompareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomOptionCompareSpec.scala
@@ -139,7 +139,7 @@ class SqlIdiomOptionCompareSpec extends Spec {
     }
     "embedded" - {
       case class TestEntity(optionalEmbedded: Option[EmbeddedEntity])
-      case class EmbeddedEntity(value: Int) extends Embedded
+      case class EmbeddedEntity(value: Int)
 
       "exists" in {
         val q = quote {
@@ -158,7 +158,7 @@ class SqlIdiomOptionCompareSpec extends Spec {
     }
     "nested" - {
       case class TestEntity(optionalEmbedded: Option[EmbeddedEntity])
-      case class EmbeddedEntity(optionalValue: Option[Int]) extends Embedded
+      case class EmbeddedEntity(optionalValue: Option[Int])
 
       "contains" in {
         val q = quote {
@@ -349,7 +349,7 @@ class SqlIdiomOptionCompareSpec extends Spec {
     }
     "embedded" - {
       case class TestEntity(optionalEmbedded: Option[EmbeddedEntity])
-      case class EmbeddedEntity(value: Int) extends Embedded
+      case class EmbeddedEntity(value: Int)
 
       "exists" in {
         val q = quote {
@@ -368,7 +368,7 @@ class SqlIdiomOptionCompareSpec extends Spec {
     }
     "nested" - {
       case class TestEntity(optionalEmbedded: Option[EmbeddedEntity])
-      case class EmbeddedEntity(optionalValue: Option[Int]) extends Embedded
+      case class EmbeddedEntity(optionalValue: Option[Int])
 
       "contains" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -831,7 +831,7 @@ class SqlIdiomSpec extends Spec {
           "SELECT t.s FROM TestEntity t"
       }
       "nested" in {
-        case class A(s: String) extends Embedded
+        case class A(s: String)
         case class B(a: A)
         testContext.run(query[B]).string mustEqual
           "SELECT x.s FROM B x"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
@@ -8,8 +8,8 @@ class ObservationMirrorSpec extends Spec {
   val ctx = io.getquill.context.sql.testContext
   import ctx._
 
-  case class LatLon(lat: Int, lon: Int) extends Embedded
-  case class ScalarData(value: Long, position: Option[LatLon]) extends Embedded
+  case class LatLon(lat: Int, lon: Int)
+  case class ScalarData(value: Long, position: Option[LatLon])
   case class Observation(data: Option[ScalarData], foo: Option[String], bar: Option[String])
 
   val obs = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -217,7 +217,7 @@ class ExpandNestedQueriesSpec extends Spec {
       val q = quote {
         query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id))
       }
-      ctx.run(q).string mustEqual "SELECT e.name AS _1, e.id AS _2 FROM (SELECT DISTINCT p.name, p.id FROM Parent p) AS e"
+      ctx.run(q).string mustEqual "SELECT p._1name AS _1, p._1id AS _2 FROM (SELECT DISTINCT p.name AS _1name, p.id AS _1id FROM Parent p) AS p"
     }
 
     "can be propagated across distinct query with naming intact - double distinct" in {
@@ -227,7 +227,7 @@ class ExpandNestedQueriesSpec extends Spec {
       val q = quote {
         query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT DISTINCT e.name AS _1, e.id AS _2 FROM (SELECT DISTINCT p.name, p.id FROM Parent p) AS e"
+      ctx.run(q).string mustEqual "SELECT DISTINCT p._1name AS _1, p._1id AS _2 FROM (SELECT DISTINCT p.name AS _1name, p.id AS _1id FROM Parent p) AS p"
     }
 
     "can be propagated across distinct query with naming intact then re-wrapped into the parent" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -122,7 +122,7 @@ class ExpandNestedQueriesSpec extends Spec {
   "expands nested mapped entity correctly" in {
     import testContext._
 
-    case class TestEntity(s: String, i: Int, l: Long, o: Option[Int]) extends Embedded
+    case class TestEntity(s: String, i: Int, l: Long, o: Option[Int])
     case class Dual(ta: TestEntity, tb: TestEntity)
 
     val qr1 = quote {
@@ -179,7 +179,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "embedded, distinct entity in sub-tuple" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
 
       val q = quote {
         query[Parent].map(p => (p.emb, 1)).distinct.map(e => (e._1.name, e._1.id))
@@ -190,7 +190,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "embedded, distinct entity in case class" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
       case class SuperParent(emb: Emb, id: Int)
 
       val q = quote {
@@ -202,7 +202,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "can be propagated across nested query with naming intact" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
 
       val q = quote {
         query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id))
@@ -212,7 +212,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "can be propagated across distinct query with naming intact" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
 
       val q = quote {
         query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id))
@@ -222,7 +222,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "can be propagated across distinct query with naming intact - double distinct" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
 
       val q = quote {
         query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct
@@ -232,7 +232,7 @@ class ExpandNestedQueriesSpec extends Spec {
 
     "can be propagated across distinct query with naming intact then re-wrapped into the parent" in {
       case class Parent(id: Int, emb: Emb)
-      case class Emb(name: String, id: Int) extends Embedded
+      case class Emb(name: String, id: Int)
 
       val q = quote {
         query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct.map(tup => Emb(tup._1, tup._2)).distinct
@@ -248,8 +248,8 @@ class ExpandNestedQueriesSpec extends Spec {
 
   "multiple embedding levels" in {
     import testContext._
-    case class Emb(id: Int, name: String) extends Embedded
-    case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+    case class Emb(id: Int, name: String)
+    case class Parent(id: Int, name: String, emb: Emb)
     case class GrandParent(id: Int, par: Parent)
 
     val q = quote {
@@ -303,8 +303,8 @@ class ExpandNestedQueriesSpec extends Spec {
 
   "multiple embedding levels - another example" in {
     import testContext._
-    case class Sim(sid: Int) extends Embedded
-    case class Mam(mid: Int, sim: Sim) extends Embedded
+    case class Sim(sid: Int)
+    case class Mam(mid: Int, sim: Sim)
     case class Bim(bid: Int, mam: Mam)
 
     val q = quote {
@@ -365,8 +365,8 @@ class ExpandNestedQueriesSpec extends Spec {
 
   "multiple embedding levels - another example - with rename" in {
     import testContext._
-    case class Sim(sid: Int) extends Embedded
-    case class Mam(mid: Int, sim: Sim) extends Embedded
+    case class Sim(sid: Int)
+    case class Mam(mid: Int, sim: Sim)
     case class Bim(bid: Int, mam: Mam)
 
     implicit val bimSchemaMeta = schemaMeta[Bim]("theBim", _.bid -> "theBid", _.mam.sim.sid -> "theSid")
@@ -431,8 +431,8 @@ class ExpandNestedQueriesSpec extends Spec {
   "multiple embedding levels - another example - with rename - with escape column" in {
     val ctx = testContextUpperEscapeColumn
     import ctx._
-    case class Sim(sid: Int) extends Embedded
-    case class Mam(mid: Int, sim: Sim) extends Embedded
+    case class Sim(sid: Int)
+    case class Mam(mid: Int, sim: Sim)
     case class Bim(bid: Int, mam: Mam)
 
     implicit val bimSchemaMeta = schemaMeta[Bim]("theBim", _.bid -> "theBid", _.mam.sim.sid -> "theSid")
@@ -496,8 +496,8 @@ class ExpandNestedQueriesSpec extends Spec {
   "multiple embedding levels - another example - with rename - with escape column - with groupby" in {
     val ctx = testContextUpperEscapeColumn
     import ctx._
-    case class Sim(sid: Int) extends Embedded
-    case class Mam(mid: Int, sim: Sim) extends Embedded
+    case class Sim(sid: Int)
+    case class Mam(mid: Int, sim: Sim)
     case class Bim(bid: Int, mam: Mam)
 
     implicit val bimSchemaMeta = schemaMeta[Bim]("theBim", _.bid -> "theBid", _.mam.sim.sid -> "theSid")
@@ -591,7 +591,7 @@ class ExpandNestedQueriesSpec extends Spec {
     val ctx = testContextUpperEscapeColumn
     import ctx._
 
-    case class Sim(sid: Int) extends Embedded
+    case class Sim(sid: Int)
     case class Mam(mid: Int, sim: Sim)
 
     val q = quote {
@@ -653,7 +653,7 @@ class ExpandNestedQueriesSpec extends Spec {
     }
 
     "should be handled correctly in a regular schema - nested" in {
-      case class Name(firstName: String, lastName: String) extends Embedded
+      case class Name(firstName: String, lastName: String)
       case class Person(name: Name, theAge: Int)
       val q = quote {
         sql"fromSomewhere()".as[Query[Person]]

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -349,13 +349,13 @@ class RenamePropertiesOverrideSpec extends Spec {
   "respects the schema definition for embeddeds" - {
     "query" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         testContextUpper.run(query[A]).string mustEqual
           "SELECT x.C AS c FROM A x"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC")
@@ -366,13 +366,13 @@ class RenamePropertiesOverrideSpec extends Spec {
     }
     "query for Option embeddeds" - {
       "without schema" in {
-        case class B(c1: Int, c2: Int) extends Embedded
+        case class B(c1: Int, c2: Int)
         case class A(b: Option[B])
         testContextUpper.run(query[A]).string mustEqual
           "SELECT x.C1 AS c1, x.C2 AS c2 FROM A x"
       }
       "with schema" in {
-        case class B(c1: Int, c2: Int) extends Embedded
+        case class B(c1: Int, c2: Int)
         case class A(b: Option[B])
         val q = quote {
           querySchema[A]("A", _.b.map(_.c1) -> "bC1", _.b.map(_.c2) -> "bC2")
@@ -383,7 +383,7 @@ class RenamePropertiesOverrideSpec extends Spec {
     }
     "update" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           query[A].update(_.b.c -> 1)
@@ -392,7 +392,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           "UPDATE A SET C = 1"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC").update(_.b.c -> 1)
@@ -403,7 +403,7 @@ class RenamePropertiesOverrideSpec extends Spec {
     }
     "insert" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           query[A].insert(_.b.c -> 1)
@@ -412,7 +412,7 @@ class RenamePropertiesOverrideSpec extends Spec {
           "INSERT INTO A (C) VALUES (1)"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC").insert(_.b.c -> 1)
@@ -423,7 +423,7 @@ class RenamePropertiesOverrideSpec extends Spec {
     }
 
     "sql" - {
-      case class B(b: Int) extends Embedded
+      case class B(b: Int)
       case class A(u: Long, v: Int, w: B)
       "does not break schema" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -393,13 +393,13 @@ class RenamePropertiesSpec extends Spec {
   "respects the schema definition for embeddeds" - {
     "query" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         testContext.run(query[A]).string mustEqual
           "SELECT x.c FROM A x"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC")
@@ -410,13 +410,13 @@ class RenamePropertiesSpec extends Spec {
     }
     "query for Option embeddeds" - {
       "without schema" in {
-        case class B(c1: Int, c2: Int) extends Embedded
+        case class B(c1: Int, c2: Int)
         case class A(b: Option[B])
         testContext.run(query[A]).string mustEqual
           "SELECT x.c1, x.c2 FROM A x"
       }
       "with schema" in {
-        case class B(c1: Int, c2: Int) extends Embedded
+        case class B(c1: Int, c2: Int)
         case class A(b: Option[B])
         val q = quote {
           querySchema[A]("A", _.b.map(_.c1) -> "bC1", _.b.map(_.c2) -> "bC2")
@@ -427,7 +427,7 @@ class RenamePropertiesSpec extends Spec {
     }
     "update" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           query[A].update(_.b.c -> 1)
@@ -436,7 +436,7 @@ class RenamePropertiesSpec extends Spec {
           "UPDATE A SET c = 1"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC").update(_.b.c -> 1)
@@ -447,7 +447,7 @@ class RenamePropertiesSpec extends Spec {
     }
     "insert" - {
       "without schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           query[A].insert(_.b.c -> 1)
@@ -456,7 +456,7 @@ class RenamePropertiesSpec extends Spec {
           "INSERT INTO A (c) VALUES (1)"
       }
       "with schema" in {
-        case class B(c: Int) extends Embedded
+        case class B(c: Int)
         case class A(b: B)
         val q = quote {
           querySchema[A]("A", _.b.c -> "bC").insert(_.b.c -> 1)
@@ -467,7 +467,7 @@ class RenamePropertiesSpec extends Spec {
     }
 
     "sql" - {
-      case class B(b: Int) extends Embedded
+      case class B(b: Int)
       case class A(u: Long, v: Int, w: B)
       "does not break schema" in {
         val q = quote {


### PR DESCRIPTION
Object no longer need to be embedded. Objects will automatically be embedded unless there is an encoder for them (which automatically happens when there's a mapped encoding or they are an AnyVal).
Probably need to make a warning for things that "seem" to be something that a use would like to encode e.g. products that have a single argument which is a value. Need to think about that.