### PR TITLE
Fix sbt Docker image version

### DIFF
--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u312_1.5.5_2.13.6
+FROM sbtscala/scala-sbt:eclipse-temurin-focal-17.0.8.1_1_1.9.6_3.3.1
 MAINTAINER mdedetrich@gmail.com
 
 RUN apt-get update


### PR DESCRIPTION



### Problem

The command in doc that build with sbt and docker doesn't work afte upgrade to Jdk 11.

### Solution

Use sbt with jdk 11 in order to build with `-release:11`.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
