### PR TITLE
Fix CI: Revert Changes From Scala Steward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.3]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.2]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -35,20 +35,20 @@ jobs:
          - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.1.3
+         - scala: 3.1.2
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
          # For now, only do the `base` build for Scala 3
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: db
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: js
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: async
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: codegen
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: bigdata
          # For other modules, `base` build is already included
          - scala: 2.11.12
@@ -92,7 +92,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.3]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.2]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -104,19 +104,19 @@ jobs:
          - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.1.3
+         - scala: 3.1.2
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: db
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: js
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: async
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: codegen
-         - scala: 3.1.3
+         - scala: 3.1.2
            module: bigdata
          # Do not release 2.11 Scala JS anymore since various modules such as scala-collection-compat are missing for it
          - scala: 2.11.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.0]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.2.0]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -32,7 +32,7 @@ jobs:
          - scala: 2.12.10
            scala_short: 212
            scala_short_dot: 2.12
-         - scala: 2.13.10
+         - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
          - scala: 3.2.0
@@ -55,7 +55,7 @@ jobs:
            module: base
          - scala: 2.12.10
            module: base
-         - scala: 2.13.10
+         - scala: 2.13.2
            module: base
          # Do not build 2.11 Scala JS anymore since various modules such as scala-collection-compat are missing for it
          - scala: 2.11.12
@@ -92,7 +92,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.0]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.2.0]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -101,7 +101,7 @@ jobs:
          - scala: 2.12.10
            scala_short: 212
            scala_short_dot: 2.12
-         - scala: 2.13.10
+         - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
          - scala: 3.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.2, 3.2.0]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.3]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -35,20 +35,20 @@ jobs:
          - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.2.0
+         - scala: 3.1.3
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
          # For now, only do the `base` build for Scala 3
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: db
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: js
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: async
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: codegen
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: bigdata
          # For other modules, `base` build is already included
          - scala: 2.11.12
@@ -92,7 +92,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.2, 3.2.0]
+       scala: [2.11.12, 2.12.10, 2.13.2, 3.1.3]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -104,19 +104,19 @@ jobs:
          - scala: 2.13.2
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.2.0
+         - scala: 3.1.3
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: db
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: js
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: async
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: codegen
-         - scala: 3.2.0
+         - scala: 3.1.3
            module: bigdata
          # Do not release 2.11 Scala JS anymore since various modules such as scala-collection-compat are missing for it
          - scala: 2.11.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.1]
+       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.0]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -35,20 +35,20 @@ jobs:
          - scala: 2.13.10
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.2.1
+         - scala: 3.2.0
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
          # For now, only do the `base` build for Scala 3
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: db
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: js
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: async
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: codegen
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: bigdata
          # For other modules, `base` build is already included
          - scala: 2.11.12
@@ -92,7 +92,7 @@ jobs:
 
    strategy:
      matrix:
-       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.1]
+       scala: [2.11.12, 2.12.10, 2.13.10, 3.2.0]
        module: [base, db, js, async, codegen, bigdata]
        include:
          - scala: 2.11.12
@@ -104,19 +104,19 @@ jobs:
          - scala: 2.13.10
            scala_short: 213
            scala_short_dot: 2.13
-         - scala: 3.2.1
+         - scala: 3.2.0
            scala_short: 30
            scala_short_dot: 3.0
        exclude:
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: db
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: js
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: async
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: codegen
-         - scala: 3.2.1
+         - scala: 3.2.0
            module: bigdata
          # Do not release 2.11 Scala JS anymore since various modules such as scala-collection-compat are missing for it
          - scala: 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -779,11 +779,11 @@ lazy val jdbcTestingLibraries = Seq(
     "com.zaxxer"              %  "HikariCP"                % "3.4.5",
     "mysql"                   %  "mysql-connector-java"    % "8.0.30"             % Test,
     "com.h2database"          %  "h2"                      % "2.1.212"            % Test,
-    "org.postgresql"          %  "postgresql"              % "42.5.0"             % Test,
-    "org.xerial"              %  "sqlite-jdbc"             % "3.39.3.0"           % Test,
-    "com.microsoft.sqlserver" %  "mssql-jdbc"              % "7.2.2.jre8"         % Test,
+    "org.postgresql"          %  "postgresql"              % "42.3.6"             % Test,
+    "org.xerial"              %  "sqlite-jdbc"             % "3.39.3.0"             % Test,
+    "com.microsoft.sqlserver" %  "mssql-jdbc"              % "7.2.2.jre8"        % Test,
     "com.oracle.ojdbc"        %  "ojdbc8"                  % "19.3.0.0"           % Test,
-    "org.mockito"             %% "mockito-scala-scalatest" % "1.16.46"            % Test
+    "org.mockito"             %% "mockito-scala-scalatest" % "1.16.46"              % Test
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -749,7 +749,7 @@ lazy val `quill-orientdb` =
         Test / fork := true,
         libraryDependencies ++= Seq(
           // For some reason OrientDB 3.0.42 does not stay up once started during local testing so need to bump to 3.2.6
-          "com.orientechnologies" % "orientdb-graphdb" % "3.2.12"
+          "com.orientechnologies" % "orientdb-graphdb" % "3.2.11"
         )
       )
       .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -576,7 +576,7 @@ lazy val `quill-jasync` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-common" % "2.1.7",
