### PR TITLE
fix ZioMockSpec

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 import sbt.Keys.*
 
 object Version {
-  val zio = "2.1.16"
+  val zio = "2.1.19"
 }
 
 sealed trait ExcludeTests

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mock/ZioMockSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mock/ZioMockSpec.scala
@@ -148,7 +148,6 @@ class ZioMockSpec extends AnyFreeSpec with MockitoSugar { // with AsyncMockitoSu
         }.getOrThrow()
       }
 
-    resultMsg.contains("fiber") mustBe true
     resultMsg.contains(msg) mustBe true
 
     // In test suite verifications come after
@@ -188,7 +187,6 @@ class ZioMockSpec extends AnyFreeSpec with MockitoSugar { // with AsyncMockitoSu
       }.getOrThrow()
     }
 
-    resultMsg.contains("fiber") mustBe true
     resultMsg.contains(msg) mustBe true
 
     // In test suite verifications come after


### PR DESCRIPTION
`ZioMockSpec` has been breaking the build. The changes from [this PR](https://github.com/zio/zio/pull/9386), introduced in zio 2.1.18, removed some of the `FiberFailure`s messages, so that's removed here as well, once the rest of the spec still ensures the expected behaviour.