### PR TITLE
Update scalafmt-core to `3.7.13`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -215,7 +215,7 @@ lazy val `quill-util` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        ("org.scalameta" %% "scalafmt-core" % "3.1.2")
+        ("org.scalameta" %% "scalafmt-core" % "3.7.13")
           .excludeAll(
             (Seq(
               ExclusionRule(organization = "com.lihaoyi", name = "sourcecode_2.13"),


### PR DESCRIPTION
Fixes https://github.com/zio/zio-quill/issues/2740

### Problem

scalafmt-core `3.1.0` depends on old versions of pprint and geny creating binary compatibility problems with projects using other com.lihaoyi libraries that transitively depend on newer versions of pprint and geny.

### Solution

Update scalafmt-core to its latest version which now depends on a shaded fansi library from scalameta.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
