### PR TITLE
DataSource initialization shuold be lazy

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ContextVerbTranslate.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextVerbTranslate.scala
@@ -62,20 +62,25 @@ trait ContextTranslateProto {
     extractor: Extractor[T] = identityExtractor,
     prettyPrint: Boolean = false
   )(executionInfo: ExecutionInfo, dc: Runner): TranslateResult[String] =
-    push(prepareParams(statement, prepare)) { params =>
-      val query =
-        if (params.nonEmpty) {
-          params.foldLeft(statement) { case (expanded, param) =>
-            expanded.replaceFirst("\\?", param)
+    try {
+      push(prepareParams(statement, prepare)) { params =>
+        val query =
+          if (params.nonEmpty) {
+            params.foldLeft(statement) { case (expanded, param) =>
+              expanded.replaceFirst("\\?", param)
+            }
+          } else {
+            statement
           }
-        } else {
-          statement
-        }
 
-      if (prettyPrint)
-        idiom.format(query)
-      else
-        query
+        if (prettyPrint)
+          idiom.format(query)
+        else
+          query
+      }
+    } catch {
+      case e: Exception =>
+        wrap("<!-- Cannot display parameters due to preparation error: " + e.getMessage + " -->\n" + statement)
     }
 
   def translateBatchQuery(

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
@@ -15,20 +15,22 @@ import java.sql.{Connection, SQLException}
 import javax.sql.DataSource
 
 object Quill {
-  class Postgres[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class Postgres[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[PostgresDialect, N]
       with PostgresJdbcTypes[PostgresDialect, N]
       with PostgresJsonExtensions {
     val idiom: PostgresDialect = PostgresDialect
     val dsDelegate             = new PostgresZioJdbcContext[N](naming)
+    lazy val ds: DataSource    = dataSourceInput
   }
 
   /** Postgres ZIO Context without JDBC Encoders */
-  class PostgresLite[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class PostgresLite[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[PostgresDialect, N]
       with PostgresJdbcTypes[PostgresDialect, N] {
     val idiom: PostgresDialect = PostgresDialect
     val dsDelegate             = new PostgresZioJdbcContext[N](naming)
+    lazy val ds: DataSource    = dataSourceInput
   }
 
   object Postgres {
@@ -37,11 +39,12 @@ object Quill {
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Postgres[N](naming, ds))
   }
 
-  class SqlServer[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class SqlServer[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[SQLServerDialect, N]
       with SqlServerJdbcTypes[SQLServerDialect, N] {
     val idiom: SQLServerDialect = SQLServerDialect
     val dsDelegate              = new SqlServerZioJdbcContext[N](naming)
+    lazy val ds: DataSource     = dataSourceInput
   }
   object SqlServer {
     def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new SqlServer[N](naming, ds)
@@ -49,11 +52,12 @@ object Quill {
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new SqlServer[N](naming, ds))
   }
 
-  class H2[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class H2[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[H2Dialect, N]
       with H2JdbcTypes[H2Dialect, N] {
-    val idiom: H2Dialect = H2Dialect
-    val dsDelegate       = new H2ZioJdbcContext[N](naming)
+    val idiom: H2Dialect    = H2Dialect
+    val dsDelegate          = new H2ZioJdbcContext[N](naming)
+    lazy val ds: DataSource = dataSourceInput
   }
   object H2 {
     def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new H2[N](naming, ds)
@@ -61,11 +65,12 @@ object Quill {
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new H2[N](naming, ds))
   }
 
-  class Mysql[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class Mysql[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[MySQLDialect, N]
       with MysqlJdbcTypes[MySQLDialect, N] {
     val idiom: MySQLDialect = MySQLDialect
     val dsDelegate          = new MysqlZioJdbcContext[N](naming)
+    lazy val ds: DataSource = dataSourceInput
   }
   object Mysql {
     def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Mysql[N](naming, ds)
@@ -73,11 +78,12 @@ object Quill {
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Mysql[N](naming, ds))
   }
 
-  class Sqlite[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class Sqlite[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[SqliteDialect, N]
       with SqliteJdbcTypes[SqliteDialect, N] {
     val idiom: SqliteDialect = SqliteDialect
     val dsDelegate           = new SqliteZioJdbcContext[N](naming)
+    lazy val ds: DataSource  = dataSourceInput
   }
   object Sqlite {
     def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Sqlite[N](naming, ds)
@@ -85,11 +91,12 @@ object Quill {
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Sqlite[N](naming, ds))
   }
 
-  class Oracle[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+  class Oracle[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource)
       extends Quill[OracleDialect, N]
       with OracleJdbcTypes[OracleDialect, N] {
     val idiom: OracleDialect = OracleDialect
     val dsDelegate           = new OracleZioJdbcContext[N](naming)
+    lazy val ds: DataSource  = dataSourceInput
   }
   object Oracle {
     def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Oracle[N](naming, ds)

--- a/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
@@ -7,10 +7,12 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{JdbcContext, H2JdbcContextBase}
 import io.getquill.util.LoadConfig
 
-class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class H2JdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[H2Dialect, N]
     with H2JdbcContextBase[H2Dialect, N] {
-  override val idiom: H2Dialect = H2Dialect
+  override val idiom: H2Dialect                           = H2Dialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))

--- a/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
@@ -7,10 +7,12 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{JdbcContext, MysqlJdbcContextBase}
 import io.getquill.util.LoadConfig
 
-class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[MySQLDialect, N]
     with MysqlJdbcContextBase[MySQLDialect, N] {
-  override val idiom: MySQLDialect = MySQLDialect
+  override val idiom: MySQLDialect                        = MySQLDialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))

--- a/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
@@ -7,10 +7,12 @@ import io.getquill.context.jdbc.{JdbcContext, OracleJdbcContextBase}
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class OracleJdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[OracleDialect, N]
     with OracleJdbcContextBase[OracleDialect, N] {
-  override val idiom: OracleDialect = OracleDialect
+  override val idiom: OracleDialect                       = OracleDialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))

--- a/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
@@ -7,10 +7,12 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{JdbcContext, PostgresJdbcContextBase}
 import io.getquill.util.LoadConfig
 
-class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[PostgresDialect, N]
     with PostgresJdbcContextBase[PostgresDialect, N] {
-  override val idiom: PostgresDialect = PostgresDialect
+  override val idiom: PostgresDialect                     = PostgresDialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))

--- a/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
@@ -7,10 +7,12 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{JdbcContext, SqlServerJdbcContextBase}
 import io.getquill.util.LoadConfig
 
-class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[SQLServerDialect, N]
     with SqlServerJdbcContextBase[SQLServerDialect, N] {
-  override val idiom: SQLServerDialect = SQLServerDialect
+  override val idiom: SQLServerDialect                    = SQLServerDialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))

--- a/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
@@ -7,10 +7,12 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{JdbcContext, SqliteJdbcContextBase}
 import io.getquill.util.LoadConfig
 
-class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, dataSourceInput: => DataSource with Closeable)
     extends JdbcContext[SqliteDialect, N]
     with SqliteJdbcContextBase[SqliteDialect, N] {
-  override val idiom: SqliteDialect = SqliteDialect
+  override val idiom: SqliteDialect                       = SqliteDialect
+  override lazy val dataSource: DataSource with Closeable = dataSourceInput
+
   def this(naming: N, config: JdbcContextConfig) = this(naming, config.dataSource)
   def this(naming: N, config: Config) = this(naming, JdbcContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))


### PR DESCRIPTION
DataSource should not immediately be created when a context is initialized, it should wait for the first DB command invocation.
As a consequence of this, doing only a single invocation of `translate` should not fail due to no DB connection.