### PR TITLE
Option or else

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -942,8 +942,8 @@ lazy val basicSettings = excludeFilterSettings ++ Seq(
     "-unchecked",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
-
+    "-Ywarn-value-discard",
+    "-Ypatmat-exhaust-depth", "40"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -52,6 +52,7 @@ trait Liftables extends QuatLiftable {
     case OptionTableForall(a, b, c)  => q"$pack.OptionTableForall($a,$b,$c)"
     case OptionFlatten(a)            => q"$pack.OptionFlatten($a)"
     case OptionGetOrElse(a, b)       => q"$pack.OptionGetOrElse($a,$b)"
+    case OptionOrElse(a, b)          => q"$pack.OptionOrElse($a,$b)"
     case OptionFlatMap(a, b, c)      => q"$pack.OptionFlatMap($a,$b,$c)"
     case OptionMap(a, b, c)          => q"$pack.OptionMap($a,$b,$c)"
     case OptionForall(a, b, c)       => q"$pack.OptionForall($a,$b,$c)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -2,7 +2,6 @@ package io.getquill.quotation
 
 import scala.reflect.ClassTag
 import io.getquill.ast._
-import io.getquill.Embedded
 import io.getquill.context._
 import io.getquill.norm.{ BetaReduction, TypeBehavior }
 import io.getquill.util.MacroContextExt.RichContext
@@ -14,7 +13,7 @@ import scala.collection.immutable.StringOps
 import scala.reflect.macros.TypecheckException
 import io.getquill.ast.Implicits._
 import io.getquill.ast.Renameable.Fixed
-import io.getquill.ast.Visibility.{ Hidden, Visible }
+import io.getquill.ast.Visibility.Visible
 import io.getquill.quat._
 import io.getquill.util.Messages.TraceType
 import io.getquill.util.{ Interleave, Interpolator, Messages }
@@ -556,6 +555,8 @@ trait Parsing extends ValueComputation with QuatMaking with MacroUtilBase {
       OptionFlatten(astParser(o))
     case q"$o.getOrElse[$t]($body)" if is[Option[Any]](o) =>
       OptionGetOrElse(astParser(o), astParser(body))
+    case q"$o.orElse[$t]($body)" if is[Option[Any]](o) =>
+      OptionOrElse(astParser(o), astParser(body))
     case q"$o.contains[$t]($body)" if is[Option[Any]](o) =>
       OptionContains(astParser(o), astParser(body))
     case q"$o.isEmpty" if is[Option[Any]](o) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -43,6 +43,7 @@ trait Unliftables extends QuatUnliftable {
     case q"$pack.OptionTableForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => OptionTableForall(a, b, c)
     case q"$pack.OptionFlatten.apply(${ a: Ast })"                                  => OptionFlatten(a)
     case q"$pack.OptionGetOrElse.apply(${ a: Ast }, ${ b: Ast })"                   => OptionGetOrElse(a, b)
+    case q"$pack.OptionOrElse.apply(${ a: Ast }, ${ b: Ast })"                      => OptionOrElse(a, b)
     case q"$pack.OptionFlatMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"      => OptionFlatMap(a, b, c)
     case q"$pack.OptionMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"          => OptionMap(a, b, c)
     case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"       => OptionForall(a, b, c)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -415,6 +415,14 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("b"))
         }
       }
+      "orElse" in {
+        val ast: Ast = OptionOrElse(Ident("a"), Ident("b"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionOrElse(Ident("a'"), Ident("b'"))
+            att.state mustEqual List(Ident("a"), Ident("b"))
+        }
+      }
       "flatMap - Unchecked" in {
         val ast: Ast = OptionTableFlatMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -267,6 +267,11 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
           OptionGetOrElse(Ident("a'"), Ident("b'"))
       }
+      "orElse" in {
+        val ast: Ast = OptionOrElse(Ident("a"), Ident("b"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
+          OptionOrElse(Ident("a'"), Ident("b'"))
+      }
       "flatMap - Unchecked" in {
         val ast: Ast = OptionTableFlatMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual

--- a/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
@@ -520,6 +520,13 @@ class MirrorIdiomSpec extends Spec {
       stmt"${(q.ast: Ast).token}" mustEqual
         stmt"(o) => o.getOrElse(1)"
     }
+    "orElse" in {
+      val q = quote {
+        (o: Option[Int]) => o.orElse(Option(1))
+      }
+      stmt"${(q.ast: Ast).token}" mustEqual
+        stmt"(o) => o.orElse(Option(1))"
+    }
     "flatten" in {
       val q = quote {
         (o: Option[Option[Int]]) => o.flatten

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -8,7 +8,7 @@ import io.getquill.MoreAstOps._
 import io.getquill.base.Spec
 import io.getquill.util.TraceConfig
 
-class FlattenOptionOperationSpec extends Spec { //hello
+class FlattenOptionOperationSpec extends Spec {
 
   def o = Ident("o")
   def c1 = Constant.auto(1)
@@ -32,22 +32,22 @@ class FlattenOptionOperationSpec extends Spec { //hello
         val q = quote {
           (o: Option[Int]) => o.orElse(Option(1))
         }
-        new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
           IfExist(o, o, c1)
       }
       "with forall" in {
         val q = quote {
           (o: Option[Int]) => o.orElse(Option(1)).forall(_ == 2)
         }
-        new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
           ((o +==+ c2) +||+ (IsNullCheck(o) +&&+ (c1 +==+ c2))
             +||+ (IsNullCheck(o) +&&+ IsNullCheck(c1)))
       }
       "with exists" in {
         val q = quote {
-          (o: Option[Int]) => o.orElse(Option(1)).contains(2)
+          (o: Option[Int]) => o.orElse(Option(1)).exists(_ == 2)
         }
-        new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
           ((o +==+ c2 +&&+ IsNotNullCheck(o)) +||+ (c1 +==+ c2 +&&+ IsNotNullCheck(c1)))
       }
     }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1306,6 +1306,12 @@ class QuotationSpec extends Spec {
             Constant.auto(true)
           )
       }
+      "orElse" in {
+        val q = quote {
+          (o: Option[Int]) => o.orElse(Option(11))
+        }
+        quote(unquote(q)).ast.body mustEqual OptionOrElse(Ident("o"), OptionApply(Constant.auto(11)))
+      }
       "flatten" in {
         val q = quote {
           (o: Option[Option[Int]]) => o.flatten

--- a/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -156,6 +156,7 @@ trait MirrorIdiomBase extends Idiom {
     case OptionTableForall(ast, alias, body)  => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
     case OptionFlatten(ast)                   => stmt"${ast.token}.flatten"
     case OptionGetOrElse(ast, body)           => stmt"${ast.token}.getOrElse(${body.token})"
+    case OptionOrElse(ast, body)              => stmt"${ast.token}.orElse(${body.token})"
     case OptionFlatMap(ast, alias, body)      => stmt"${ast.token}.flatMap((${alias.token}) => ${body.token})"
     case OptionMap(ast, alias, body)          => stmt"${ast.token}.map((${alias.token}) => ${body.token})"
     case OptionForall(ast, alias, body)       => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"

--- a/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
@@ -488,6 +488,7 @@ object Property {
 sealed trait OptionOperation extends Ast
 case class OptionFlatten(ast: Ast) extends OptionOperation { def quat = ast.quat; def bestQuat = ast.bestQuat }
 case class OptionGetOrElse(ast: Ast, body: Ast) extends OptionOperation { def quat = body.quat; def bestQuat = body.bestQuat }
+case class OptionOrElse(ast: Ast, body: Ast) extends OptionOperation { def quat = body.quat; def bestQuat = body.bestQuat }
 case class OptionFlatMap(ast: Ast, alias: Ident, body: Ast)
   extends OptionOperation { def quat = body.quat; def bestQuat = body.bestQuat }
 case class OptionMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation { def quat = body.quat; def bestQuat = body.bestQuat }

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -78,6 +78,10 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
         (OptionGetOrElse(at, ct), ctt)
+      case OptionOrElse(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (OptionOrElse(at, ct), ctt)
       case OptionFlatMap(a, b, c) =>
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
@@ -94,6 +94,10 @@ trait StatefulTransformerWithStack[T] {
         val (at, att) = apply(a)(History(o))
         val (ct, ctt) = att.apply(c)(History(o))
         (OptionGetOrElse(at, ct), ctt)
+      case OptionOrElse(a, c) =>
+        val (at, att) = apply(a)(History(o))
+        val (ct, ctt) = att.apply(c)(History(o))
+        (OptionOrElse(at, ct), ctt)
       case OptionFlatMap(a, b, c) =>
         val (at, att) = apply(a)(History(o))
         val (ct, ctt) = att.apply(c)(History(o))

--- a/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -48,6 +48,7 @@ trait StatelessTransformer {
       case OptionTableForall(a, b, c)  => OptionTableForall(apply(a), applyIdent(b), apply(c))
       case OptionFlatten(a)            => OptionFlatten(apply(a))
       case OptionGetOrElse(a, b)       => OptionGetOrElse(apply(a), apply(b))
+      case OptionOrElse(a, b)          => OptionOrElse(apply(a), apply(b))
       case OptionFlatMap(a, b, c)      => OptionFlatMap(apply(a), applyIdent(b), apply(c))
       case OptionMap(a, b, c)          => OptionMap(apply(a), applyIdent(b), apply(c))
       case OptionForall(a, b, c)       => OptionForall(apply(a), applyIdent(b), apply(c))

--- a/quill-engine/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -88,14 +88,30 @@ class FlattenOptionOperation(concatBehavior: ConcatBehavior, traceConfig: TraceC
       case OptionGetOrElse(ast, body) =>
         apply(If(IsNotNullCheck(ast), ast, body))
 
+      case OptionOrElse(ast, body) =>
+        apply(If(IsNotNullCheck(ast), ast, body))
+
       case OptionFlatMap(ast, alias, body) =>
         uncheckedReduction(ast, alias, body, containsNonFallthroughElement)
 
       case OptionMap(ast, alias, body) =>
         uncheckedReduction(ast, alias, body, containsNonFallthroughElement)
 
+      case OptionForall(OptionOrElse(a, b), alias, body) =>
+        val reducedA = BetaReduction(body, alias -> a)
+        val reducedB = BetaReduction(body, alias -> b)
+        val isNullA = IsNullCheck(a)
+        val isNullB = IsNullCheck(b)
+
+        apply(reducedA) +||+ apply((isNullA +&&+ reducedB): Ast) +||+ apply((isNullA +&&+ isNullB): Ast)
+
       case OptionForall(ast, alias, body) =>
         uncheckedForall(ast, alias, body, containsNonFallthroughElement)
+
+      case OptionExists(OptionOrElse(a, b), alias, body) =>
+        val reducedA = BetaReduction(body, alias -> a)
+        val reducedB = BetaReduction(body, alias -> b)
+        apply((reducedA +&&+ IsNotNullCheck(a)): Ast) +||+ apply((reducedB +&&+ IsNotNullCheck(b)): Ast)
 
       case OptionExists(ast, alias, body) =>
         validateContainsOrElse(

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -30,8 +32,20 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -48,5 +62,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -30,8 +32,20 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -48,5 +62,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -26,8 +28,24 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with GetOrElse`) should contain theSameElementsAs `Simple Map with GetOrElse Result`
   }
 
+  "Example 1.2 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -44,5 +62,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -30,8 +32,20 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -48,5 +62,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -30,8 +32,20 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -44,5 +58,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 5 - Map+getOrElse Join" in {
     testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -41,8 +43,20 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(`Simple Map with Condition and OrElse`) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -59,5 +73,13 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(`Filter with OrElse and Forall`) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(`Filter with OrElse and Exists`) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }


### PR DESCRIPTION
Fixes #1691

### Problem

Quill does not support `Option.orElse`

### Solution

Support `if columnA.orElse(columnB).forall(_ == value)` syntax

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
