### PR TITLE
Add a max size for normalize cache

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,16 @@ lazy val scala213Modules =
 
 lazy val scala3Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](`quill-engine`, `quill-util`)
 
+def javaMainVersion = {
+  val javaVersion = System.getProperty("java.version")
+  val versionSplit = javaVersion.split('.')
+  if (versionSplit.head.equals("1")) {
+    versionSplit(1).toInt
+  } else {
+    versionSplit(0).toInt
+  }
+}
+
 def isScala213 = {
   val scalaVersion = sys.props.get("quill.scala.version")
   scalaVersion.map(_.startsWith("2.13")).getOrElse(false)
@@ -227,11 +237,17 @@ lazy val `quill-engine` =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "com.typesafe"                % "config"        % "1.4.2",
-        "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-        ("com.github.takayahilton"   %% "sql-formatter" % "1.2.1").cross(CrossVersion.for3Use2_13),
-        "io.suzaku"                  %% "boopickle"     % "1.4.0",
-        "com.lihaoyi"                %% "pprint"        % "0.8.1"
+        "com.typesafe"                  % "config"        % "1.4.2",
+        "com.typesafe.scala-logging"   %% "scala-logging" % "3.9.5",
+        ("com.github.takayahilton"     %% "sql-formatter" % "1.2.1").cross(CrossVersion.for3Use2_13),
+        "io.suzaku"                    %% "boopickle"     % "1.4.0",
+        "com.lihaoyi"                  %% "pprint"        % "0.8.1",
+        // caffeine 3.x doesn't support Java version lower than 11
+        if (javaMainVersion >= 11) {
+          "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8"
+        } else {
+          "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+        }
       ),
       coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;io.getquill.Model;io.getquill.ScalarTag;io.getquill.QuotationTag"
     )

--- a/quill-engine/src/main/scala/io/getquill/norm/NormalizeCaching.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/NormalizeCaching.scala
@@ -1,21 +1,20 @@
 package io.getquill.norm
 
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import io.getquill.ast.Ast
-import java.util.concurrent.ConcurrentHashMap
+import io.getquill.util.Messages
 
 object NormalizeCaching {
-  private val cache = new ConcurrentHashMap[Ast, Ast]
+
+  private val cache: Cache[Ast, Ast] = Caffeine
+    .newBuilder()
+    .maximumSize(Messages.cacheDynamicMaxSize)
+    .recordStats()
+    .build()
 
   def apply(f: Ast => Ast): Ast => Ast = { ori =>
     val (stabilized, state) = StabilizeLifts.stabilize(ori)
-    val cachedR             = cache.get(stabilized)
-    val normalized = if (cachedR != null) {
-      cachedR
-    } else {
-      val r = f(stabilized)
-      cache.put(stabilized, r)
-      r
-    }
+    val normalized          = cache.get(stabilized, ast => f(ast))
     StabilizeLifts.revert(normalized, state)
   }
 

--- a/quill-engine/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-engine/src/main/scala/io/getquill/util/Messages.scala
@@ -49,6 +49,10 @@ object Messages {
     "quill.query.cacheDynamic",
     variable("quill.query.cacheDynamic", "query_query_cacheDynamic", "true").toBoolean
   )
+  def cacheDynamicMaxSize = cache(
+    "quill.query.cacheDynamicMaxSize",
+    variable("quill.query.cacheDynamicMaxSize", "query_query_cacheDynamicMaxSize", "1024").toLong
+  )
   def querySubexpand =
     cache("quill.query.subexpand", variable("quill.query.subexpand", "query_query_subexpand", "true").toBoolean)
   def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "false")))


### PR DESCRIPTION
Fixes #2484

### Problem

There is no bound for normalize cache which results memory usage increase without limit for dynamic queries.

### Solution

Added a capacity to normalize cache. Default to 1024 and can be override by `quill.query.cacheDynamicMaxSize`.

### Notes

Added a new dependency Google Guava to use its cache implementation. I know it's better to avoid new dependency but Google Guava is a pretty widely adopted library. It's cache implementation is widely tested. For such a critical use case in quill, I think it's better to have a widely tested implementation than reinventing the wheel.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

Note:

`sbt scalariformFormat test:scalariformFormat` give me error:

```
[error] Not a valid command: scalariformFormat                                                                                                                                       
[error] Not a valid project ID: scalariformFormat                                         
[error] Expected ':'                                                                                                                                                                 
[error] Not a valid key: scalariformFormat (similar: scalaArtifacts, scalafmt, scalafmtDoFormatOnCompile)                                                                            
[error] scalariformFormat                                                                                                                                                            
[error]     
```
