### PR TITLE
Issue-2912: Optimize calendar creation

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -3,7 +3,7 @@ package io.getquill.context.jdbc
 import java.sql.Types
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset, ZonedDateTime}
 import java.{time, util}
-import java.util.{Calendar, TimeZone}
+import java.util.TimeZone
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
 trait Decoders {
@@ -55,7 +55,7 @@ trait Decoders {
   implicit val doubleDecoder: Decoder[Double]         = decoder(_.getDouble)
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder(_.getBytes)
   implicit val dateDecoder: Decoder[util.Date] =
-    decoder((index, row, session) => new util.Date(row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).getTime))
+    decoder((index, row, session) => new util.Date(row.getTimestamp(index, calendar).getTime))
 }
 
 trait BasicTimeDecoders { self: Decoders =>

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -3,7 +3,6 @@ package io.getquill.context.jdbc
 import java.sql.{Date, Timestamp, Types}
 import java.time.temporal.TemporalField
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset, ZonedDateTime}
-import java.util.Calendar
 import java.{sql, util}
 
 trait Encoders {
@@ -64,7 +63,7 @@ trait Encoders {
     encoder(
       Types.TIMESTAMP,
       (index, value, row) =>
-        row.setTimestamp(index, new sql.Timestamp(value.getTime), Calendar.getInstance(dateTimeZone))
+        row.setTimestamp(index, new sql.Timestamp(value.getTime), calendar)
     )
 }
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
@@ -30,7 +30,7 @@ trait JdbcContextTypes[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
 
   val dateTimeZone = TimeZone.getDefault
 
-  val calendar: Calendar = Calendar.getInstance(dateTimeZone)
+  final lazy val calendar: Calendar = Calendar.getInstance(dateTimeZone)
 
   /**
    * Parses instances of java.sql.Types to string form so it can be used in

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextTypes.scala
@@ -8,7 +8,7 @@ import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.util.ContextLogger
 
 import java.sql.{Connection, JDBCType, PreparedStatement, ResultSet, Statement}
-import java.util.TimeZone
+import java.util.{Calendar, TimeZone}
 
 trait JdbcContextTypes[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
     extends Context[Dialect, Naming]
@@ -29,6 +29,8 @@ trait JdbcContextTypes[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   implicit val nullChecker: JdbcNullChecker = new JdbcNullChecker()
 
   val dateTimeZone = TimeZone.getDefault
+
+  val calendar: Calendar = Calendar.getInstance(dateTimeZone)
 
   /**
    * Parses instances of java.sql.Types to string form so it can be used in


### PR DESCRIPTION
Fixes #2912

### Problem
Inefficient creation `java.util.Calendar`

### Solution
Move `Calendar.getInstance(dateTimeZone)` to a member value

@getquill/maintainers
