### PR TITLE
fix sbt build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           distribution: temurin
           java-version: '17'
           check-latest: true
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - name: Check scalafmt
         run: sbt 'scalafmtCheckAll' # https://scalameta.org/scalafmt/docs/installation.html#task-keys
 
@@ -92,6 +94,8 @@ jobs:
         distribution: temurin
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
 
     - name: Build modules
       run: |
@@ -115,6 +119,8 @@ jobs:
           distribution: temurin
           java-version: '11'
           check-latest: true
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - run: |
           sbt ++2.12.x -Dquill.scala.version=2.12.x -Dquill.macro.log=false ci-release
           sbt ++2.13.x -Dquill.scala.version=2.13.x -Dquill.macro.log=false ci-release

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,6 +27,8 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Check if the README file is up to date
       run: sbt  docs/checkReadme
     - name: Check if the site workflow is up to date
@@ -48,6 +50,8 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Setup NodeJs
       uses: actions/setup-node@v3
       with:
@@ -73,6 +77,8 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Generate Readme
       run: sbt  docs/generateReadme
     - name: Commit Changes


### PR DESCRIPTION
Apparently, [sbt was removed from Ubuntu 24](https://github.com/actions/setup-java/issues/712). This PR includes another step in the process to do the proper setup of the tool.

@getquill/maintainers
