### PR TITLE
Fix `sbt doc` execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-java@v3.12.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '11'
           check-latest: true
       - run: |
           sbt ++2.12.x -Dquill.scala.version=2.12.x -Dquill.macro.log=false ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -740,7 +740,12 @@ lazy val docs = project
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
     scalacOptions += "-Xlog-implicits",
-    libraryDependencies ++= Seq("dev.zio" %% "zio" % Version.zio),
+    libraryDependencies ++= Seq("dev.zio" %% "zio" % Version.zio) ++ {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Seq(compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"))
+        case _            => Seq.empty
+      }
+    },
     projectName    := "ZIO Quill",
     mainModuleName := (`quill-core` / moduleName).value,
     // With Scala 2.12, these projects doc isn't compiling.


### PR DESCRIPTION
Error was:
```scala
[error] /home/runner/work/zio-quill/zio-quill/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala:203:27: value withFilter is not a member of zio.ZIO[zio.Scope with java.sql.Connection,Throwable,(java.sql.Connection, java.sql.ResultSet)]
[error]             (conn, rs) <- executeQuery
[error]                           ^
```

See https://github.com/zio/zio-quill/actions/runs/8985241908/job/24679689779
