### PR TITLE
update zio-logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,7 +313,7 @@ lazy val `quill-core` =
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.2",
-      "dev.zio"                    %% "zio-logging"   % "2.0.0",
+      "dev.zio"                    %% "zio-logging"   % "2.1.10",
       "dev.zio"                    %% "zio"           % Version.zio,
       "dev.zio"                    %% "zio-streams"   % Version.zio,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/quill-core/src/main/scala/io/getquill/util/QueryLogger.scala
+++ b/quill-core/src/main/scala/io/getquill/util/QueryLogger.scala
@@ -13,10 +13,11 @@ class QueryLogger(logToFile: LogToFile) {
   val runtime =
     Unsafe.unsafe { implicit u =>
       logToFile match {
-        case LogToFile.Enabled(logFile) => Some(Runtime.unsafe.fromLayer(file(
+        case LogToFile.Enabled(logFile) => Some(Runtime.unsafe.fromLayer(fileLogger(FileLoggerConfig(
+          destination = Paths.get(logFile),
           format = LogFormat.line,
-          destination = Paths.get(logFile)
-        )))
+          filter = LogFilter.logLevel(LogLevel.Info)
+        ))))
         case LogToFile.Disabled => None
       }
     }


### PR DESCRIPTION
### Problem

In our project we can't upgrade to zio-logging `2.1.12` because the method `file` has been removed

### Solution

Update to zio-logging 2.1.10 and use fileLogger

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
