### PR TITLE
Fix node12 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
    name: Build ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
    steps:
-   - uses: actions/checkout@v2
+   - uses: actions/checkout@v3
    - name: Cache sbt
      uses: actions/cache@v2
      with:
@@ -115,7 +115,7 @@ jobs:
    name: Release ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
    steps:
-   - uses: actions/checkout@v2
+   - uses: actions/checkout@v3
    - name: Cache sbt
      uses: actions/cache@v2
      with:
@@ -165,7 +165,7 @@ jobs:
     name: Publish ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache sbt
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
    steps:
    - uses: actions/checkout@v3
    - name: Cache sbt
-     uses: actions/cache@v2
+     uses: actions/cache@v3
      with:
        path: |
          ~/.cache/coursier
@@ -117,7 +117,7 @@ jobs:
    steps:
    - uses: actions/checkout@v3
    - name: Cache sbt
-     uses: actions/cache@v2
+     uses: actions/cache@v3
      with:
        path: |
          ~/.cache/coursier
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/coursier


### PR DESCRIPTION
Fixes #issue_number

### Problem

> [Build 2.13 - codegen](https://github.com/check-spelling/zio-quill/actions/runs/5170247147/jobs/9313036811)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

### Solution

Bump 

### Notes

Had renovate been active (#2351), it would have made this PR.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
