### PR TITLE
using expandBatchActionNew and removes old expandBatchAction

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -37,7 +37,7 @@ class ActionMacro(val c: MacroContext) extends ContextMacro with ReifyLiftings {
     translateBatchQueryPrettyPrint(quoted, q"false")
 
   def translateBatchQueryPrettyPrint(quoted: Tree, prettyPrint: Tree): Tree =
-    expandBatchActionNew(quoted, false) {
+    expandBatchActionNew(quoted, isReturning = false) {
       case (batch, param, expanded, injectableLiftList, idiomNamingOriginalAstVars, idiomContext, canDoBatch) =>
         q"""
           ..${EnableReflectiveCalls(c)}
@@ -119,7 +119,7 @@ class ActionMacro(val c: MacroContext) extends ContextMacro with ReifyLiftings {
     batchActionRows(quoted, method, q"1")
 
   def batchActionRows(quoted: Tree, method: String, numRows: Tree): Tree =
-    expandBatchActionNew(quoted, false) {
+    expandBatchActionNew(quoted, isReturning = false) {
       case (batch, param, expanded, injectableLiftList, idiomNamingOriginalAstVars, idiomContext, canDoBatch) =>
         q"""
           ..${EnableReflectiveCalls(c)}
@@ -177,7 +177,7 @@ class ActionMacro(val c: MacroContext) extends ContextMacro with ReifyLiftings {
     batchActionReturningRows(quoted, numRows)
 
   def batchActionReturningRows[T](quoted: Tree, numRows: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandBatchActionNew(quoted, true) {
+    expandBatchActionNew(quoted, isReturning = true) {
       case (batch, param, expanded, injectableLiftList, idiomNamingOriginalAstVars, idiomContext, canDoBatch) =>
         q"""
           ..${EnableReflectiveCalls(c)}


### PR DESCRIPTION
Fixes #2572

### Problem

As described in the issue, we need to update`translateBatchQueryPrettyPrint` to use `expandBatchActionNew` instead of `expandBatchAction`.

### Solution

Updates the code and removes `expandBatchAction`;

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
