### PR TITLE
Fix PostgresSQL batch returning for snakeCase.

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-engine/src/main/scala/io/getquill/PostgresDialect.scala
@@ -68,14 +68,19 @@ trait PostgresDialect
       e match {
         case Returning(action, alias, property) =>
           val newAlias    = alias.copy(name = batchAlias)
-          val newProperty = BetaReduction(property, alias -> newAlias)
+          val newProperty = BetaReduction(FixedProp(property), alias -> newAlias)
           Returning(action, newAlias, newProperty)
         case ReturningGenerated(action, alias, property) =>
           val newAlias    = alias.copy(name = batchAlias)
-          val newProperty = BetaReduction(property, alias -> newAlias)
+          val newProperty = BetaReduction(FixedProp(property), alias -> newAlias)
           ReturningGenerated(action, newAlias, newProperty)
         case _ => super.apply(e)
       }
+  }
+
+  private[getquill] object FixedProp extends StatelessTransformer {
+    override def apply(p: ast.Property): ast.Property =
+      p.copyAll(renameable = Renameable.Fixed)
   }
 
   override protected def actionTokenizer(insertEntityTokenizer: Tokenizer[Entity])(implicit

--- a/quill-jdbc-test-postgres/src/test/scala/io/getquill/context/jdbc/postgres/BatchUpdateJdbcSpec.scala
+++ b/quill-jdbc-test-postgres/src/test/scala/io/getquill/context/jdbc/postgres/BatchUpdateJdbcSpec.scala
@@ -10,8 +10,10 @@ class BatchUpdateValuesJdbcSpec extends BatchUpdateValuesSpec { //
   import testContext._
 
   override def beforeEach(): Unit = {
-    val schema = quote(querySchema[ContactBase]("Contact"))
+    val schema  = quote(querySchema[ContactBase]("Contact"))
+    val schema2 = quote(querySchema[ContactBase]("contact_snake"))
     testContext.run(schema.delete)
+    testContext.run(schema2.delete)
     super.beforeEach()
   }
 
@@ -71,6 +73,14 @@ class BatchUpdateValuesJdbcSpec extends BatchUpdateValuesSpec { //
     val agesReturned = context.run(update, 2)
     agesReturned mustEqual expectedReturn
     context.run(get).toSet mustEqual (expect.toSet)
+  }
+
+  "Ex 4 - Returning Multiple (Snake Case)" in {
+    import `Ex 4 - Returning Multiple (Snake Case)`._
+    testContextSnake.run(insert)
+    val agesReturned = testContextSnake.run(update, 2)
+    agesReturned mustEqual expectedReturn
+    testContextSnake.run(get).toSet mustEqual (expect.toSet)
   }
 
   "Ex 5 - Append Data" in {

--- a/quill-jdbc-test-postgres/src/test/scala/io/getquill/context/jdbc/postgres/package.scala
+++ b/quill-jdbc-test-postgres/src/test/scala/io/getquill/context/jdbc/postgres/package.scala
@@ -11,4 +11,10 @@ package object postgres {
       with TestEncoders
       with TestDecoders
 
+  object testContextSnake
+      extends PostgresJdbcContext(SnakeCase, "testPostgresDB")
+      with TestEntities
+      with TestEncoders
+      with TestDecoders
+
 }

--- a/quill-sql-test/src/test/sql/postgres-schema.sql
+++ b/quill-sql-test/src/test/sql/postgres-schema.sql
@@ -165,3 +165,12 @@ CREATE TABLE Address(
     zip int,
     otherExtraInfo VARCHAR(255)
 );
+
+
+CREATE TABLE Contact_Snake(
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
+    age int,
+    address_fk int,
+    extra_info VARCHAR(255)
+)

--- a/quill-test-kit/src/test/scala/io/getquill/context/sql/base/BatchUpdateValuesSpec.scala
+++ b/quill-test-kit/src/test/scala/io/getquill/context/sql/base/BatchUpdateValuesSpec.scala
@@ -208,6 +208,24 @@ trait BatchUpdateValuesSpec extends Spec with BeforeAndAfterEach {
   }
 
   // noinspection TypeAnnotation
+  object `Ex 4 - Returning Multiple (Snake Case)` extends Adaptable {
+    case class ContactSnake(firstName: String, lastName: String, age: Int)
+    type Row = ContactSnake
+    override def makeData(c: ContactBase): ContactSnake = ContactSnake(c.firstName, c.lastName, c.age)
+
+    val insert = quote {
+      liftQuery(data: List[ContactSnake]).foreach(ps => query[ContactSnake].insertValue(ps))
+    }
+    val update = quote {
+      liftQuery(updateData: List[ContactSnake]).foreach(ps =>
+        query[ContactSnake].filter(p => p.firstName == ps.firstName).updateValue(ps).returning(r => (r.lastName, r.age))
+      )
+    }
+    val expectedReturn = updateData.map(r => (r.lastName, r.age))
+    val get            = quote(query[ContactSnake])
+  }
+
+  // noinspection TypeAnnotation
   object `Ex 5 - Append Data` extends Adaptable {
     case class Contact(firstName: String, lastName: String, age: Int)
     type Row = Contact


### PR DESCRIPTION
Use `Renamable.Fixed` on batch returning properties.

Fixes #2944 


@getquill/maintainers
