### PR TITLE
The scaladoc apparently requires Scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,9 @@ jobs:
           java-version: '8'
           check-latest: true
       - run: |
-          sbt ++2.12.x -Dquill.scala.version=2.12.x ci-release
-          sbt ++2.13.x -Dquill.scala.version=2.13.x ci-release
-          sbt ++3.3.x -Dquill.scala.version=3.3.x ci-release
+          sbt ++2.12.x -Dquill.scala.version=2.12.x -Dquill.macro.log=false ci-release
+          sbt ++2.13.x -Dquill.scala.version=2.13.x -Dquill.macro.log=false ci-release
+          sbt ++3.3.x -Dquill.scala.version=3.3.x -Dquill.macro.log=false ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -70,10 +70,10 @@ lazy val bigdataModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
 )
 
 lazy val allModules =
-  baseModules ++ dbModules ++ jasyncModules ++ codegenModules ++ bigdataModules ++ docsModules
+  baseModules ++ dbModules ++ jasyncModules ++ codegenModules ++ bigdataModules
 
 lazy val scala212Modules =
-  baseModules ++ dbModules ++ jasyncModules ++ codegenModules ++ bigdataModules
+  baseModules ++ dbModules ++ jasyncModules ++ codegenModules ++ bigdataModules ++ docsModules
 
 lazy val scala3Modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](`quill-engine`, `quill-util`)
 


### PR DESCRIPTION
See: https://github.com/zio/zio-quill/actions/runs/6337872463/job/17215027348#logs

Error:
```scala
[info] Main Scala API documentation to /home/runner/work/zio-quill/zio-quill/zio-quill-docs/target/scala-2.12/unidoc...
java.io.IOException: Scala signature package has wrong version
 expected: 5.0
 found: 5.2 in package.class
```