### PR TITLE
Warning about embedding fields that should have encoders

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -409,7 +409,7 @@ class CqlIdiomSpec extends Spec {
       implicitly[Tokenizer[Value]].token(Tuple(List(Ident("a")))) mustBe stmt"a"
     }
     "value in caseclass" in {
-      implicitly[Tokenizer[Value]].token(CaseClass(List(("value", Ident("a"))))) mustBe stmt"a"
+      implicitly[Tokenizer[Value]].token(CaseClass("CC", List(("value", Ident("a"))))) mustBe stmt"a"
     }
     "action" in {
       val t = implicitly[Tokenizer[AstAction]]

--- a/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -109,7 +109,7 @@ object RuntimeEntityQuat {
     cls match {
       case AnyVal() => Quat.Value
       case Embedded(methods) =>
-        Quat.Product(methods.map(m => (m.getName, forClass(m.getReturnType))))
+        Quat.Product(cls.getName.split('.').last, methods.map(m => (m.getName, forClass(m.getReturnType))))
       // If we are here we are already inside of a product which means if we are not a embedded, we have to be value-level
       case _ => Quat.Value
     }
@@ -119,11 +119,11 @@ object RuntimeEntityQuat {
       case AnyVal() => Quat.Value
       // Embedded object can be a top-level entity
       case Embedded(methods) =>
-        Quat.Product(methods.map(m => (m.getName, forClass(m.getReturnType))))
+        Quat.Product(cls.getName.split('.').last, methods.map(m => (m.getName, forClass(m.getReturnType))))
       case Tuple() =>
         throw new IllegalArgumentException("Tuple are not supported with Dynamic Query Schemas.")
       case CaseClass(methods) =>
-        Quat.Product(methods.map(m => (m.getName, forClass(m.getReturnType))))
+        Quat.Product(cls.getName.split('.').last, methods.map(m => (m.getName, forClass(m.getReturnType))))
       case _ =>
         Quat.Value
     }
@@ -326,11 +326,11 @@ trait QuatMakingBase extends MacroUtilUniverse {
         // For other types of case classes (and if there does not exist an encoder for it)
         // the exception to that is a cassandra UDT that we treat like an encodeable entity even if it has a parsed type
         case CaseClassBaseType(name, fields) if !existsEncoderFor(tpe) || tpe <:< typeOf[Udt] =>
-          Quat.Product(fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
+          Quat.Product(name.split('.').last, fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
 
         // If we are already inside a bounded type, treat an arbitrary type as a interface list
         case ArbitraryBaseType(name, fields) if (boundedInterfaceType) =>
-          Quat.Product(fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
+          Quat.Product(name.split('.').last, fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
 
         // Is it a generic or does it have any generic parameters that have not been filled (e.g. is T not filled in Option[T] ?)
         case Param(tpe) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -201,7 +201,7 @@ trait Liftables extends QuatLiftable {
     case NullValue         => q"$pack.NullValue"
     case Constant(a, quat) => q"$pack.Constant(${Literal(mctx.universe.Constant(a))}, $quat)"
     case Tuple(a)          => q"$pack.Tuple($a)"
-    case CaseClass(a)      => q"$pack.CaseClass($a)"
+    case CaseClass(n, a)   => q"$pack.CaseClass($n, $a)"
   }
 
   implicit val identLiftable: Liftable[Ident] = Liftable[Ident] {

--- a/quill-core/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -15,8 +15,8 @@ trait QuatLiftable {
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JVM, use Kryo to serialize our Quat due to JVM 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat.Product if (serializeQuats)                                       => q"io.getquill.quat.Quat.Product.fromSerialized(${quat.serialize})"
-    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.Product.fromSerialized(${quat.serialize})"
+    case Quat.Product.WithRenamesCompact(name, tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($name, $tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
   }
 
   implicit val quatProductTypeLiftable: Liftable[Quat.Product.Type] = Liftable[Quat.Product.Type] {
@@ -26,7 +26,7 @@ trait QuatLiftable {
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
     case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.fromSerialized(${quat.serialize})"
-    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case Quat.Product.WithRenamesCompact(name, tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($name, $tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
     case Quat.Value => q"io.getquill.quat.Quat.Value"
     case Quat.Null => q"io.getquill.quat.Quat.Null"
     case Quat.Generic => q"io.getquill.quat.Quat.Generic"

--- a/quill-core/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -17,7 +17,7 @@ trait QuatUnliftable {
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerialized(${ str: String })" => Quat.Product.fromSerialized(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ name: String }, ${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(name, tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
   }
 
   implicit val quatProductTypeUnliftable: Unliftable[Quat.Product.Type] = Unliftable[Quat.Product.Type] {
@@ -28,8 +28,8 @@ trait QuatUnliftable {
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.fromSerialized(${ str: String })" => Quat.fromSerialized(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
-    case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ name: String }, ${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(name, tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.apply(${ name: String }, ${ fields: List[(String, Quat)] })" => Quat.Product(name, fields)
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null
     case q"$pack.Quat.Generic" => Quat.Generic

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -200,7 +200,7 @@ trait Unliftables extends QuatUnliftable {
     case q"$pack.NullValue" => NullValue
     case q"$pack.Constant.apply(${ Literal(mctx.universe.Constant(a)) }, ${ quat: Quat })" => Constant(a, quat)
     case q"$pack.Tuple.apply(${ a: List[Ast] })" => Tuple(a)
-    case q"$pack.CaseClass.apply(${ values: List[(String, Ast)] })" => CaseClass(values)
+    case q"$pack.CaseClass.apply(${ n: String }, ${ values: List[(String, Ast)] })" => CaseClass(n, values)
   }
 
   implicit val identUnliftable: Unliftable[Ident] = Unliftable[Ident] {

--- a/quill-core/src/main/scala/io/getquill/util/MacroContextExt.scala
+++ b/quill-core/src/main/scala/io/getquill/util/MacroContextExt.scala
@@ -3,6 +3,7 @@ package io.getquill.util
 import io.getquill.idiom.Idiom
 import io.getquill.util.IndentUtil._
 import io.getquill.util.Messages.{ debugEnabled, prettyPrint }
+import io.getquill.quat.VerifyNoBranches
 
 import scala.reflect.macros.blackbox.{ Context => MacroContext }
 
@@ -20,6 +21,12 @@ object MacroContextExt {
 
     def warn(msg: String): Unit =
       c.warning(c.enclosingPosition, msg)
+
+    def warn(verifyOutput: VerifyNoBranches.Output): Unit = {
+      val pos = c.enclosingPosition
+      val locationString = s"${pos.source.path}:${pos.line}:${pos.column}"
+      verifyOutput.messages.distinct.foreach(message => println(s"[WARNING] ${locationString} Questionable row-class found.\n${message.msg}"))
+    }
 
     def query(queryString: String, idiom: Idiom): Unit = {
       val formatted =

--- a/quill-core/src/test/scala/io/getquill/TestEntities.scala
+++ b/quill-core/src/test/scala/io/getquill/TestEntities.scala
@@ -20,13 +20,13 @@ trait TestEntities {
   private val QV = Quat.Value
   private val QBV = Quat.BooleanValue
 
-  val TestEntityQuat = Quat.Product("s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV, "b" -> QBV)
-  val TestEntityEmbQuat = Quat.Product("emb" -> Quat.Product("s" -> QV, "i" -> QV), "l" -> QV, "o" -> QV)
-  val TestEntity2Quat = Quat.Product("s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV)
-  val TestEntity3Quat = Quat.Product("s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV)
-  val TestEntity4Quat = Quat.Product("i" -> QV)
-  val TestEntity5Quat = Quat.Product("i" -> QV, "s" -> QV)
-  val TestEntity4EmbQuat = Quat.Product("emb" -> Quat.Product("i" -> QV))
+  val TestEntityQuat = Quat.Product("TestEntity", "s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV, "b" -> QBV)
+  val TestEntityEmbQuat = Quat.Product("TestEntityEmb", "emb" -> Quat.Product("Emb", "s" -> QV, "i" -> QV), "l" -> QV, "o" -> QV)
+  val TestEntity2Quat = Quat.Product("TestEntity2", "s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV)
+  val TestEntity3Quat = Quat.Product("TestEntity3", "s" -> QV, "i" -> QV, "l" -> QV, "o" -> QV)
+  val TestEntity4Quat = Quat.Product("TestEntity4", "i" -> QV)
+  val TestEntity5Quat = Quat.Product("TestEntity5", "i" -> QV, "s" -> QV)
+  val TestEntity4EmbQuat = Quat.Product("TestEntity4Emb", "emb" -> Quat.Product("EmbSingle", "i" -> QV))
 
   val qr1 = quote {
     query[TestEntity]

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -184,10 +184,10 @@ class StatefulTransformerSpec extends Spec {
         }
       }
       "caseclass" in {
-        val ast: Ast = CaseClass(List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
+        val ast: Ast = CaseClass("CC", List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
           case (at, att) =>
-            at mustEqual CaseClass(List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
+            at mustEqual CaseClass("CC", List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
             att.state mustEqual List(Ident("a"), Ident("b"), Ident("c"))
         }
       }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -122,9 +122,9 @@ class StatelessTransformerSpec extends Spec {
           Tuple(List(Ident("a'"), Ident("b'"), Ident("c'")))
       }
       "caseclass" in {
-        val ast: Ast = CaseClass(List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
+        val ast: Ast = CaseClass("CC", List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
-          CaseClass(List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
+          CaseClass("CC", List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/base/Spec.scala
+++ b/quill-core/src/test/scala/io/getquill/base/Spec.scala
@@ -14,8 +14,8 @@ import scala.concurrent.{ Await, Future }
 
 abstract class Spec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   val QV = Quat.Value
-  val QEP = Quat.Product.empty
-  def QP(fields: String*) = Quat.LeafProduct(fields: _*)
+  val QEP = Quat.Product.empty("Product")
+  def QP(name: String, fields: String*) = Quat.LeafProduct(name, fields: _*)
 
   // Used by various tests to replace temporary idents created by AttachToEntity with 'x'
   val replaceTempIdent = new StatelessTransformer {

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -18,11 +18,11 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast) mustEqual Ident("a")
     }
     "caseclass field" in {
-      val ast: Ast = Property(CaseClass(List(("foo", Ident("a")))), "foo")
+      val ast: Ast = Property(CaseClass("CC", List(("foo", Ident("a")))), "foo")
       BetaReduction(ast) mustEqual Ident("a")
     }
     "caseclass field - fixed property" in {
-      val ast: Ast = Property.Opinionated(CaseClass(List(("foo", Ident("a")))), "foo", Fixed, Visible)
+      val ast: Ast = Property.Opinionated(CaseClass("CC", List(("foo", Ident("a")))), "foo", Fixed, Visible)
       BetaReduction(ast) mustEqual Ident("a")
     }
     "function apply" in {
@@ -84,7 +84,7 @@ class BetaReductionSpec extends Spec {
           Val(aE, entity),
           Val(b, c2),
           Val(c, c3),
-          CaseClass(List(("foo", aE), ("bar", bE), ("baz", cE)))
+          CaseClass("CC", List(("foo", aE), ("bar", bE), ("baz", cE)))
         ))
         val outer = Block(List(
           Val(aE, inner),
@@ -92,7 +92,7 @@ class BetaReductionSpec extends Spec {
           Val(cE, bE),
           cE
         ))
-        BetaReduction.AllowEmpty(outer) mustEqual CaseClass(List(("foo", entity), ("bar", c2), ("baz", c3)))
+        BetaReduction.AllowEmpty(outer) mustEqual CaseClass("CC", List(("foo", entity), ("bar", c2), ("baz", c3)))
       }
     }
     "avoids replacing idents of an outer scope" - {
@@ -190,7 +190,7 @@ class BetaReductionSpec extends Spec {
   "reapplies the beta reduction if the structure changes caseclass" in {
     val quat = Quat.LeafProduct("foo")
     val ast: Ast = Property(Ident("a", quat), "foo")
-    BetaReduction(ast, Ident("a", quat) -> CaseClass(List(("foo", Ident("a'"))))) mustEqual
+    BetaReduction(ast, Ident("a", quat) -> CaseClass("CC", List(("foo", Ident("a'"))))) mustEqual
       Ident("a'")
   }
 

--- a/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
@@ -13,7 +13,7 @@ class ExpandReturningSpec extends Spec {
 
   case class Person(name: String, age: Int)
   case class Foo(bar: String, baz: Int)
-  val quat = Quat.Product("name" -> QV, "age" -> QV)
+  val quat = Quat.Product("TestQuat", "name" -> QV, "age" -> QV)
 
   "inner apply" - {
     val mi = MirrorIdiom

--- a/quill-core/src/test/scala/io/getquill/norm/QueryGenerator.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/QueryGenerator.scala
@@ -31,9 +31,9 @@ class QueryGenerator(seed: Int) {
 
   def apply(i: Int): Query = {
     if (i <= 2) {
-      val quat = Quat.Product()
+      val quat = Quat.Product("Test")
       val s = string(3)
-      Entity(s, Nil, Quat.Product((1 to 20).map(i => (string(3), Quat.Value)).toList.distinct: _*))
+      Entity(s, Nil, Quat.Product("Test", (1 to 20).map(i => (string(3), Quat.Value)).toList.distinct: _*))
     } else {
       random.nextInt(8) match {
         case 0 => map(i)

--- a/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -14,7 +14,7 @@ class QuatSpec extends Spec {
 
   "boolean and optional boolean" in {
     case class MyPerson(name: String, isHuman: Boolean, isRussian: Option[Boolean])
-    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "isHuman" -> Quat.BooleanValue, "isRussian" -> Quat.BooleanValue)
+    val MyPersonQuat = Quat.Product("MyPerson", "name" -> Quat.Value, "isHuman" -> Quat.BooleanValue, "isRussian" -> Quat.BooleanValue)
 
     quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
     makeQuat[MyPerson] mustEqual MyPersonQuat
@@ -22,7 +22,7 @@ class QuatSpec extends Spec {
 
   "should support standard case class" in {
     case class MyPerson(firstName: String, lastName: String, age: Int)
-    val MyPersonQuat = Quat.LeafProduct("firstName", "lastName", "age")
+    val MyPersonQuat = Quat.LeafProduct("MyPerson", "firstName", "lastName", "age")
 
     quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
     makeQuat[MyPerson] mustEqual MyPersonQuat
@@ -31,7 +31,7 @@ class QuatSpec extends Spec {
   "should support embedded" in {
     case class MyName(first: String, last: String)
     case class MyPerson(name: MyName, age: Int)
-    val MyPersonQuat = Quat.Product("name" -> Quat.LeafProduct("first", "last"), "age" -> Quat.Value)
+    val MyPersonQuat = Quat.Product("MyPerson", "name" -> Quat.LeafProduct("MyName", "first", "last"), "age" -> Quat.Value)
 
     quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
     makeQuat[MyPerson] mustEqual MyPersonQuat
@@ -39,7 +39,7 @@ class QuatSpec extends Spec {
 
   "should refine quats from generic infixes" - {
     case class MyPerson(name: String, age: Int)
-    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
+    val MyPersonQuat = Quat.Product("MyPerson", "name" -> Quat.Value, "age" -> Quat.Value)
 
     "propagating from transparent infixes in: extension methods" in {
       implicit class QueryOps[Q <: Query[_]](q: Q) {
@@ -88,14 +88,14 @@ class QuatSpec extends Spec {
     case class MyName(first: String, last: String)
     case class MyId(name: MyName, memberNum: Int)
     case class MyPerson(name: MyId, age: Int)
-    val MyPersonQuat = Quat.Product("name" -> Quat.Product("name" -> Quat.LeafProduct("first", "last"), "memberNum" -> Quat.Value), "age" -> Quat.Value)
+    val MyPersonQuat = Quat.Product("MyPerson", "name" -> Quat.Product("MyId", "name" -> Quat.LeafProduct("MyName", "first", "last"), "memberNum" -> Quat.Value), "age" -> Quat.Value)
 
     quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
   }
 
   "should support least upper types" - {
-    val AnimalQuat = Quat.LeafProduct("name")
-    val CatQuat = Quat.LeafProduct("name", "color")
+    val AnimalQuat = Quat.LeafProduct("AnimalQuat", "name")
+    val CatQuat = Quat.LeafProduct("Cat", "name", "color")
 
     "simple reduction" in {
       AnimalQuat.leastUpperType(CatQuat).get mustEqual AnimalQuat
@@ -115,9 +115,9 @@ class QuatSpec extends Spec {
   }
 
   "lookup" - {
-    val bar = Quat.Product("baz" -> Quat.Value)
-    val foo = Quat.Product("v" -> Quat.Value, "bar" -> bar)
-    val example = Quat.Product("v" -> Quat.Value, "foo" -> foo)
+    val bar = Quat.Product("bar", "baz" -> Quat.Value)
+    val foo = Quat.Product("foo", "v" -> Quat.Value, "bar" -> bar)
+    val example = Quat.Product("example", "v" -> Quat.Value, "foo" -> foo)
     "path" in {
       example.lookup("foo", false) mustEqual foo
       example.lookup(List("foo", "bar"), false) mustEqual bar
@@ -127,7 +127,7 @@ class QuatSpec extends Spec {
   }
 
   "probit" in {
-    val p: Quat = Quat.Product("foo" -> Quat.Value)
+    val p: Quat = Quat.Product("p", "foo" -> Quat.Value)
     val v: Quat = Quat.Value
     p.probit mustEqual p
     val e = intercept[QuatException] {
@@ -136,8 +136,8 @@ class QuatSpec extends Spec {
   }
 
   "rename" - {
-    val prod = Quat.Product("bv" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "p" -> Quat.Product("vv" -> Quat.Value, "pp" -> Quat.Product("ppp" -> Quat.Value)))
-    val expect = Quat.Product("bva" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "pa" -> Quat.Product("vv" -> Quat.Value, "pp" -> Quat.Product("ppp" -> Quat.Value)))
+    val prod = Quat.Product("prod", "bv" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "p" -> Quat.Product("innerProd", "vv" -> Quat.Value, "pp" -> Quat.Product("innerProd1", "ppp" -> Quat.Value)))
+    val expect = Quat.Product("expect", "bva" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "pa" -> Quat.Product("innerExpect", "vv" -> Quat.Value, "pp" -> Quat.Product("innerExpect1", "ppp" -> Quat.Value)))
     val value = Quat.Value
     "rename field" in {
       prod.withRenames(List("bv" -> "bva", "p" -> "pa")).applyRenames mustEqual expect
@@ -150,7 +150,7 @@ class QuatSpec extends Spec {
   "should serialize" - {
     // Need to import implicits from BooQuatSerializer otherwise c_jl_UnsupportedOperationException happens in JS
     import BooQuatSerializer._
-    val example = Quat.Product("bv" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "p" -> Quat.Product("vv" -> Quat.Value))
+    val example = Quat.Product("outer", "bv" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "p" -> Quat.Product("inner", "vv" -> Quat.Value))
     "with boo" in {
       Quat.fromSerialized(serialize(example)) mustEqual example
     }
@@ -195,7 +195,7 @@ class QuatSpec extends Spec {
       def func = quote {
         (q: Query[MyPerson]) => q.filter(p => p.name == "Joe")
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("MyPerson", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "case class with boundary" in {
       case class MyPerson(name: String, isRussian: Boolean)
@@ -277,28 +277,29 @@ class QuatSpec extends Spec {
       def func[T <: { def name: String; def isRussian: Boolean }] = quote {
         (q: T) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue).withType(Quat.Product.Type.Abstract)
+      // back here
+      func.ast.quat mustEqual Quat.Product("T", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue).withType(Quat.Product.Type.Abstract)
     }
     "structural with bool indirect" in {
       type Bool = Boolean
       def func[T <: { def name: String; def isRussian: Bool }] = quote {
         (q: T) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("T", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "case class" in {
       case class MyPerson(name: String, isRussian: Boolean)
       def func = quote {
         (q: MyPerson) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("MyPerson", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "case class with boundary" in {
       case class MyPerson(name: String, isRussian: Boolean)
       def func[T <: MyPerson] = quote {
         (q: T) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("MyPerson", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "interface" in {
       trait LikePerson { def name: String; def isRussian: Boolean }
@@ -312,7 +313,7 @@ class QuatSpec extends Spec {
       def func[T <: LikePerson] = quote {
         (q: T) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("LikePerson", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "interface with boundary boolean indirect" in {
       type Bool = Boolean
@@ -320,7 +321,7 @@ class QuatSpec extends Spec {
       def func[T <: LikePerson] = quote {
         (q: T) => q
       }
-      func.ast.quat mustEqual Quat.Product("name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
+      func.ast.quat mustEqual Quat.Product("LikePerson", "name" -> Quat.Value, "isRussian" -> Quat.BooleanValue)
     }
     "boundary with value" in {
       def func[T <: Int] = quote {

--- a/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -221,12 +221,12 @@ trait MirrorIdiomBase extends Idiom {
   }
 
   implicit val valueTokenizer: Tokenizer[Value] = Tokenizer[Value] {
-    case Constant(v: String, _) => stmt""""${v.token}""""
-    case Constant((), _)        => stmt"{}"
-    case Constant(v, _)         => stmt"${v.toString.token}"
-    case NullValue              => stmt"null"
-    case Tuple(values)          => stmt"(${values.token})"
-    case CaseClass(values)      => stmt"CaseClass(${values.map { case (k, v) => s"${k.token}: ${v.token}" }.mkString(", ").token})"
+    case Constant(v: String, _)  => stmt""""${v.token}""""
+    case Constant((), _)         => stmt"{}"
+    case Constant(v, _)          => stmt"${v.toString.token}"
+    case NullValue               => stmt"null"
+    case Tuple(values)           => stmt"(${values.token})"
+    case CaseClass(name, values) => stmt"${name.token}(${values.map { case (k, v) => s"${k.token}: ${v.token}" }.mkString(", ").token})"
   }
 
   implicit val identTokenizer: Tokenizer[Ident] = Tokenizer[Ident] {

--- a/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
@@ -610,16 +610,27 @@ case class Tuple(values: List[Ast]) extends Value {
   def bestQuat = bestComputedQuat
 }
 
-case class CaseClass(values: List[(String, Ast)]) extends Value {
-  private lazy val computedQuat = Quat.Product(values.map { case (k, v) => (k, v.quat) })
+case class CaseClass(name: String, values: List[(String, Ast)]) extends Value {
+  private lazy val computedQuat = Quat.Product(name, values.map { case (k, v) => (k, v.quat) })
   def quat = computedQuat
-  private lazy val bestComputedQuat = Quat.Product(values.map { case (k, v) => (k, v.bestQuat) })
+  private lazy val bestComputedQuat = Quat.Product(name, values.map { case (k, v) => (k, v.bestQuat) })
   def bestQuat = bestComputedQuat
+  private lazy val id = CaseClass.Id(values)
+
+  // Even thought name is not an "opinion" it still does not make sense to use it to compare CaseClass Asts
+  override def hashCode(): Int = CaseClass.Id(values).hashCode()
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case cc: CaseClass => this.id.equals(cc.id)
+      case _             => false
+    }
 }
 
 object CaseClass {
+  case class Id(values: List[(String, Ast)])
+  val GeneratedName = "<Generated>"
   object Single {
-    def apply(tup: (String, Ast)) = new CaseClass(List(tup))
+    def apply(tup: (String, Ast)) = new CaseClass(GeneratedName, List(tup))
     def unapply(cc: CaseClass): Option[(String, Ast)] =
       cc.values match {
         case (name, property) :: Nil => Some((name, property))

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -259,10 +259,10 @@ trait StatefulTransformer[T] {
       case Tuple(a) =>
         val (at, att) = apply(a)(_.apply)
         (Tuple(at), att)
-      case CaseClass(a) =>
+      case CaseClass(n, a) =>
         val (keys, values) = a.unzip
         val (at, att) = apply(values)(_.apply)
-        (CaseClass(keys.zip(at)), att)
+        (CaseClass(n, keys.zip(at)), att)
     }
 
   def apply(e: Action): (Action, StatefulTransformer[T]) =

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
@@ -275,10 +275,10 @@ trait StatefulTransformerWithStack[T] {
       case Tuple(a) =>
         val (at, att) = apply(a)(s => (u => s.apply(u)(History(e))))
         (Tuple(at), att)
-      case CaseClass(a) =>
+      case CaseClass(n, a) =>
         val (keys, values) = a.unzip
         val (at, att) = apply(values)(s => (u => s.apply(u)(History(e))))
-        (CaseClass(keys.zip(at)), att)
+        (CaseClass(n, keys.zip(at)), att)
     }
 
   def apply(e: Action)(implicit parent: History): (Action, StatefulTransformerWithStack[T]) =

--- a/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -122,9 +122,9 @@ trait StatelessTransformer {
       case e: Constant   => e
       case NullValue     => NullValue
       case Tuple(values) => Tuple(values.map(apply))
-      case CaseClass(tuples) => {
+      case CaseClass(n, tuples) => {
         val (keys, values) = tuples.unzip
-        CaseClass(keys.zip(values.map(apply)))
+        CaseClass(n, keys.zip(values.map(apply)))
       }
     }
 

--- a/quill-engine/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -136,7 +136,7 @@ trait CqlIdiom extends Idiom {
     case Constant((), _)        => stmt"1"
     case Constant(v, _)         => stmt"${v.toString.token}"
     case Tuple(values)          => stmt"${values.token}"
-    case CaseClass(values)      => stmt"${values.map(_._2).token}"
+    case CaseClass(_, values)   => stmt"${values.map(_._2).token}"
     case NullValue              => fail("Cql doesn't support null values.")
   }
 

--- a/quill-engine/src/main/scala/io/getquill/context/cassandra/CqlQuery.scala
+++ b/quill-engine/src/main/scala/io/getquill/context/cassandra/CqlQuery.scala
@@ -79,13 +79,13 @@ object CqlQuery {
 
   private def select(ast: Ast): List[Ast] =
     ast match {
-      case Tuple(values)     => values.flatMap(select)
-      case CaseClass(values) => values.flatMap(v => select(v._2))
-      case p: Property       => List(p)
-      case i: Ident          => List()
-      case l: Lift           => List(l)
-      case l: ScalarTag      => List(l)
-      case other             => fail(s"Cql supports only properties as select elements. Found: $other")
+      case Tuple(values)        => values.flatMap(select)
+      case CaseClass(_, values) => values.flatMap(v => select(v._2))
+      case p: Property          => List(p)
+      case i: Ident             => List()
+      case l: Lift              => List(l)
+      case l: ScalarTag         => List(l)
+      case other                => fail(s"Cql supports only properties as select elements. Found: $other")
     }
 
   private def orderByCriterias(ast: Ast, ordering: Ast): List[OrderByCriteria] =

--- a/quill-engine/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -70,7 +70,7 @@ case class BetaReduction(map: IMap[Ast, Ast], typeBehavior: TypeBehavior, emptyB
       case Property(Tuple(values), name) =>
         apply(values(name.drop(1).toInt - 1))
 
-      case Property(CaseClass(tuples), name) =>
+      case Property(CaseClass(_, tuples), name) =>
         apply(tuples.toMap.apply(name))
 
       case FunctionApply(Function(params, body), values) =>

--- a/quill-engine/src/main/scala/io/getquill/norm/ExpandReturning.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/ExpandReturning.scala
@@ -46,9 +46,9 @@ object ExpandReturning {
     // Tuple(List(ExternalIdent("name"), BinaryOperation(ExternalIdent("age"), +, Constant(1))))
     // => List(ExternalIdent("name"), BinaryOperation(ExternalIdent("age"), +, Constant(1)))
     val deTuplified = dePropertized match {
-      case Tuple(values)     => values
-      case CaseClass(values) => values.map(_._2)
-      case other             => List(other)
+      case Tuple(values)        => values
+      case CaseClass(_, values) => values.map(_._2)
+      case other                => List(other)
     }
 
     implicit val namingStrategy: NamingStrategy = naming

--- a/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -48,7 +48,7 @@ class RepropagateQuats(traceConfig: TraceConfig) extends StatelessTransformer {
           Product.Type.Concrete
       // Note, some extra renames from properties that don't exist could make it here.
       // Need to make sure to ignore extra ones when they are actually applied.
-      Quat.Product(newFields).withRenames(other.renames).withType(newTpe)
+      Quat.Product(q.name, newFields).withRenames(other.renames).withType(newTpe)
     }
   }
 

--- a/quill-engine/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
@@ -12,6 +12,7 @@ object BooQuatSerializer {
 
   implicit object productPickler extends Pickler[Quat.Product] {
     override def pickle(value: Quat.Product)(implicit state: PickleState): Unit = {
+      state.pickle(value.name)
       state.pickle(value.tpe)
       state.pickle(value.fields)
       state.pickle(value.renames)
@@ -19,6 +20,7 @@ object BooQuatSerializer {
     }
     override def unpickle(implicit state: UnpickleState): Quat.Product = {
       Quat.Product.WithRenames(
+        state.unpickle[String],
         state.unpickle[Quat.Product.Type],
         state.unpickle[LinkedHashMap[String, Quat]],
         state.unpickle[LinkedHashMap[String, String]]

--- a/quill-engine/src/main/scala/io/getquill/quat/FindBranches.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/FindBranches.scala
@@ -1,0 +1,176 @@
+package io.getquill.quat
+
+import io.getquill.quat.FindBranches.BranchQuat.PathElement
+import io.getquill.quat.FindBranches.Result
+import io.getquill.quat.FindBranches.Result.ProductWithBranches
+
+object VerifyNoBranches {
+  private implicit class DotsExt(list: List[String]) {
+    def dots = list.mkString(".")
+  }
+
+  private implicit class StringExt(str: String) {
+    def appendIfNotEmpty(value: String) =
+      str.trim match {
+        case ""    => ""
+        case other => other + value
+      }
+    def isNonEmpty = str.trim != ""
+  }
+
+  case class BranchFound(outerClass: Option[String], pathToInnerField: String, innerField: String, possibleInnerPaths: List[String])
+  object BranchFound {
+    def constructFrom(result: FindBranches.Result): List[BranchFound] = {
+      def recurse(result: FindBranches.Result, classesToHere: List[String]): List[BranchFound] =
+        result match {
+          case Result.SingleBranch(path, innermostField) =>
+            val pathToInnerField = classesToHere ++ path.map(_.fieldClassName)
+            val innerField = innermostField
+            // CCOuter(foo: CCFoo(bar: CCBar(baz: V))) is Branch(foo->CCFoo,bar->CCBar, baz)
+            val shiftedBranchPaths = {
+              val pathToHere = classesToHere.dots
+              // from foo->CCFoo,bar->CCBar
+              // take foo,bar
+              val shiftedFields = path.map(_.field)
+              // (CCFoo,CCBar).dropRight(1) =>
+              //   Then tack "CCOuter." to everything
+              //   Then prepend with "CCOuter" since that's the root-level class
+              //   So then we have List(CCOuter, "CCOuter." + CCFoo)
+              val fullPathClasses = pathToHere +: path.map(_.fieldClassName).dropRight(1).map(pathToHere.appendIfNotEmpty(".") + _)
+              // recompose into foo->CCOuter,bar->CCFoo
+              (shiftedFields zip fullPathClasses).collect {
+                // This should become List(CCOuter.foo, CCOuter.CCFoo.bar)
+                case (field, cls) if (field.isNonEmpty && cls.isNonEmpty) => cls + "." + field
+              }
+            }
+            List(BranchFound(classesToHere.headOption, pathToInnerField.dots, innerField, shiftedBranchPaths))
+          case ProductWithBranches(name, children) =>
+            children.flatMap(child => recurse(child, classesToHere :+ name))
+        }
+
+      val foundBranches = recurse(result, List())
+      // In some situations e.g. CCOuter(a: CCFoo(bar: CCBar(baz), b: CCFoo(bar: CCBar(baz)) we will have two messages:
+      // field 'baz' will be used instead of a in Outer.a
+      // and:
+      // field 'baz' will be used instead of a in Outer.b
+      // Should merge these together
+      foundBranches
+        .groupBy(b => (b.outerClass, b.innerField, b.pathToInnerField))
+        .map {
+          case ((outerClass, innerField, pathToInnerField), branches) =>
+            BranchFound(
+              outerClass,
+              pathToInnerField,
+              innerField,
+              branches.map(_.possibleInnerPaths).flatten
+            )
+        }
+        .toList
+    }
+  }
+
+  // TODO What about a a top-level branch, what's the text for that?
+  case class BranchFoundMessage(msg: String)
+  object BranchFoundMessage {
+    def makeFrom(found: BranchFound) = {
+      val link = "https://getquill.io/#extending-quill-custom-encoding"
+      // The field 'value' in Person.Name.First will be use in the query[Person] instead of Person.name or Person.Name.first.
+      // Are you sure this is the intended behavior? Perhaps you meant to write an encoder/decoder for Person.Name.First?
+      // See the section on Mapped Encodings in the quill documentation here: <> for the simplest way to do that.
+      val msg =
+        s"The field '${found.innerField}' in the object ${found.pathToInnerField} will be used in the query${found.outerClass.map(r => s"[$r]").getOrElse("")} " +
+          s"instead of the field ${found.possibleInnerPaths.mkString(" or ")}." +
+          s"\nAre you sure this is the intended behavior? " +
+          s"Perhaps you meant to write an encoder/decoder for ${found.pathToInnerField}?" +
+          s"\nSee the section on Mapped Encodings in the quill " +
+          s"documentation here: $link for the simplest way to do that."
+      BranchFoundMessage(msg)
+    }
+  }
+
+  case class Output(messages: List[BranchFoundMessage])
+  def in(quat: Quat) = {
+    val foundBranchResults = FindBranches.in(quat)
+    val foundBranches = foundBranchResults.map(BranchFound.constructFrom(_)).getOrElse(List())
+    Output(foundBranches.map(BranchFoundMessage.makeFrom(_)))
+  }
+}
+
+private[getquill] object FindBranches {
+
+  sealed trait Result
+  object Result {
+    case class SingleBranch private[quat] (path: List[PathElement], innermostField: String) extends Result
+    case class ProductWithBranches(name: String, children: List[Result]) extends Result
+  }
+
+  def in(quat: Quat) = recurseFind("root", quat)
+
+  private def recurseFind(currentPropName: String, quat: Quat): Option[Result] =
+    quat match {
+      // CCParent(foo:CCFoo(bar: CCBar(baz: Value), other:Value) - say we are in CCParent and recursing on `foo` which becomes:
+      // -> Result.SingleBranch(Branch(Path(root->CCFoo,bar->CCBar),baz)) - when we parse it, it became this
+      // -> Result.SingleBranch(Branch(Path(foo->CCFoo,bar->CCBar),baz)) - from the upper level we know the property name is foo, so swap that in
+      case BranchQuat(branch) => Some(Result.SingleBranch(branch.pathWithRootField(currentPropName), branch.innermostField))
+      // if it is not a product then it has to be a leaf at this point, return nothing
+      case _ if (!quat.isProduct) =>
+        None
+      // if it is a product, check if there are any branches or products-with-branches inside
+      case p: Quat.Product =>
+        val children =
+          p.fields.collect {
+            case (name, quat: Quat.Product) =>
+              recurseFind(name, quat)
+          }.toList.collect {
+            case Some(v) => v
+          }
+        Some(ProductWithBranches(p.name, children))
+    }
+
+  object BranchQuat {
+    def unapply(quat: Quat): Option[Branch] =
+      quat match {
+        // Need to match outermost one and know we're starting a branch for the recursion chain to work correctly
+        // (see the assumption inside)
+        case SingletonProduct(productName, (childField, childQuat)) =>
+          recurse(childField, childQuat, AccumPath.make(productName))
+        case _ =>
+          None
+      }
+
+    case class AccumPath private[quat] (first: RootElement, rest: List[PathElement]) {
+      def :+(elem: PathElement) = this.copy(rest = rest :+ elem)
+    }
+    object AccumPath {
+      def make(firstClassName: String) = new AccumPath(RootElement(firstClassName), List())
+    }
+    def recurse(thisField: String, thisQuat: Quat, path: AccumPath): Option[Branch] =
+      thisQuat match {
+        // If it's a singleton product it might be a branch all the way through
+        case SingletonProduct(productName, (childField, childQuat)) =>
+          recurse(childField, childQuat, path :+ PathElement(thisField, productName))
+        // If it's a product that's not singleton we know it's not a singleton branch
+        case _: Quat.Product => None
+        // (assuming we are already in a brach of at least 1-depth) if we ran into a Quat Value return the path to it
+        case _               => Some(Branch(path.first, path.rest, thisField))
+      }
+
+    object SingletonProduct {
+      def unapply(quat: Quat) =
+        quat match {
+          case p: Quat.Product if (p.fields.size == 1) => Some((p.name, p.fields.head))
+          case _                                       => None
+        }
+    }
+
+    case class RootElement(fieldClassName: String)
+    case class PathElement(field: String, fieldClassName: String)
+
+    case class Branch(first: RootElement, tailPath: List[PathElement], innermostField: String) {
+      // field name originally given to a branch will always be "root" but this allows a higher level mechanism to set it since
+      // the higher level mechanism should know the parent-product of the whole branch
+      def pathWithRootField(fieldName: String) =
+        PathElement(fieldName, first.fieldClassName) +: tailPath
+    }
+  }
+}

--- a/quill-engine/src/main/scala/io/getquill/quat/QuatNestingHelper.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/QuatNestingHelper.scala
@@ -5,9 +5,9 @@ import io.getquill.ast.{ Ast, Ident, Property }
 object QuatNestingHelper {
   def valueQuat(quat: Quat): Quat =
     quat match {
-      case Quat.BooleanExpression => Quat.BooleanValue
-      case Quat.Product(fields)   => Quat.Product(fields.toList.map { case (k, v) => (k, valueQuat(v)) })
-      case other                  => other
+      case Quat.BooleanExpression   => Quat.BooleanValue
+      case p @ Quat.Product(fields) => Quat.Product(p.name, fields.toList.map { case (k, v) => (k, valueQuat(v)) })
+      case other                    => other
     }
 
   def valuefyQuatInProperty(ast: Ast): Ast =

--- a/quill-engine/src/main/scala/io/getquill/quat/QuatOps.scala
+++ b/quill-engine/src/main/scala/io/getquill/quat/QuatOps.scala
@@ -36,7 +36,7 @@ private[getquill] object QuatOps {
           val newFields = quat.fields.map(kv => if (kv._1 == head) (kv._1, newSubQuat) else kv)
           // Re-create the quat with the new fields. Can't use copy since it would not copy the renames
           // along with the object.
-          Quat.Product.WithRenames(quat.tpe, newFields, quat.renames)
+          Quat.Product.WithRenames(quat.name, quat.tpe, newFields, quat.renames)
       }
 
     renameQuatAtPathRecurse(path, List(), rootQuat)

--- a/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
@@ -85,11 +85,11 @@ object TakeDropFlatten {
 object CaseClassMake {
   def fromQuat(quat: Quat)(idName: String) =
     quat match {
-      case Quat.Product(fields) =>
-        CaseClass(fields.toList.map { case (name, _) => (name, Property(Ident(idName, quat), name)) })
+      case p @ Quat.Product(fields) =>
+        CaseClass(p.name, fields.toList.map { case (name, _) => (name, Property(Ident(idName, quat), name)) })
       // Figure out a way to test this case?
       case _ =>
-        CaseClass(List((idName, Ident(idName, quat))))
+        CaseClass(CaseClass.GeneratedName, List((idName, Ident(idName, quat))))
     }
 }
 

--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -500,7 +500,7 @@ trait SqlIdiom extends Idiom {
     case Constant(v, _)         => stmt"${v.toString.token}"
     case NullValue              => stmt"null"
     case Tuple(values)          => stmt"${values.token}"
-    case CaseClass(values)      => stmt"${values.map(_._2).token}"
+    case CaseClass(_, values)   => stmt"${values.map(_._2).token}"
   }
 
   implicit def infixTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {

--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/VerifySqlQuery.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/VerifySqlQuery.scala
@@ -77,9 +77,9 @@ object VerifySqlQuery {
     // be skipped during verification.
     def expandSelect(sv: SelectValue): List[SelectValue] =
       sv.ast match {
-        case Tuple(values)     => values.map(v => SelectValue(v)).flatMap(expandSelect(_))
-        case CaseClass(values) => values.map(v => SelectValue(v._2)).flatMap(expandSelect(_))
-        case _                 => List(sv)
+        case Tuple(values)        => values.map(v => SelectValue(v)).flatMap(expandSelect(_))
+        case CaseClass(_, values) => values.map(v => SelectValue(v._2)).flatMap(expandSelect(_))
+        case _                    => List(sv)
       }
 
     val freeVariableErrors: List[Error] =

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandDistinct.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandDistinct.scala
@@ -38,11 +38,11 @@ class ExpandDistinct(traceConfig: TraceConfig) {
           //      query[SomeTable].map(st => AdHocCaseClass(st.id, st.name)).distinct
           //    }
           // ... need some special treatment. Otherwise their values will not be correctly expanded.
-          case Distinct(Map(q, x, cc @ CaseClass(values))) =>
+          case Distinct(Map(q, x, cc @ CaseClass(n, values))) =>
             val newIdent = Ident(x.name, valueQuat(cc.quat))
             trace"ExpandDistinct Distinct(Map(q, _, CaseClass))" andReturn
               Map(Distinct(Map(q, x, cc)), newIdent,
-                CaseClass(values.map {
+                CaseClass(n, values.map {
                   case (name, _) => (name, Property(newIdent, name))
                 }))
 

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
@@ -69,7 +69,7 @@ class ExpandSelection(from: List[FromContext]) {
             // Quat doesn't count anymore. If level=Inner then it's the same.
             apply(SelectValue(ast, concatOr(alias, label)(Some(label)), concat), level.withoutTopQuat)
         }
-      case SelectValue(CaseClass(fields), alias, concat) =>
+      case SelectValue(CaseClass(_, fields), alias, concat) =>
         fields.flatMap {
           case (name, ast) =>
             // Go into the select values, if the level is Top we need to go TopUnwrapped since the top-level

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/VendorizeBooleans.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/VendorizeBooleans.scala
@@ -12,8 +12,8 @@ object VendorizeBooleans extends StatelessTransformer {
       // Map clauses need values e.g. map(n=>n.status==true) => map(n=>if(n.status==true) 1 else 0)
       case Map(q, alias, body) =>
         Map(apply(q), alias, valuefyExpression(apply(body)))
-      case CaseClass(values) =>
-        CaseClass(values.map { case (name, value) => (name, valuefyExpression(apply(value))) })
+      case CaseClass(n, values) =>
+        CaseClass(n, values.map { case (name, value) => (name, valuefyExpression(apply(value))) })
       case Tuple(values) =>
         Tuple(values.map(value => valuefyExpression(apply(value))))
 

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/nested/FindUnexpressedInfixes.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/nested/FindUnexpressedInfixes.scala
@@ -57,7 +57,7 @@ class FindUnexpressedInfixes(select: List[OrderedSelect], traceConfig: TraceConf
                 case (ast, index) =>
                   findMissingInfixes(ast, parentOrder :+ index)
               }
-          case CaseClass(values) =>
+          case CaseClass(_, values) =>
             values.zipWithIndex
               .filter(v => containsInfix(v._1._2))
               .flatMap {

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -147,7 +147,7 @@ object Messages {
 
   val qprint = new AstPrinter(traceOpinions, traceAstSimple, Messages.traceQuats)
   def qprintCustom(traceOpinions: Boolean = false, traceAstSimple: Boolean = false, traceQuats: QuatTrace = QuatTrace.None) =
-    new AstPrinter(traceOpinions, traceAstSimple, Messages.traceQuats)
+    new AstPrinter(traceOpinions, traceAstSimple, traceQuats)
 
   def fail(msg: String) =
     throw new IllegalStateException(msg)

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -271,7 +271,7 @@ trait OrientDBIdiom extends Idiom {
     case Constant(v, _)         => stmt"${v.toString.token}"
     case NullValue              => stmt"null"
     case Tuple(values)          => stmt"${values.token}"
-    case CaseClass(values)      => stmt"${values.map(_._2).token}"
+    case CaseClass(_, values)   => stmt"${values.map(_._2).token}"
   }
 
   implicit def infixTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy, idiomContext: IdiomContext): Tokenizer[Infix] = Tokenizer[Infix] {

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
@@ -22,7 +22,7 @@ object TopLevelExpansion {
           case (ast, i) =>
             SelectValue(ast, Some(s"_${i + 1}"), concat)
         }
-      case SelectValue(CaseClass(fields), alias, concat) =>
+      case SelectValue(CaseClass(_, fields), alias, concat) =>
         fields.map {
           case (name, ast) =>
             SelectValue(ast, Some(name), concat)

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -138,7 +138,7 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
   override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
     case Constant(v: String, _) => stmt"'${v.replaceAll("""[\\']""", """\\$0""").token}'"
     case Tuple(values)          => stmt"struct(${values.zipWithIndex.map { case (value, index) => stmt"${value.token} AS _${(index + 1).toString.token}" }.token})"
-    case CaseClass(values)      => stmt"struct(${values.map { case (name, value) => stmt"${value.token} AS ${name.token}" }.token})"
+    case CaseClass(_, values)   => stmt"struct(${values.map { case (name, value) => stmt"${value.token} AS ${name.token}" }.token})"
     case other                  => super.valueTokenizer.token(other)
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandDistinctSpec.scala
@@ -31,7 +31,7 @@ class ExpandDistinctSpec extends Spec {
         qr1.map(e => Rec(e.i, e.l)).distinct.nested
       }
       ExpandDistinct(q.ast).toString mustEqual
-        """querySchema("TestEntity").map(e => CaseClass(one: e.i, two: e.l)).distinct.map(e => CaseClass(one: e.one, two: e.two)).nested"""
+        """querySchema("TestEntity").map(e => Rec(one: e.i, two: e.l)).distinct.map(e => Rec(one: e.one, two: e.two)).nested"""
     }
     "with tuple" in {
       val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatRunSpec.scala
@@ -10,7 +10,7 @@ class QuatRunSpec extends Spec {
 
   "should refine quats from generic infixes and express during execution" - {
     case class MyPerson(name: String, age: Int)
-    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "age" -> Quat.Value)
+    val MyPersonQuat = Quat.Product("MyPersonQuat", "name" -> Quat.Value, "age" -> Quat.Value)
 
     "from extension methods" in {
       implicit class QueryOps[Q <: Query[_]](q: Q) {


### PR DESCRIPTION
One significant problem occurs with auto-embedded changes introduced in https://github.com/zio/zio-quill/pull/2607
In cases where you have a single-value case class inside an entity it will become embedded so it is confusing why the column of the outer entity will be replaced when the inner one is missing an encoder. For example:

```scala
case class MyIdType(value: String)
case class Person(id: MyIdType, name: String)
run(query[Person])
// SELECT x.value /*instead of x.id*/, x.name FROM Person x,
```
Since MyIdType is being treated as an embedded entity, it is automatically embedded and it's `value` field is being used as the column instead of `id`. Once the encoder for MyIdType is written this problem will go away. Need to warn the user in cases where the embedded entity has one field that this is likely a column that needs to be embedded.