### PR TITLE
Remove noisy and useless Logback logs

### DIFF
--- a/quill-cassandra/src/test/resources/logback-test.xml
+++ b/quill-cassandra/src/test/resources/logback-test.xml
@@ -1,4 +1,6 @@
 <configuration>
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex

--- a/quill-codegen-jdbc/src/test/resources/logback.xml
+++ b/quill-codegen-jdbc/src/test/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex

--- a/quill-core/src/test/resources/logback.xml
+++ b/quill-core/src/test/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+	
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex

--- a/quill-jdbc-zio/src/test/resources/logback-test.xml
+++ b/quill-jdbc-zio/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <configuration>
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+	<appender name="STDOUT" class="ch.qos.l
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+	ogback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex
 			</pattern>

--- a/quill-jdbc-zio/src/test/resources/logback-test.xml
+++ b/quill-jdbc-zio/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
-	<appender name="STDOUT" class="ch.qos.l
 	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-	ogback.core.ConsoleAppender">
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex
 			</pattern>

--- a/quill-jdbc-zio/src/test/resources/logback.xml
+++ b/quill-jdbc-zio/src/test/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex

--- a/quill-jdbc/src/test/resources/logback.xml
+++ b/quill-jdbc/src/test/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex


### PR DESCRIPTION
Removes all these kind of logs:
```
08:05:27,263 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.4.11
08:05:27,266 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - No custom configurators were discovered as a service.
08:05:27,266 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
08:05:27,267 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
08:05:27,291 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
08:05:27,293 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
08:05:27,305 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 26 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
08:05:27,305 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
08:05:27,306 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
08:05:27,308 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback-test.xml] at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/target/scala-2.13/test-classes/logback-test.xml]
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs multiple times on the classpath.
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/target/scala-2.13/test-classes/logback-test.xml]
08:05:27,309 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@3be5e2e7 - Resource [logback-test.xml] occurs at [file:/home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/src/test/resources/logback-test.xml]
08:05:27,412 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [STDOUT]
08:05:27,412 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
08:05:27,422 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [io.getquill] to DEBUG
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari] to ERROR
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [io.netty] to ERROR
08:05:27,447 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to INFO
08:05:27,448 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [STDOUT] to Logger[ROOT]
08:05:27,448 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@5353fb50 - End of configuration.
08:05:27,449 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@2efb9e2f - Registering current configuration as safe fallback point
08:05:27,449 |-INFO in ch.qos.logback.classic.util.ContextInitializer@39f7822f - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 143 milliseconds.
```
