### PR TITLE
Fix exception in Postgres inserting None value for Option[JsonValue[...]] or Option[JsonbValue[...]] fields

### DIFF
--- a/quill-jdbc-zio/src/main/scala-2.13/io/getquill/context/json/PostgresJsonExtensions.scala
+++ b/quill-jdbc-zio/src/main/scala-2.13/io/getquill/context/json/PostgresJsonExtensions.scala
@@ -26,7 +26,7 @@ trait PostgresJsonExtensions { this: Encoders with Decoders =>
 
   def astEncoder[Wrapper](valueToString: Wrapper => String, jsonType: String): Encoder[Wrapper] =
     encoder(
-      Types.VARCHAR,
+      Types.OTHER,
       (index, jsonValue, row) => {
         val obj = new org.postgresql.util.PGobject()
         obj.setType(jsonType)
@@ -56,7 +56,7 @@ trait PostgresJsonExtensions { this: Encoders with Decoders =>
     jsonEncoder: JsonEncoder[JsValue]
   ): Encoder[Wrapper] =
     encoder(
-      Types.VARCHAR,
+      Types.OTHER,
       (index, jsonValue, row) => {
         val obj = new org.postgresql.util.PGobject()
         obj.setType(jsonType)

--- a/quill-jdbc-zio/src/test/scala-2.13/io/getquill/postgres/PostgresJsonSpec.scala
+++ b/quill-jdbc-zio/src/test/scala-2.13/io/getquill/postgres/PostgresJsonSpec.scala
@@ -1,11 +1,12 @@
 package io.getquill.postgres
 
 import io.getquill.{JsonValue, JsonbValue, ZioSpec}
+import org.scalatest.BeforeAndAfterEach
 import zio.Chunk
 import zio.json.ast.Json
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
-class PostgresJsonSpec extends ZioSpec {
+class PostgresJsonSpec extends ZioSpec with BeforeAndAfterEach {
   val context = testContext
   import testContext._
 
@@ -15,6 +16,9 @@ class PostgresJsonSpec extends ZioSpec {
   case class JsonEntity(name: String, value: JsonValue[PersonJson])
   case class JsonbEntity(name: String, value: JsonbValue[PersonJsonb])
 
+  case class JsonOptEntity(name: String, value: Option[JsonValue[PersonJson]])
+  case class JsonbOptEntity(name: String, value: Option[JsonbValue[PersonJsonb]])
+
   val jsonJoe    = JsonValue(PersonJson("Joe", 123))
   val jsonValue  = JsonEntity("JoeEntity", jsonJoe)
   val jsonbJoe   = JsonbValue(PersonJsonb("Joe", 123))
@@ -23,14 +27,17 @@ class PostgresJsonSpec extends ZioSpec {
   case class JsonAstEntity(name: String, value: JsonValue[Json])
   case class JsonbAstEntity(name: String, value: JsonbValue[Json])
 
+  case class JsonAstOptEntity(name: String, value: Option[JsonValue[Json]])
+  case class JsonbAstOptEntity(name: String, value: Option[JsonbValue[Json]])
+
   implicit val personJsonEncoder: JsonEncoder[PersonJson] = DeriveJsonEncoder.gen[PersonJson]
   implicit val personJsonDecoder: JsonDecoder[PersonJson] = DeriveJsonDecoder.gen[PersonJson]
 
   implicit val personJsonbEncoder: JsonEncoder[PersonJsonb] = DeriveJsonEncoder.gen[PersonJsonb]
   implicit val personJsonbDecoder: JsonDecoder[PersonJsonb] = DeriveJsonDecoder.gen[PersonJsonb]
 
-  override def beforeAll = {
-    super.beforeAll()
+  override def beforeEach = {
+    super.beforeEach()
     testContext.run(quote(query[JsonbEntity].delete)).runSyncUnsafe()
     testContext.run(quote(query[JsonEntity].delete)).runSyncUnsafe()
     ()
@@ -50,6 +57,43 @@ class PostgresJsonSpec extends ZioSpec {
     }
   }
 
+  "encodes and decodes optional json entity" - {
+    val jsonOptQuery  = quote(querySchema[JsonOptEntity]("JsonEntity"))
+    val jsonbOptQuery = quote(querySchema[JsonbOptEntity]("JsonEntity"))
+
+    "some json" in {
+      val value = JsonOptEntity("JoeEntity", Some(jsonJoe))
+
+      testContext.run(jsonOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "some jsonb" in {
+      val value = JsonbOptEntity("JoeEntity", Some(jsonbJoe))
+
+      testContext.run(jsonbOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonbOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "none json" in {
+      val value = JsonOptEntity("JoeEntity", None)
+
+      testContext.run(jsonOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "none jsonb" in {
+      val value = JsonbOptEntity("JoeEntity", None)
+
+      testContext.run(jsonbOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonbOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+  }
+
   "encodes and decodes json ast" - {
     val jsonJoe       = Json.Obj(Chunk("age" -> Json.Num(123), "name" -> Json.Str("Joe")))
     val jsonAstQuery  = quote(querySchema[JsonAstEntity]("JsonEntity"))
@@ -63,10 +107,49 @@ class PostgresJsonSpec extends ZioSpec {
       val inserted = testContext.run(jsonAstQuery).runSyncUnsafe().head
       inserted mustEqual jsonAstValue
     }
+
     "jsonb" in {
       testContext.run(jsonbAstQuery.insertValue(lift(jsonbAstValue))).runSyncUnsafe()
       val inserted = testContext.run(jsonbAstQuery).runSyncUnsafe().head
       inserted mustEqual jsonbAstValue
     }
   }
+
+  "encodes and decodes optional json ast" - {
+    val jsonJoe          = Json.Obj(Chunk("age" -> Json.Num(123), "name" -> Json.Str("Joe")))
+    val jsonAstOptQuery  = quote(querySchema[JsonAstOptEntity]("JsonEntity"))
+    val jsonbAstOptQuery = quote(querySchema[JsonbAstOptEntity]("JsonbEntity"))
+
+    val jsonbAstValue = JsonbAstEntity("JoeEntity", JsonbValue(jsonJoe))
+
+    "some json" in {
+      val value = JsonAstOptEntity("JoeEntity", Some(JsonValue(jsonJoe)))
+      testContext.run(jsonAstOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonAstOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "some jsonb" in {
+      val value = JsonbAstOptEntity("JoeEntity", Some(JsonbValue(jsonJoe)))
+      testContext.run(jsonbAstOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonbAstOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "none json" in {
+      val value = JsonAstOptEntity("JoeEntity", None)
+      testContext.run(jsonAstOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonAstOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+    "none jsonb" in {
+      val value = JsonbAstOptEntity("JoeEntity", None)
+      testContext.run(jsonbAstOptQuery.insertValue(lift(value))).runSyncUnsafe()
+      val inserted = testContext.run(jsonbAstOptQuery).runSyncUnsafe().head
+      inserted mustEqual value
+    }
+
+  }
+
 }


### PR DESCRIPTION
Fixes #3022

### Problem

Exception in Postgres inserting None value for Option[JsonValue[...]] or Option[JsonbValue[...]] fields:
`ERROR: column "..." is of type json but expression is of type character varying`

### Solution

This PR fixes `entityEncoder` and `astEncoder` methods in `PostgresJsonExtensions` trait by changing `sqlType` parameter from `Types.VARCHAR` to `Types.OTHER`.

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
