### PR TITLE
Remove noisy and useless lobgack logs in CI/test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,7 @@ lazy val `quill-util` =
         else Seq.empty
       }
     )
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-engine` =
@@ -204,6 +205,7 @@ lazy val `quill-engine` =
       ),
       coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;io.getquill.Model;io.getquill.ScalarTag;io.getquill.QuotationTag"
     )
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-core` =
@@ -212,7 +214,6 @@ lazy val `quill-core` =
     .settings(
       libraryDependencies ++= Seq(
         "com.typesafe"                % "config"        % "1.4.3",
-        "dev.zio"                    %% "zio-logging"   % "2.1.14",
         "dev.zio"                    %% "zio"           % Version.zio,
         "dev.zio"                    %% "zio-streams"   % Version.zio,
         "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
@@ -220,6 +221,7 @@ lazy val `quill-core` =
       Test / fork := true
     )
     .dependsOn(`quill-engine` % "compile->compile")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-sql` =
@@ -229,12 +231,14 @@ lazy val `quill-sql` =
       `quill-engine` % "compile->compile",
       `quill-core`   % "compile->compile;test->test"
     )
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-codegen` =
   (project in file("quill-codegen"))
     .settings(commonSettings: _*)
     .dependsOn(`quill-core` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
 
 lazy val `quill-codegen-jdbc` =
   (project in file("quill-codegen-jdbc"))
@@ -248,6 +252,7 @@ lazy val `quill-codegen-jdbc` =
     )
     .dependsOn(`quill-codegen` % "compile->compile;test->test")
     .dependsOn(`quill-jdbc` % "compile->compile")
+    .dependsOn(`quill-test-kit` % Test)
 
 lazy val `quill-codegen-tests` =
   (project in file("quill-codegen-tests"))
@@ -282,6 +287,7 @@ lazy val `quill-codegen-tests` =
       }.tag(CodegenTag)
     )
     .dependsOn(`quill-codegen-jdbc` % "compile->test")
+    .dependsOn(`quill-test-kit` % Test)
 
 val excludeTests =
   sys.props.getOrElse("excludeTests", "false") match {
@@ -298,6 +304,7 @@ lazy val `quill-jdbc` =
     .settings(commonSettings: _*)
     .settings(jdbcTestingSettings: _*)
     .dependsOn(`quill-sql` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 ThisBuild / libraryDependencySchemes += "org.typelevel" %% "cats-effect" % "always"
@@ -312,6 +319,7 @@ lazy val `quill-doobie` =
       )
     )
     .dependsOn(`quill-jdbc` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-monix` =
@@ -325,6 +333,7 @@ lazy val `quill-monix` =
       )
     )
     .dependsOn(`quill-core` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-jdbc-monix` =
@@ -350,6 +359,7 @@ lazy val `quill-jdbc-monix` =
     .dependsOn(`quill-monix` % "compile->compile;test->test")
     .dependsOn(`quill-sql` % "compile->compile;test->test")
     .dependsOn(`quill-jdbc` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-zio` =
@@ -363,6 +373,7 @@ lazy val `quill-zio` =
       )
     )
     .dependsOn(`quill-core` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-jdbc-zio` =
@@ -397,6 +408,7 @@ lazy val `quill-jdbc-zio` =
     .dependsOn(`quill-zio` % "compile->compile;test->test")
     .dependsOn(`quill-sql` % "compile->compile;test->test")
     .dependsOn(`quill-jdbc` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-spark` =
@@ -408,6 +420,7 @@ lazy val `quill-spark` =
       excludeDependencies ++= Seq("ch.qos.logback" % "logback-classic")
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-cassandra` =
@@ -424,6 +437,7 @@ lazy val `quill-cassandra` =
       )
     )
     .dependsOn(`quill-core` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-cassandra-monix` =
@@ -434,6 +448,7 @@ lazy val `quill-cassandra-monix` =
     )
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
     .dependsOn(`quill-monix` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-cassandra-zio` =
@@ -448,6 +463,7 @@ lazy val `quill-cassandra-zio` =
     )
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
     .dependsOn(`quill-zio` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-cassandra-alpakka` =
@@ -461,6 +477,7 @@ lazy val `quill-cassandra-alpakka` =
       )
     )
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
 
 lazy val `quill-orientdb` =
@@ -473,7 +490,13 @@ lazy val `quill-orientdb` =
       )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
+    .dependsOn(`quill-test-kit` % Test)
     .enablePlugins(MimaPlugin)
+
+lazy val `quill-test-kit` =
+  (project in file("quill-test-kit"))
+    .settings(commonSettings: _*)
+    .settings(noPublishSettings: _*)
 
 lazy val jdbcTestingLibraries = Seq(
   libraryDependencies ++= Seq(
@@ -665,3 +688,10 @@ lazy val docs = project
          |
          |You can notify all current maintainers using the handle `@getquill/maintainers`.""".stripMargin
   )
+
+lazy val noPublishSettings = Seq(
+  publish := {},
+  publishLocal := {},
+  publishM2 := {},
+  publishArtifact := false,
+)

--- a/quill-test-kit/src/main/resources/logback-test.xml
+++ b/quill-test-kit/src/main/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Configuration doc: https://logback.qos.ch/manual/layouts.html -->
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            </appender>
+        </appender-ref>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="ASYNC_STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Removes all these kind of logs:
```
08:05:27,263 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.4.11
08:05:27,266 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - No custom configurators were discovered as a service.
08:05:27,266 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
08:05:27,267 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
08:05:27,291 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
08:05:27,293 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
08:05:27,305 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 26 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
08:05:27,305 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
08:05:27,306 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
08:05:27,308 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback-test.xml] at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/target/scala-2.13/test-classes/logback-test.xml]
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs multiple times on the classpath.
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/target/scala-2.13/test-classes/logback-test.xml]
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/src/test/resources/logback-test.xml]
08:05:27,412 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [STDOUT]
08:05:27,412 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
08:05:27,422 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [io.getquill] to DEBUG
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari] to ERROR
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [io.netty] to ERROR
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to INFO
08:05:27,448 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [STDOUT] to Logger[ROOT]
08:05:27,448 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@5353fb50 - End of configuration.
08:05:27,449 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@2efb9e2f - Registering current configuration as safe fallback point
08:05:27,449 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 143 milliseconds.
```
