### PR TITLE
JDBC DataSource should not need to be closeable

### DIFF
--- a/quill-core/src/main/scala/io/getquill/JsonValue.scala
+++ b/quill-core/src/main/scala/io/getquill/JsonValue.scala
@@ -1,0 +1,4 @@
+package io.getquill
+
+final case class JsonValue[+T](value: T)
+final case class JsonbValue[+T](value: T)

--- a/quill-jdbc-zio/src/main/scala/io/getquill/JsonValue.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/JsonValue.scala
@@ -1,4 +1,0 @@
-package io.getquill
-
-final case class JsonValue[T](value: T) extends AnyVal
-final case class JsonbValue[T](value: T) extends AnyVal

--- a/quill-jdbc-zio/src/test/scala-2.12/io/getquill/postgres/PostgresJsonSpec.scala
+++ b/quill-jdbc-zio/src/test/scala-2.12/io/getquill/postgres/PostgresJsonSpec.scala
@@ -4,6 +4,7 @@ import io.getquill.{ JsonValue, JsonbValue, ZioSpec }
 import zio.Chunk
 import zio.json.ast.Json
 import zio.json.{ DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder }
+import scala.language.higherKinds
 
 class PostgresJsonSpec extends ZioSpec {
   val context = testContext
@@ -68,5 +69,9 @@ class PostgresJsonSpec extends ZioSpec {
       val inserted = testContext.run(jsonbAstQuery).runSyncUnsafe().head
       inserted mustEqual jsonbAstValue
     }
+  }
+
+  "unwrapping now allowed" in {
+    "testContext.run(query[JsonEntity].map(_.value.value)).runSyncUnsafe().head" mustNot compile
   }
 }

--- a/quill-jdbc-zio/src/test/scala-2.13/io/getquill/postgres/PostgresJsonSpec.scala
+++ b/quill-jdbc-zio/src/test/scala-2.13/io/getquill/postgres/PostgresJsonSpec.scala
@@ -4,6 +4,7 @@ import io.getquill.{ JsonValue, JsonbValue, ZioSpec }
 import zio.Chunk
 import zio.json.ast.Json
 import zio.json.{ DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder }
+import scala.language.higherKinds
 
 class PostgresJsonSpec extends ZioSpec {
   val context = testContext
@@ -68,5 +69,9 @@ class PostgresJsonSpec extends ZioSpec {
       val inserted = testContext.run(jsonbAstQuery).runSyncUnsafe().head
       inserted mustEqual jsonbAstValue
     }
+  }
+
+  "unwrapping now allowed" in {
+    "testContext.run(query[JsonEntity].map(_.value.value)).runSyncUnsafe().head" mustNot compile
   }
 }

--- a/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, H2JdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[H2Dialect, N]
   with H2JdbcContextBase[H2Dialect, N] {
   override val idiom: H2Dialect = H2Dialect

--- a/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, MysqlJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[MySQLDialect, N]
   with MysqlJdbcContextBase[MySQLDialect, N] {
   override val idiom: MySQLDialect = MySQLDialect

--- a/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
@@ -7,7 +7,7 @@ import io.getquill.context.jdbc.{ JdbcContext, OracleJdbcContextBase }
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[OracleDialect, N]
   with OracleJdbcContextBase[OracleDialect, N] {
   override val idiom: OracleDialect = OracleDialect

--- a/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, PostgresJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[PostgresDialect, N]
   with PostgresJdbcContextBase[PostgresDialect, N] {
   override val idiom: PostgresDialect = PostgresDialect

--- a/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqlServerJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[SQLServerDialect, N]
   with SqlServerJdbcContextBase[SQLServerDialect, N] {
   override val idiom: SQLServerDialect = SQLServerDialect

--- a/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqliteJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[SqliteDialect, N]
   with SqliteJdbcContextBase[SqliteDialect, N] {
   override val idiom: SqliteDialect = SqliteDialect

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -5,17 +5,20 @@ import java.sql.{ Connection, PreparedStatement }
 import javax.sql.DataSource
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
-import io.getquill.context.{ ExecutionInfo, ProtoContext, ContextVerbTranslate }
+import io.getquill.context.{ ContextVerbTranslate, ExecutionInfo, ProtoContext }
 
 import scala.util.{ DynamicVariable, Try }
 import scala.util.control.NonFatal
 import io.getquill.monad.SyncIOMonad
+import io.getquill.util.ContextLogger
 
 abstract class JdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   extends JdbcContextBase[Dialect, Naming]
   with ProtoContext[Dialect, Naming]
   with ContextVerbTranslate
   with SyncIOMonad {
+
+  private val logger = ContextLogger(classOf[JdbcContext[_, _]])
 
   // Need to override these with same values as JdbcRunContext because SyncIOMonad imports them. The imported values need to be overridden
   override type Result[T] = T
@@ -26,7 +29,7 @@ abstract class JdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   override type RunBatchActionResult = List[Long]
   override type RunBatchActionReturningResult[T] = List[T]
 
-  val dataSource: DataSource with Closeable
+  val dataSource: DataSource
   override def wrap[T](t: => T): T = t
   override def push[A, B](result: A)(f: A => B): B = f(result)
   override def seq[A](list: List[A]): List[A] = list
@@ -63,7 +66,11 @@ abstract class JdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
       finally conn.close()
     }
 
-  def close() = dataSource.close()
+  override def close() =
+    dataSource match {
+      case closeable: java.io.Closeable => closeable.close()
+      case _ => logger.underlying.warn(s"Could not close the DataSource `$dataSource`. It is not an instance of java.io.Closeable.")
+    }
 
   def probe(sql: String) =
     Try {


### PR DESCRIPTION
JDBC DataSource should not need to be closeable. Can check if it is and close if possible. Otherwise warn that it isn't.