### PR TITLE
Update Dockerfile-setup

### DIFF
--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -1,10 +1,12 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER gustavo.amigo@gmail.com
+
+ARG CASSANDRA_URL_BASE=https://archive.apache.org/dist/cassandra/
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    mysql-client \
+    mariadb-client \
     netcat \
     postgresql-client \
     python \
@@ -18,33 +20,26 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 ADD https://repo1.maven.org/maven2/sqlline/sqlline/1.12.0/sqlline-1.12.0-jar-with-dependencies.jar /sqlline/sqlline.jar
 ADD https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar /sqlline/ojdbc.jar
 
-# RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-# RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-# RUN apt-get update && \
-# ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
+RUN curl https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc && \
+    curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools
 
-
-# Needed to get the apt-key add - to work
-RUN apt-get update && apt-get install -my wget gnupg
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
-RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list
-RUN apt update
-RUN ACCEPT_EULA=Y apt-get install -y mssql-tools
+ENV PATH $PATH:/opt/mssql-tools/bin
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.13
-ENV CASSANDRA_URL https://downloads.apache.org/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz
+ENV CASSANDRA_VERSION 3.11.15
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"
-RUN echo "Getting $CASSANDRA_URL"
+
+RUN echo "Getting $CASSANDRA_URL_BASE/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 
 RUN  cd /opt ; \
-     curl "$CASSANDRA_URL" | tar zx
+     curl "${CASSANDRA_URL_BASE}/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz" | tar zx
 
 ENV PATH /opt/apache-cassandra-$CASSANDRA_VERSION/bin:$PATH
 

--- a/build/m1/Dockerfile-setup
+++ b/build/m1/Dockerfile-setup
@@ -1,10 +1,12 @@
-FROM --platform=linux/amd64 debian:jessie
+FROM --platform=linux/amd64 debian:bullseye
 MAINTAINER gustavo.amigo@gmail.com
 
-RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+ARG CASSANDRA_URL_BASE=https://archive.apache.org/dist/cassandra/
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    mysql-client \
+    mariadb-client \
     netcat \
     postgresql-client \
     python \
@@ -13,10 +15,10 @@ RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-insta
     apt-transport-https \
     locales
 
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/debian/8/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc && \
+    curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools
 
 ENV PATH $PATH:/opt/mssql-tools/bin
 
@@ -25,13 +27,14 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.11
+ENV CASSANDRA_VERSION 3.11.15
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"
-RUN echo "Getting http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz"
+
+RUN echo "Getting $CASSANDRA_URL_BASE/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 
 RUN  cd /opt ; \
-     curl "http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz" | tar zx
+     curl "${CASSANDRA_URL_BASE}/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz" | tar zx
 
 ENV PATH /opt/apache-cassandra-$CASSANDRA_VERSION/bin:$PATH
 


### PR DESCRIPTION
### Problem

Neither dockerfile works.

* jessie was eol
* the cassandra urls were both dead

### Solution

* Upgrade debian from jessie to bullseye
  * Switch from mysql-client to mariadb-client
  * Change from msodbcsql to msodbcsql18
  * Replace deprecated apt-key with a trusted.gpg.d entry
* Update cassandra url (and use an arg to reduce duplication)
* Upgrade cassandra to 3.11.13
* Mostly sync m1 and non-m1 Dockerfile

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
