### PR TITLE
Support Option.orElse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -798,7 +798,8 @@ lazy val basicSettings = excludeFilterSettings ++ Seq(
     "-unchecked",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"
+    "-Ywarn-value-discard",
+    "-Ypatmat-exhaust-depth", "40"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -52,6 +52,7 @@ trait Liftables extends QuatLiftable {
     case OptionTableForall(a, b, c)  => q"$pack.OptionTableForall($a,$b,$c)"
     case OptionFlatten(a)            => q"$pack.OptionFlatten($a)"
     case OptionGetOrElse(a, b)       => q"$pack.OptionGetOrElse($a,$b)"
+    case OptionOrElse(a, b)          => q"$pack.OptionOrElse($a,$b)"
     case OptionFlatMap(a, b, c)      => q"$pack.OptionFlatMap($a,$b,$c)"
     case OptionMap(a, b, c)          => q"$pack.OptionMap($a,$b,$c)"
     case OptionForall(a, b, c)       => q"$pack.OptionForall($a,$b,$c)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.StringOps
 import scala.reflect.macros.TypecheckException
 import io.getquill.ast.Implicits._
 import io.getquill.ast.Renameable.Fixed
-import io.getquill.ast.Visibility.{Hidden, Visible}
+import io.getquill.ast.Visibility.Visible
 import io.getquill.quat._
 import io.getquill.util.Messages.TraceType
 import io.getquill.util.{Interleave, Interpolator, Messages}
@@ -588,6 +588,8 @@ trait Parsing extends ValueComputation with QuatMaking with MacroUtilBase {
       OptionFlatten(astParser(o))
     case q"$o.getOrElse[$t]($body)" if is[Option[Any]](o) =>
       OptionGetOrElse(astParser(o), astParser(body))
+    case q"$o.orElse[$t]($body)" if is[Option[Any]](o) =>
+      OptionOrElse(astParser(o), astParser(body))
     case q"$o.contains[$t]($body)" if is[Option[Any]](o) =>
       OptionContains(astParser(o), astParser(body))
     case q"$o.isEmpty" if is[Option[Any]](o) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -44,6 +44,7 @@ trait Unliftables extends QuatUnliftable {
     case q"$pack.OptionTableForall.apply(${a: Ast}, ${b: Ident}, ${c: Ast})"  => OptionTableForall(a, b, c)
     case q"$pack.OptionFlatten.apply(${a: Ast})"                              => OptionFlatten(a)
     case q"$pack.OptionGetOrElse.apply(${a: Ast}, ${b: Ast})"                 => OptionGetOrElse(a, b)
+    case q"$pack.OptionOrElse.apply(${a: Ast}, ${b: Ast})"                    => OptionOrElse(a, b)
     case q"$pack.OptionFlatMap.apply(${a: Ast}, ${b: Ident}, ${c: Ast})"      => OptionFlatMap(a, b, c)
     case q"$pack.OptionMap.apply(${a: Ast}, ${b: Ident}, ${c: Ast})"          => OptionMap(a, b, c)
     case q"$pack.OptionForall.apply(${a: Ast}, ${b: Ident}, ${c: Ast})"       => OptionForall(a, b, c)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -433,6 +433,14 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("b"))
         }
       }
+      "orElse" in {
+        val ast: Ast = OptionOrElse(Ident("a"), Ident("b"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionOrElse(Ident("a'"), Ident("b'"))
+            att.state mustEqual List(Ident("a"), Ident("b"))
+        }
+      }
       "flatMap - Unchecked" in {
         val ast: Ast = OptionTableFlatMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -284,6 +284,11 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
           OptionGetOrElse(Ident("a'"), Ident("b'"))
       }
+      "orElse" in {
+        val ast: Ast = OptionOrElse(Ident("a"), Ident("b"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
+          OptionOrElse(Ident("a'"), Ident("b'"))
+      }
       "flatMap - Unchecked" in {
         val ast: Ast = OptionTableFlatMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual

--- a/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
@@ -522,6 +522,13 @@ class MirrorIdiomSpec extends Spec {
       stmt"${(q.ast: Ast).token}" mustEqual
         stmt"(o) => o.getOrElse(1)"
     }
+    "orElse" in {
+      val q = quote { (o: Option[Int]) =>
+        o.orElse(Option(1))
+      }
+      stmt"${(q.ast: Ast).token}" mustEqual
+        stmt"(o) => o.orElse(Option(1))"
+    }
     "flatten" in {
       val q = quote { (o: Option[Option[Int]]) =>
         o.flatten

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -12,6 +12,7 @@ class FlattenOptionOperationSpec extends Spec { // hello
 
   def o      = Ident("o")
   def c1     = Constant.auto(1)
+  def c2     = Constant.auto(2)
   def cFoo   = Constant.auto("foo")
   def cBar   = Constant.auto("bar")
   def cValue = Constant.auto("value")
@@ -24,7 +25,31 @@ class FlattenOptionOperationSpec extends Spec { // hello
         o.getOrElse(1)
       }
       new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
-        If(BinaryOperation(Ident("o"), EqualityOperator.`_!=`, NullValue), Ident("o"), Constant.auto(1))
+        IfExist(o, o, c1)
+    }
+    "orElse" - {
+      "regular operation" in {
+        val q = quote { (o: Option[Int]) =>
+          o.orElse(Option(1))
+        }
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
+          IfExist(o, o, c1)
+      }
+      "with forall" in {
+        val q = quote { (o: Option[Int]) =>
+          o.orElse(Option(1)).forall(_ == 2)
+        }
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
+          ((o +==+ c2) +||+ (IsNullCheck(o) +&&+ (c1 +==+ c2))
+            +||+ (IsNullCheck(o) +&&+ IsNullCheck(c1)))
+      }
+      "with exists" in {
+        val q = quote { (o: Option[Int]) =>
+          o.orElse(Option(1)).exists(_ == 2)
+        }
+        new FlattenOptionOperation(AnsiConcat, TraceConfig.Empty)(q.ast.body: Ast) mustEqual
+          ((o +==+ c2 +&&+ IsNotNullCheck(o)) +||+ (c1 +==+ c2 +&&+ IsNotNullCheck(c1)))
+      }
     }
     "flatten" - {
       "regular operation" in {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1541,6 +1541,12 @@ class QuotationSpec extends Spec {
             Constant.auto(true)
           )
       }
+      "orElse" in {
+        val q = quote { (o: Option[Int]) =>
+          o.orElse(Option(11))
+        }
+        quote(unquote(q)).ast.body mustEqual OptionOrElse(Ident("o"), OptionApply(Constant.auto(11)))
+      }
       "flatten" in {
         val q = quote { (o: Option[Option[Int]]) =>
           o.flatten

--- a/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-engine/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -163,6 +163,7 @@ trait MirrorIdiomBase extends Idiom {
       case OptionTableForall(ast, alias, body)  => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
       case OptionFlatten(ast)                   => stmt"${ast.token}.flatten"
       case OptionGetOrElse(ast, body)           => stmt"${ast.token}.getOrElse(${body.token})"
+      case OptionOrElse(ast, body)              => stmt"${ast.token}.orElse(${body.token})"
       case OptionFlatMap(ast, alias, body)      => stmt"${ast.token}.flatMap((${alias.token}) => ${body.token})"
       case OptionMap(ast, alias, body)          => stmt"${ast.token}.map((${alias.token}) => ${body.token})"
       case OptionForall(ast, alias, body)       => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"

--- a/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/Ast.scala
@@ -502,6 +502,9 @@ case class OptionFlatten(ast: Ast) extends OptionOperation { def quat = ast.quat
 case class OptionGetOrElse(ast: Ast, body: Ast) extends OptionOperation {
   def quat = body.quat; def bestQuat = body.bestQuat
 }
+case class OptionOrElse(ast: Ast, body: Ast) extends OptionOperation {
+  def quat = body.quat; def bestQuat = body.bestQuat
+}
 case class OptionFlatMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation {
   def quat = body.quat; def bestQuat = body.bestQuat
 }

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -78,6 +78,10 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
         (OptionGetOrElse(at, ct), ctt)
+      case OptionOrElse(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (OptionOrElse(at, ct), ctt)
       case OptionFlatMap(a, b, c) =>
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)

--- a/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatefulTransformerWithStack.scala
@@ -94,6 +94,10 @@ trait StatefulTransformerWithStack[T] {
         val (at, att) = apply(a)(History(o))
         val (ct, ctt) = att.apply(c)(History(o))
         (OptionGetOrElse(at, ct), ctt)
+      case OptionOrElse(a, c) =>
+        val (at, att) = apply(a)(History(o))
+        val (ct, ctt) = att.apply(c)(History(o))
+        (OptionOrElse(at, ct), ctt)
       case OptionFlatMap(a, b, c) =>
         val (at, att) = apply(a)(History(o))
         val (ct, ctt) = att.apply(c)(History(o))

--- a/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-engine/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -48,6 +48,7 @@ trait StatelessTransformer {
       case OptionTableForall(a, b, c)  => OptionTableForall(apply(a), applyIdent(b), apply(c))
       case OptionFlatten(a)            => OptionFlatten(apply(a))
       case OptionGetOrElse(a, b)       => OptionGetOrElse(apply(a), apply(b))
+      case OptionOrElse(a, b)          => OptionOrElse(apply(a), apply(b))
       case OptionFlatMap(a, b, c)      => OptionFlatMap(apply(a), applyIdent(b), apply(c))
       case OptionMap(a, b, c)          => OptionMap(apply(a), applyIdent(b), apply(c))
       case OptionForall(a, b, c)       => OptionForall(apply(a), applyIdent(b), apply(c))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -32,8 +34,22 @@ class OptionJdbcSpec extends OptionQuerySpec {
     ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -50,5 +66,17 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -32,8 +34,22 @@ class OptionJdbcSpec extends OptionQuerySpec {
     ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -50,5 +66,17 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -26,8 +28,28 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Simple Map with GetOrElse`) should contain theSameElementsAs `Simple Map with GetOrElse Result`
   }
 
+  "Example 1.2 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(
+      `Simple Map with Condition and GetOrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -44,5 +66,17 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -32,8 +34,22 @@ class OptionJdbcSpec extends OptionQuerySpec {
     ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -50,5 +66,17 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
@@ -64,10 +64,6 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
   }
 
-  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
-    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
-  }
-
   "Example 7 - Filter with OrElse and Forall" in {
     testContext.run(
       `Filter with OrElse and Forall`

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -32,8 +34,22 @@ class OptionJdbcSpec extends OptionQuerySpec {
     ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -46,5 +62,21 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 5 - Map+getOrElse Join" in {
     testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
+    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
@@ -12,8 +12,10 @@ class OptionJdbcSpec extends OptionQuerySpec {
     testContext.transaction {
       testContext.run(query[Contact].delete)
       testContext.run(query[Address].delete)
+      testContext.run(query[Task].delete)
       testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
       testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+      testContext.run(liftQuery(taskEntries).foreach(p => taskInsert(p)))
     }
     ()
   }
@@ -45,8 +47,22 @@ class OptionJdbcSpec extends OptionQuerySpec {
     ) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
   }
 
+  "Example 1.3 - Simple Map with OrElse" in {
+    testContext.run(`Simple Map with OrElse`) should contain theSameElementsAs `Simple Map with OrElse Result`
+  }
+
+  "Example 1.4 - Simple Map with Condition and OrElse" in {
+    testContext.run(
+      `Simple Map with Condition and OrElse`
+    ) should contain theSameElementsAs `Simple Map with Condition and OrElse Result`
+  }
+
   "Example 2 - Simple GetOrElse" in {
     testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 2.1 - Simple OrElse" in {
+    testContext.run(`Simple OrElse`) should contain theSameElementsAs `Simple OrElse Result`
   }
 
   "Example 3 - LeftJoin with FlatMap" in {
@@ -63,5 +79,17 @@ class OptionJdbcSpec extends OptionQuerySpec {
 
   "Example 6 - Map+Option+Flatten+getOrElse Join" in {
     testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+
+  "Example 7 - Filter with OrElse and Forall" in {
+    testContext.run(
+      `Filter with OrElse and Forall`
+    ) should contain theSameElementsAs `Filter with OrElse and Forall Result`
+  }
+
+  "Example 7.1 - Filter with OrElse and Exists" in {
+    testContext.run(
+      `Filter with OrElse and Exists`
+    ) should contain theSameElementsAs `Filter with OrElse and Exists Result`
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
@@ -12,6 +12,7 @@ trait OptionQuerySpec extends Spec {
   case class HasAddressContact(firstName: String, lastName: String, age: Int, addressFk: Int)
   case class Contact(firstName: String, lastName: String, age: Int, addressFk: Option[Int], extraInfo: String)
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: Option[String])
+  case class Task(emp: Option[String], tsk: Option[String])
 
   val peopleInsert =
     quote((p: Contact) => query[Contact].insertValue(p))
@@ -30,6 +31,15 @@ trait OptionQuerySpec extends Spec {
     Address(2, "456 Old Street", 45678, Some("something else")),
     Address(3, "789 New Street", 89010, None),
     Address(111, "111 Default Address", 12345, None)
+  )
+
+  val taskInsert = quote((t: Task) => query[Task].insertValue(t))
+
+  val taskEntries = List(
+    Task(Some("Feed the dogs"), Some("Feed the cats")),
+    Task(Some("Feed the dogs"), None),
+    Task(None, Some("Feed the cats")),
+    Task(None, None)
   )
 
   val `Simple Map with Condition` = quote {
@@ -138,4 +148,54 @@ trait OptionQuerySpec extends Spec {
     ("Cora", "111 Default Address")
   )
 
+  val `Simple OrElse` = quote {
+    query[Address].map(a => (a.street, a.otherExtraInfo.orElse(Some("yet something else"))))
+  }
+  val `Simple OrElse Result` = List(
+    ("123 Fake Street", Some("something")),
+    ("456 Old Street", Some("something else")),
+    ("789 New Street", Some("yet something else")),
+    ("111 Default Address", Some("yet something else"))
+  )
+
+  val `Simple Map with OrElse` = quote {
+    query[Address].map(a => (a.street, a.otherExtraInfo.map(info => info + " suffix").orElse(Some("baz"))))
+  }
+  val `Simple Map with OrElse Result` = List(
+    ("123 Fake Street", Some("something suffix")),
+    ("456 Old Street", Some("something else suffix")),
+    ("789 New Street", Some("baz")),
+    ("111 Default Address", Some("baz"))
+  )
+
+  val `Simple Map with Condition and OrElse` = quote {
+    query[Address].map(a =>
+      (a.street, a.otherExtraInfo.map(info => if (info == "something") "foo" else "bar").orElse(Some("baz")))
+    )
+  }
+  val `Simple Map with Condition and OrElse Result` = List(
+    ("123 Fake Street", Some("foo")),
+    ("456 Old Street", Some("bar")),
+    ("789 New Street", Some("baz")),
+    ("111 Default Address", Some("baz"))
+  )
+
+  val `Filter with OrElse and Forall` = quote {
+    query[Task].filter(t => t.emp.orElse(t.tsk).forall(_ == "Feed the dogs"))
+  }
+
+  val `Filter with OrElse and Forall Result` = List(
+    Task(Some("Feed the dogs"), Some("Feed the cats")),
+    Task(Some("Feed the dogs"), None),
+    Task(None, None)
+  )
+
+  val `Filter with OrElse and Exists` = quote {
+    query[Task].filter(t => t.emp.orElse(t.tsk).contains("Feed the dogs"))
+  }
+
+  val `Filter with OrElse and Exists Result` = List(
+    Task(Some("Feed the dogs"), Some("Feed the cats")),
+    Task(Some("Feed the dogs"), None)
+  )
 }


### PR DESCRIPTION
Fixes #1691

### Problem

Quill does not support `Option.orElse`

### Solution

Implemented support for

`if columnA.orElse(columnB).forall(_ == value)` 

and 

`if columnA.orElse(columnB).exists(_ == value)`

syntax

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
