### PR TITLE
Fix publishing to Sonatype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,6 @@ jobs:
     if: ${{github.event_name != 'pull_request'}}
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        scala: [ 2.12.x, 2.13.x, 3.3.x ]
     env:
       CI_RELEASE: publishSigned # By default, sbt-ci-release uses the `+publishSigned` which is publishing for all the Scala versions configured, which is not what we want
       CI_SNAPSHOT_RELEASE: publish # By default, sbt-ci-release uses the `+publish` which is publishing for all the Scala versions configured, which is not what we want
@@ -97,7 +93,10 @@ jobs:
           distribution: temurin
           java-version: '8'
           check-latest: true
-      - run: sbt ++${{ matrix.scala }} -Dquill.scala.version=${{ matrix.scala }} ci-release
+      - run: |
+          sbt ++2.12.x -Dquill.scala.version=2.12.x ci-release
+          sbt ++2.13.x -Dquill.scala.version=2.13.x ci-release
+          sbt ++3.3.x -Dquill.scala.version=3.3.x ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
It seems not possible to publish in parallel to Sonatype, one publish process "closing" the ongoing other ones

See logs in:
- https://github.com/zio/zio-quill/actions/runs/6336694216/job/17211353656
- https://github.com/zio/zio-quill/actions/runs/6336694216/job/17211353055

```bash
2023-09-28 09:39:19.526Z  info [SonatypeClient] Creating a staging repository in profile io.getquill with a description key: [sbt-sonatype] quill 4.7.1  - (SonatypeClient.scala:122)
2023-09-28 09:39:39.873Z  info [SonatypeService] Found a previous staging repository [iogetquill-2462] status:open, profile:io.getquill(4b350f33294246) description: [sbt-sonatype] quill 4.7.1  - (SonatypeService.scala:105)
2023-09-28 09:39:39.873Z  info [SonatypeClient] Dropping staging repository [iogetquill-2462] status:open, profile:io.getquill(4b350f33294246) description: [sbt-sonatype] quill 4.7.1  - (SonatypeClient.scala:225)
```
