### PR TITLE
Fixing onConflict case when custom NamingStrategy is used

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/sql/idiom/OnConflictSupport.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/idiom/OnConflictSupport.scala
@@ -23,7 +23,7 @@ trait OnConflictSupport {
 
     val customAstTokenizer =
       Tokenizer.withFallback[Ast](self.astTokenizer(_, strategy, idiomContext)) {
-        case Property(_: OnConflict.Excluded, value) => stmt"EXCLUDED.${value.token}"
+        case Property(_: OnConflict.Excluded, value) => stmt"EXCLUDED.${strategy.column(value).token}"
 
         // At first glance it might be hard to understand why this is doing `case OnConflict.Existing(a) => stmt"${entityAlias}"`
         // but consider that this is a situation where multiple aliases are used in multiple update clauses e.g. the `tt` in the below example

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
@@ -25,6 +25,10 @@ trait OnConflictSpec extends Spec {
     `onConflict with schemaMeta`(fun)
     `onConflict with querySchema`(fun)
   }
+  def `onConflict with query and schemaMeta`(fun: Quoted[Insert[TestEntity]] => Unit) = {
+    `onConflict with query`(fun)
+    `onConflict with schemaMeta`(fun)
+  }
 
   def del = quote(query[TestEntity].delete)
 


### PR DESCRIPTION
Fixes #3144

### Notes

Apologies for the messy tests. The newly added test fails when used with ]querySchema], even before the changes introduced in https://github.com/zio/zio-quill/pull/3137. I’m not very familiar with this feature, so it’s possible that not renaming fields when using `querySchema` is the expected behavioгr.

BTW suggested `sbt scalariformFormat test:scalariformFormat` doesn't seem to work and prints
```
[error] Not a valid key: scalariformFormat (similar: scalaArtifacts, scalafmt, scalafmtDoFormatOnCompile)
[error] scalariformFormat
```
`sbt scalafmt` worked fine though


@getquill/maintainers
