### PR TITLE
fix: correct wrong column references in flat join filters and correlated subqueries

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-engine/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -119,6 +119,15 @@ class ApplyMap(traceConfig: TraceConfig) {
         val er = BetaReduction(e, d -> c)
         trace"ApplyMap inside filter for $q" andReturn Some(Map(Filter(a, b, er), b, c))
 
+      // FlatJoin maps are not generally detachable (FlatJoin must stay inside
+      // a Map), but for Filter we can safely beta-reduce the predicate through
+      // the map body while keeping FlatJoin wrapped in Map(Filter(FlatJoin)).
+      // Without this, Dealias renames the filter ident to match the FlatJoin
+      // alias, causing wrong column references in WHERE clauses. See #396, #239.
+      case Filter(Map(a: FlatJoin, b, c), d, e) =>
+        val er = BetaReduction(e, d -> c)
+        trace"ApplyMap inside filter (FlatJoin) for $q" andReturn Some(Map(Filter(a, b, er), b, c))
+
       // a.map(b => c).sortBy(d => e) =>
       //    a.sortBy(b => e[d := c]).map(b => c)
       case SortBy(DetachableMap(a, b, c), d, e, f) =>

--- a/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
@@ -116,6 +116,13 @@ object ExpandNestedQueries extends StatelessQueryTransformer {
           // If it is a sub-select or a renamed property, do not apply the strategy to the property
           if (isSubselect)
             Property.Opinionated(inner, path.mkString, renameable, Visibility.Visible)
+          // If the property's root ident is not in any FROM context, it belongs to a
+          // correlated subquery scope (inner or outer). Leave it unchanged — it will be
+          // properly resolved when that subquery gets its own ExpandNestedQueries pass
+          // during tokenization. Without this, multi-level paths like _2.score get
+          // incorrectly truncated to just score. See #335.
+          else if (inContext.contextReferenceType(p).isEmpty)
+            p
           else
             Property.Opinionated(inner, path.last, renameable, Visibility.Visible)
 

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/FlatJoinFilterSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/FlatJoinFilterSpec.scala
@@ -1,0 +1,84 @@
+package io.getquill.context.sql
+
+import io.getquill.context.sql.testContext._
+import io.getquill.base.Spec
+
+/**
+ * Reproduction tests for flat join + filter column reference bugs.
+ *
+ * #396: Flat join in for-comprehension with outer .filter() on tuple generates
+ * wrong column reference in WHERE clause.
+ *
+ * #239: Flat join in for-comprehension with filter on tuple references the
+ * wrong table alias.
+ *
+ * #335: Self-referencing subquery with tuple mapping uses bare column names
+ * instead of aliased _2-prefixed names.
+ */
+class FlatJoinFilterSpec extends Spec {
+
+  case class File(fileKey: Long, fileCategoryKey: Int)
+  case class FileCategory(fileCategoryKey: Int)
+
+  case class Foo(id: Int, someField: String)
+  case class Bar(fooId: Int, otherField: String)
+
+  case class Item(id: Int, score: Int, category: Int)
+
+  "#396 - flat join with outer filter should reference correct columns" in {
+    val q = quote {
+      (for {
+        f  <- query[File]
+        fc <- query[FileCategory].join(fc => fc.fileCategoryKey == f.fileCategoryKey)
+      } yield (f.fileKey, fc.fileCategoryKey))
+        .filter(_._1 == 1L)
+    }
+
+    val sql = testContext.run(q).string
+    // The WHERE clause should reference the file table's fileKey, not a synthetic _1 on the wrong table
+    sql must not include ("._1")
+    // Sanity: should still be a join query
+    sql must include("JOIN")
+  }
+
+  "#239 - flat join filter should reference correct table in equality" in {
+    val q = quote {
+      (for {
+        foo <- query[Foo]
+        bar <- query[Bar].join(bar => bar.fooId == foo.id)
+      } yield (foo, bar))
+        .filter { case (foo, bar) =>
+          foo.someField == "baz" && bar.otherField == "boo"
+        }
+    }
+
+    val sql = testContext.run(q).string
+    // foo.someField should be on the foo table, not the bar table
+    sql must not include ("bar.someField")
+    sql must not include ("bar.some_field")
+  }
+
+  "#335 - subquery with tuple mapping should use correct column aliases" in {
+    val q = quote {
+      query[Item]
+        .map(i => (sql"${i.score} + 1".as[Int], i))
+        .filter(_._1 > 0)
+        .map(_._2)
+        .filter(x =>
+          query[Item]
+            .map(i => (sql"${i.score} + 1".as[Int], i))
+            .filter(_._1 > 0)
+            .map(_._2)
+            .filter(y => y.category == x.category && y.id != x.id)
+            .map(_.score)
+            .max
+            .exists(_ < x.score)
+        )
+    }
+
+    val sql = testContext.run(q).string
+    // The subquery should NOT reference bare column names that don't exist.
+    // e.g. MAX(i1.score) should be MAX(i1._2score)
+    sql must not include ("MAX(i1.score)")
+  }
+}


### PR DESCRIPTION
## Summary

- **ApplyMap**: Add case for `Filter(Map(FlatJoin, ...))` to beta-reduce filter predicates through the map body, keeping FlatJoin wrapped in `Map(Filter(FlatJoin))`. Without this, Dealias renames the filter ident to match the FlatJoin alias, causing wrong column references in WHERE clauses.
- **ExpandNestedQueries**: Skip property flattening when the property's root ident is not in any FROM context. Such properties belong to a correlated subquery scope and will be resolved when that subquery gets its own `ExpandNestedQueries` pass during tokenization. Without this, multi-level paths like `_2.score` are incorrectly truncated to just `score`.
- Add regression tests for all three issues.

## Fixes

- #2671 — Flat Join produces invalid SQL
- zio/zio-protoquill#396 — Invalid query generation for Flat Joins with outer filter
- zio/zio-protoquill#239 — Generated query checks equality on wrong table
- zio/zio-protoquill#335 — Generated wrong query with recursive reference

## Test plan

- [x] `FlatJoinFilterSpec` — 3 regression tests covering all three issues
- [x] Full `quill-sql-test` suite passes (1020/1020, 0 failures)