+        "com.github.jasync-sql" % "jasync-common" % "2.0.8",
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
       )
     )
@@ -590,7 +590,7 @@ lazy val `quill-jasync-postgres` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-postgresql" % "2.1.7"
+        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync` % "compile->compile;test->test")
@@ -603,7 +603,7 @@ lazy val `quill-jasync-mysql` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-mysql" % "2.1.7"
+        "com.github.jasync-sql" % "jasync-mysql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync` % "compile->compile;test->test")
@@ -616,7 +616,7 @@ lazy val `quill-jasync-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-common" % "2.1.7",
+        "com.github.jasync-sql" % "jasync-common" % "2.0.8",
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
         "dev.zio" %% "zio" % Version.zio,
         "dev.zio" %% "zio-streams" % Version.zio
@@ -633,7 +633,7 @@ lazy val `quill-jasync-zio-postgres` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-postgresql" % "2.1.7"
+        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.8"
       )
     )
     .dependsOn(`quill-jasync-zio` % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ lazy val `quill-core` =
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.2",
-      "dev.zio"                    %% "zio-logging"   % "2.1.4",
+      "dev.zio"                    %% "zio-logging"   % "2.1.3",
       "dev.zio"                    %% "zio"           % Version.zio,
       "dev.zio"                    %% "zio-streams"   % Version.zio,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/build.sbt
+++ b/build.sbt
@@ -749,7 +749,7 @@ lazy val `quill-orientdb` =
         Test / fork := true,
         libraryDependencies ++= Seq(
           // For some reason OrientDB 3.0.42 does not stay up once started during local testing so need to bump to 3.2.6
-          "com.orientechnologies" % "orientdb-graphdb" % "3.2.11"
+          "com.orientechnologies" % "orientdb-graphdb" % "3.2.10"
         )
       )
       .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ lazy val `quill-core` =
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.2",
-      "dev.zio"                    %% "zio-logging"   % "2.1.2",
+      "dev.zio"                    %% "zio-logging"   % "2.0.1",
       "dev.zio"                    %% "zio"           % Version.zio,
       "dev.zio"                    %% "zio-streams"   % Version.zio,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/build.sbt
+++ b/build.sbt
@@ -847,7 +847,7 @@ def excludePaths(paths:Seq[String]) = {
 val scala_v_11 = "2.11.12"
 val scala_v_12 = "2.12.10"
 val scala_v_13 = "2.13.2"
-val scala_v_30 = "3.1.3"
+val scala_v_30 = "3.1.2"
 
 lazy val loggingSettings = Seq(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -777,7 +777,7 @@ commands += Command.command("checkUnformattedFiles") { st =>
 lazy val jdbcTestingLibraries = Seq(
   libraryDependencies ++= Seq(
     "com.zaxxer"              %  "HikariCP"                % "3.4.5",
-    "mysql"                   %  "mysql-connector-java"    % "8.0.30"             % Test,
+    "mysql"                   %  "mysql-connector-java"    % "8.0.29"             % Test,
     "com.h2database"          %  "h2"                      % "2.1.212"            % Test,
     "org.postgresql"          %  "postgresql"              % "42.3.6"             % Test,
     "org.xerial"              %  "sqlite-jdbc"             % "3.39.3.0"             % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -847,7 +847,7 @@ def excludePaths(paths:Seq[String]) = {
 val scala_v_11 = "2.11.12"
 val scala_v_12 = "2.12.10"
 val scala_v_13 = "2.13.10"
-val scala_v_30 = "3.2.1"
+val scala_v_30 = "3.2.0"
 
 lazy val loggingSettings = Seq(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ lazy val `quill-core` =
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.2",
-      "dev.zio"                    %% "zio-logging"   % "2.1.3",
+      "dev.zio"                    %% "zio-logging"   % "2.1.2",
       "dev.zio"                    %% "zio"           % Version.zio,
       "dev.zio"                    %% "zio-streams"   % Version.zio,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/build.sbt
+++ b/build.sbt
@@ -674,7 +674,7 @@ lazy val `quill-cassandra` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.datastax.oss" % "java-driver-core" % "4.15.0",
+        "com.datastax.oss" % "java-driver-core" % "4.14.1",
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -847,7 +847,7 @@ def excludePaths(paths:Seq[String]) = {
 val scala_v_11 = "2.11.12"
 val scala_v_12 = "2.12.10"
 val scala_v_13 = "2.13.2"
-val scala_v_30 = "3.2.0"
+val scala_v_30 = "3.1.3"
 
 lazy val loggingSettings = Seq(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -778,7 +778,7 @@ lazy val jdbcTestingLibraries = Seq(
   libraryDependencies ++= Seq(
     "com.zaxxer"              %  "HikariCP"                % "3.4.5",
     "mysql"                   %  "mysql-connector-java"    % "8.0.30"             % Test,
-    "com.h2database"          %  "h2"                      % "2.1.214"            % Test,
+    "com.h2database"          %  "h2"                      % "2.1.212"            % Test,
     "org.postgresql"          %  "postgresql"              % "42.5.0"             % Test,
     "org.xerial"              %  "sqlite-jdbc"             % "3.39.3.0"           % Test,
     "com.microsoft.sqlserver" %  "mssql-jdbc"              % "7.2.2.jre8"         % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -846,7 +846,7 @@ def excludePaths(paths:Seq[String]) = {
 
 val scala_v_11 = "2.11.12"
 val scala_v_12 = "2.12.10"
-val scala_v_13 = "2.13.10"
+val scala_v_13 = "2.13.2"
 val scala_v_30 = "3.2.0"
 
 lazy val loggingSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ lazy val `quill-core` =
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.2",
-      "dev.zio"                    %% "zio-logging"   % "2.0.1",
+      "dev.zio"                    %% "zio-logging"   % "2.0.0",
       "dev.zio"                    %% "zio"           % Version.zio,
       "dev.zio"                    %% "zio-streams"   % Version.zio,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/build.sbt
+++ b/build.sbt
@@ -872,7 +872,7 @@ lazy val basicSettings = excludeFilterSettings ++ Seq(
     )
     else Seq()
   } ++ {
-    Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1")
+    Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0")
   },
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(AlignParameters, true)

--- a/build.sbt
+++ b/build.sbt
@@ -780,7 +780,7 @@ lazy val jdbcTestingLibraries = Seq(
     "mysql"                   %  "mysql-connector-java"    % "8.0.30"             % Test,
     "com.h2database"          %  "h2"                      % "2.1.214"            % Test,
     "org.postgresql"          %  "postgresql"              % "42.5.0"             % Test,
-    "org.xerial"              %  "sqlite-jdbc"             % "3.39.4.0"           % Test,
+    "org.xerial"              %  "sqlite-jdbc"             % "3.39.3.0"           % Test,
     "com.microsoft.sqlserver" %  "mssql-jdbc"              % "7.2.2.jre8"         % Test,
     "com.oracle.ojdbc"        %  "ojdbc8"                  % "19.3.0.0"           % Test,
     "org.mockito"             %% "mockito-scala-scalatest" % "1.16.46"            % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object Version {
-  val zio = "2.0.3"
+  val zio = "2.0.2"
 }
 
 sealed trait ExcludeTests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object Version {
-  val zio = "2.0.2"
+  val zio = "2.0.0"
 }
 
 sealed trait ExcludeTests

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.7.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.7.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.14")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 


### PR DESCRIPTION
Starting from October 8, we have had constant failures on CI. While from that time, most PRs are from @scala-steward, I reverted all those changes.

After having a healthy up-and-running CI, we can apply those changes again but with more caution.

![image](https://user-images.githubusercontent.com/235974/202831096-2a41ff9c-37b6-4081-88f0-66314f637928.png)


@getquill/maintainers
